### PR TITLE
Add onCopy prop to CopyableTextArea

### DIFF
--- a/packages/cf-component-copyable-textarea/src/CopyableTextarea.js
+++ b/packages/cf-component-copyable-textarea/src/CopyableTextarea.js
@@ -19,7 +19,8 @@ const overlayStyles = {
 class CopyableTextarea extends React.Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
-    value: PropTypes.string.isRequired
+    value: PropTypes.string.isRequired,
+    onCopy: PropTypes.func
   };
 
   state = {
@@ -31,7 +32,7 @@ class CopyableTextarea extends React.Component {
     e.preventDefault();
 
     const target = findDOMNode(this.refs.textarea);
-
+    const {onCopy} = this.props;
     target.focus();
     target.select();
 
@@ -40,6 +41,10 @@ class CopyableTextarea extends React.Component {
       success = document.execCommand('copy');
     } catch(e) {
       success = false;
+    }
+
+    if (success && onCopy) {
+      onCopy();
     }
 
     this.setState({


### PR DESCRIPTION
Congrats on the OSS release! 🔥 

It would be nice if `CopyableTextArea` let you respond to a successful copy event. This makes that happen.

I tried adding a test, but there aren't any tests for `CopyableTextArea` at all and karma was giving me some trouble, so I'll have to figure that out.