### PR TITLE
PI-764: Updating cf-component-loading to depend on cf-component-icon …

### DIFF
--- a/example/styles.css
+++ b/example/styles.css
@@ -905,13 +905,6 @@ a.cf-link--disabled {
   speak: none;
 }
 
-.cf-icon--loading__span {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  overflow: hidden;
-}
-
 @keyframes loading {
    20% { transform: rotate3d(0, 0, 1,  15deg); }
    40% { transform: rotate3d(0, 0, 1, -10deg); }

--- a/example/styles.css
+++ b/example/styles.css
@@ -870,7 +870,7 @@ a.cf-link--disabled {
  * Loading
  */
 
-.cf-loading {
+.cf-icon--loading {
   display: inline-block;
 
   line-height: normal;
@@ -897,7 +897,7 @@ a.cf-link--disabled {
   transform-origin: center;
 }
 
-.cf-loading:before {
+.cf-icon--loading:before {
   content: "\e925";
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: "icons" !important;
@@ -905,7 +905,7 @@ a.cf-link--disabled {
   speak: none;
 }
 
-.cf-loading__label {
+.cf-icon--loading__span {
   display: inline-block;
   width: 0;
   height: 0;

--- a/packages/cf-component-loading/package.json
+++ b/packages/cf-component-loading/package.json
@@ -9,6 +9,7 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
+    "cf-component-icon": "^1.1.2",
     "react": "^0.14.2"
   },
   "devDependencies": {

--- a/packages/cf-component-loading/src/Loading.js
+++ b/packages/cf-component-loading/src/Loading.js
@@ -1,11 +1,10 @@
 const React = require('react');
+const Icon = require('cf-component-icon');
 
 class Loading extends React.Component {
   render() {
     return (
-      <div className="cf-icon--loading" role="status">
-        <span className="cf-icon--loading__span">Loading</span>
-      </div>
+      <Icon type="loading" label="Loading"/>
     );
   }
 }

--- a/packages/cf-component-loading/src/Loading.js
+++ b/packages/cf-component-loading/src/Loading.js
@@ -3,8 +3,8 @@ const React = require('react');
 class Loading extends React.Component {
   render() {
     return (
-      <div className="cf-loading" role="status">
-        <span className="cf-loading__label">Loading</span>
+      <div className="cf-icon--loading" role="status">
+        <span className="cf-icon--loading__span">Loading</span>
       </div>
     );
   }

--- a/packages/cf-component-loading/test/Loading.js
+++ b/packages/cf-component-loading/test/Loading.js
@@ -1,14 +1,13 @@
 const React = require('react');
 const assertEqualJSX = require('assert-equal-jsx');
 const Loading = require('../src/Loading');
+const Icon = require ('cf-component-icon');
 
 describe('Loading', function() {
   it('should render', function() {
     assertEqualJSX(
       <Loading/>,
-      <div className="cf-loading" role="status">
-        <span className="cf-loading__label">Loading</span>
-      </div>
+        <Icon type="loading" label="Loading"/>
     );
   });
 });


### PR DESCRIPTION
Externally `cf-component-loading` is styled fine.  

Internally there are no styles for `cf-component-loading` but `cf-component-icon` does contain `cf-component-loading` styles.  

I updated the component to depend on `cf-component-icon` styles because I think `<Loading\>` is more explicit than `<Icon label="border" type="gear" loading/>`.  