### PR TITLE
Convert class properties to plain ES6 in examples

### DIFF
--- a/packages/cf-builder-pagination/README.md
+++ b/packages/cf-builder-pagination/README.md
@@ -20,14 +20,21 @@ function isRequestingItemsFromCurrentPage() {
 }
 
 class Component extends React.Component {
-  state = {
-    items: [],
-    totalCount: 143,
-    page: 1,
-    perPage: 20
-  };
 
-  handlePageChange = page => {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      items: [],
+      totalCount: 143,
+      page: 1,
+      perPage: 20
+    };
+
+    this.handlePageChange = this.handlePageChange.bind(this);
+  }
+
+  handlePageChange(page) {
     // Send off a paginated request...
   };
 

--- a/packages/cf-builder-pagination/example/basic/component.js
+++ b/packages/cf-builder-pagination/example/basic/component.js
@@ -19,20 +19,25 @@ function hasAllItems(items, start, end) {
 }
 
 class Component extends React.Component {
-  state = {
-    items: [],
-    totalCount: 143,
-    page: 1,
-    perPage: 20
-  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      items: [],
+      totalCount: 143,
+      page: 1,
+      perPage: 20
+    };
+    this.handlePageChange = this.handlePageChange.bind(this);
+  }
 
   componentDidMount() {
     this.maybeRequestPage(this.state.page);
   }
 
-  handlePageChange = page => {
+  handlePageChange(page) {
     this.maybeRequestPage(page);
-  };
+  }
 
   // This is mimicking what will happen in the API actions/reducers:
   maybeRequestPage(page) {

--- a/packages/cf-builder-table/example/basic/component.js
+++ b/packages/cf-builder-table/example/basic/component.js
@@ -14,14 +14,21 @@ const {Button} = require('cf-component-button');
 const EXAMPLE_TABLE = 'EXAMPLE_TABLE';
 
 class Component extends React.Component {
-  state = {
-    data: [
-      { id: '1', name: 'James', coolness: 1 },
-      { id: '2', name: 'David', coolness: -1 }
-    ]
-  };
 
-  handleClick = id => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: [
+        { id: '1', name: 'James', coolness: 1 },
+        { id: '2', name: 'David', coolness: -1 }
+      ]
+    };
+
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+
+  handleClick(id) {
     this.setState({
       data: this.state.data.map(item => {
         return item.id === id
@@ -31,7 +38,7 @@ class Component extends React.Component {
     }, () => {
       this.props.dispatch(tableActions.flashRow(EXAMPLE_TABLE, id, 'success'));
     });
-  };
+  }
 
   render() {
     return (

--- a/packages/cf-component-button/example/basic/component.js
+++ b/packages/cf-component-button/example/basic/component.js
@@ -6,21 +6,21 @@ const {
 } = require('../../src/index');
 
 class Component extends React.Component {
-  handleButtonOneClick = () => {
+  handleButtonOneClick() {
     console.log('Clicked Button One!');
-  };
+  }
 
-  handleButtonTwoClick = () => {
+  handleButtonTwoClick() {
     console.log('Clicked Button Two!');
-  };
+  }
 
   render() {
     return (
       <ButtonGroup>
-        <Button type="primary" onClick={this.handleButtonOneClick}>
+        <Button type="primary" onClick={this.handleButtonOneClick.bind(this)}>
           Button One
         </Button>
-        <Button type="primary" onClick={this.handleButtonTwoClick}>
+        <Button type="primary" onClick={this.handleButtonTwoClick.bind(this)}>
           Button Two
         </Button>
       </ButtonGroup>

--- a/packages/cf-component-card/example/basic/component.js
+++ b/packages/cf-component-card/example/basic/component.js
@@ -5,18 +5,22 @@ const {
   CardContent,
   CardControl,
   CardDrawers,
-  CardLoadingText,
   CardMessages,
   CardSection
 } = require('../../src/index');
 const {Button} = require('cf-component-button');
 
 class Component extends React.Component {
-  state = {
-    activeDrawer: null
-  };
 
-  handleDrawerClick = id => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeDrawer: null
+    };
+    this.handleDrawerClick = this.handleDrawerClick.bind(this);
+  }
+
+  handleDrawerClick(id) {
     this.setState({
       activeDrawer: id === this.state.activeDrawer ? null : id
     });

--- a/packages/cf-component-checkbox/README.md
+++ b/packages/cf-component-checkbox/README.md
@@ -18,13 +18,17 @@ const {
 } = require('../../src/index');
 
 class Application extends React.Component {
-  state = {
-    checkbox1: true,
-    checkbox2: false,
-    checkboxValues: ["option1"]
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      checkbox1: true,
+      checkbox2: false,
+      checkboxValues: ["option1"]
+    };
+    this.onCheckboxGroupChange = this.onCheckboxGroupChange.bind(this);
+  }
 
-  onCheckboxGroupChange = values => {
+  onCheckboxGroupChange(values) {
     this.setState({
       checkboxValues: values
     });

--- a/packages/cf-component-checkbox/example/basic/component.js
+++ b/packages/cf-component-checkbox/example/basic/component.js
@@ -7,17 +7,21 @@ const {
 } = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    checkbox1: true,
-    checkbox2: false,
-    checkboxValues: ["option1"]
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      checkbox1: true,
+      checkbox2: false,
+      checkboxValues: ['option1']
+    };
+    this.onCheckboxGroupChange = this.onCheckboxGroupChange.bind(this);
+  }
 
-  onCheckboxGroupChange = values => {
+  onCheckboxGroupChange(values) {
     this.setState({
       checkboxValues: values
     });
-  };
+  }
 
   render() {
     return (

--- a/packages/cf-component-dropdown/README.md
+++ b/packages/cf-component-dropdown/README.md
@@ -23,9 +23,13 @@ const {
 } = require('../../src/index');
 
 class Application extends React.Component {
-  state = {
-    dropdownOpen: false
-  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      dropdownOpen: false
+    };
+  }
 
   render() {
     return (

--- a/packages/cf-component-dropdown/example/basic/component.js
+++ b/packages/cf-component-dropdown/example/basic/component.js
@@ -16,10 +16,14 @@ const {
 } = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    dropdown1Open: false,
-    dropdown2Open: false
-  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      dropdown1Open: false,
+      dropdown2Open: false
+    };
+  }
 
   render() {
     return (

--- a/packages/cf-component-form/example/basic/component.js
+++ b/packages/cf-component-form/example/basic/component.js
@@ -15,30 +15,40 @@ const Select = require('cf-component-select');
 const Textarea = require('cf-component-textarea');
 
 class Component extends React.Component {
-  state = {
-    firstName: '',
-    lastName: '',
-    type: 'suggestion',
-    message: 'This is blasphemy! This is madness!'
-  };
 
-  handleFirstNameChange = firstName => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      firstName: '',
+      lastName: '',
+      type: 'suggestion',
+      message: 'This is blasphemy! This is madness!'
+    };
+
+    this.handleFirstNameChange = this.handleFirstNameChange.bind(this);
+    this.handleLastNameChange = this.handleLastNameChange.bind(this);
+    this.handleTypeChange = this.handleTypeChange.bind(this);
+    this.handleMessageChange = this.handleMessageChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleFirstNameChange(firstName) {
     this.setState({ firstName });
-  };
+  }
 
-  handleLastNameChange = lastName => {
+  handleLastNameChange(lastName) {
     this.setState({ lastName });
-  };
+  }
 
-  handleTypeChange = type => {
+  handleTypeChange(type) {
     this.setState({ type });
-  };
+  }
 
-  handleMessageChange = message => {
+  handleMessageChange(message) {
     this.setState({ message });
-  };
+  }
 
-  handleSubmit = () => {
+  handleSubmit() {
     console.log(JSON.stringify(this.state, null, 2));
     this.setState({
       firstName: '',
@@ -46,7 +56,7 @@ class Component extends React.Component {
       type: 'suggestion',
       message: ''
     });
-  };
+  }
 
   render() {
     return (

--- a/packages/cf-component-input/README.md
+++ b/packages/cf-component-input/README.md
@@ -15,15 +15,19 @@ const React = require('react');
 const Input = require('../../src/index');
 
 class Application extends React.Component {
-  state = {
-    inputValue: 'Hello World'
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      inputValue: 'Hello World'
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
 
-  handleChange = value => {
+  handleChange(value) {
     this.setState({
       inputValue: value
     });
-  };
+  }
 
   render() {
     return (

--- a/packages/cf-component-input/example/basic/component.js
+++ b/packages/cf-component-input/example/basic/component.js
@@ -4,15 +4,20 @@ const {render} = require('react-dom');
 const Input = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    inputValue: 'Hello World'
-  };
 
-  handleChange = value => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      inputValue: 'Hello World'
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(value) {
     this.setState({
       inputValue: value
     });
-  };
+  }
 
   render() {
     return (

--- a/packages/cf-component-link/example/basic/component.js
+++ b/packages/cf-component-link/example/basic/component.js
@@ -1,7 +1,7 @@
 const React = require('react');
 const {render} = require('react-dom');
 
-const {handleRoutes, routeTo} = require('cf-util-route-handler');
+const {handleRoutes} = require('cf-util-route-handler');
 const Backbone = require('backbone');
 
 const Link = require('../../src/index');
@@ -21,7 +21,7 @@ new Backbone.Router({
 Backbone.history.start();
 
 class Component extends React.Component {
-  handleClick = () => {
+  handleClick() {
     console.log('handleClick!');
   };
 
@@ -32,7 +32,7 @@ class Component extends React.Component {
         <Link to="/">Link to /</Link>
 
         <p>Alternatively you can pass an <code>onClick</code> handler:</p>
-        <Link onClick={this.handleClick}>Link to something</Link>
+        <Link onClick={this.handleClick.bind(this)}>Link to something</Link>
         <p>Note: This will give it a <code>role="button"</code></p>
 
         <p>All additional props will be added to the <code>Link</code> element:</p>

--- a/packages/cf-component-modal/README.md
+++ b/packages/cf-component-modal/README.md
@@ -27,9 +27,13 @@ const {
 } = require('react-gateway');
 
 class MyComponentWithModal extends React.Component {
-  state = {
-    isModalOpen: false
-  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isModalOpen: false
+    };
+  }
 
   handleRequestOpen() {
     this.setState({ isModalOpen: true });

--- a/packages/cf-component-modal/example/basic/component.js
+++ b/packages/cf-component-modal/example/basic/component.js
@@ -18,17 +18,23 @@ const ReactModal2 = require('react-modal2');
 const {Button} = require('cf-component-button');
 
 class Component extends React.Component {
-  state = {
-    isModalOpen: false
-  };
 
-  handleRequestOpen = () => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isModalOpen: false
+    };
+    this.handleRequestOpen = this.handleRequestOpen.bind(this);
+    this.handleRequestClose = this.handleRequestClose.bind(this);
+  }
+
+  handleRequestOpen() {
     this.setState({ isModalOpen: true });
-  };
+  }
 
-  handleRequestClose = () => {
+  handleRequestClose() {
     this.setState({ isModalOpen: false });
-  };
+  }
 
   render() {
     return (

--- a/packages/cf-component-notifications/README.md
+++ b/packages/cf-component-notifications/README.md
@@ -17,9 +17,13 @@ const {NotificationList, Notification} = require('cf-component-notifications');
 let UNIQUE_ID = 0;
 
 class Application extends React.Component {
-  state = {
-    notifications: []
-  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      notifications: []
+    };
+  }
 
   handleAdd() {
     this.setState({

--- a/packages/cf-component-notifications/example/basic/component.js
+++ b/packages/cf-component-notifications/example/basic/component.js
@@ -13,11 +13,15 @@ const {
 let UNIQUE_ID = 0;
 
 class Component extends React.Component {
-  state = {
-    notifications: []
-  };
 
-  handleAdd = (type, persist, delay) => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      notifications: []
+    };
+  }
+
+  handleAdd(type, persist, delay) {
     const id = UNIQUE_ID++;
 
     this.setState({
@@ -29,15 +33,15 @@ class Component extends React.Component {
         delay: delay
       })
     });
-  };
+  }
 
-  handleClear = () => {
+  handleClear() {
     this.setState({
       notifications: []
     });
   };
 
-  handleClose = id => {
+  handleClose(id) {
     this.setState({
       notifications: this.state.notifications.filter(n => n.id !== id)
     });
@@ -51,20 +55,20 @@ class Component extends React.Component {
         message={n.message}
         persist={n.persist}
         delay={n.delay}
-        onClose={this.handleClose.bind(null, n.id)}/>
+        onClose={this.handleClose.bind(this, n.id)} />;
     }).reverse();
 
     return (
       <div>
-        <Button type="error" onClick={this.handleAdd.bind(null, 'error', false, 4000)}>Add Error Notification</Button>
-        <Button type="warning" onClick={this.handleAdd.bind(null, 'warning', false, 4000)}>Add Warning Notification</Button>
-        <Button type="success" onClick={this.handleAdd.bind(null, 'success', false, 4000)}>Add Success Notification</Button>
-        <Button type="primary" onClick={this.handleAdd.bind(null, 'info', false, 4000)}>Add Info Notification</Button>
+        <Button type="error" onClick={this.handleAdd.bind(this, 'error', false, 4000)}>Add Error Notification</Button>
+        <Button type="warning" onClick={this.handleAdd.bind(this, 'warning', false, 4000)}>Add Warning Notification</Button>
+        <Button type="success" onClick={this.handleAdd.bind(this, 'success', false, 4000)}>Add Success Notification</Button>
+        <Button type="primary" onClick={this.handleAdd.bind(this, 'info', false, 4000)}>Add Info Notification</Button>
 
-        <Button type="primary" onClick={this.handleAdd.bind(null, 'info', false, 10000)}>Add 10000ms Notification</Button>
-        <Button type="primary" onClick={this.handleAdd.bind(null, 'info', true, null)}>Add Persistant Notification</Button>
+        <Button type="primary" onClick={this.handleAdd.bind(this, 'info', false, 10000)}>Add 10000ms Notification</Button>
+        <Button type="primary" onClick={this.handleAdd.bind(this, 'info', true, null)}>Add Persistant Notification</Button>
 
-        <Button type="default" onClick={this.handleClear}>Clear Notifications</Button>
+        <Button type="default" onClick={this.handleClear.bind(this)}>Clear Notifications</Button>
 
         <NotificationGlobalContainer>
           <NotificationList>

--- a/packages/cf-component-pagination/README.md
+++ b/packages/cf-component-pagination/README.md
@@ -18,28 +18,32 @@ const {
 const Icon = require('cf-component-icon');
 
 class Component extends React.Component {
-  state = {
-    pages: 4,
-    active: 1
-  };
 
-  handleClickItem = page => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      pages: 4,
+      active: 1
+    };
+  }
+
+  handleClickItem(page) {
     if (page >= 1 && page <= this.state.pages) {
       this.setState({ active: page });
     }
-  };
+  }
 
-  handleClickPrev = () => {
+  handleClickPrev() {
     if (this.state.active > 1) {
       this.handleClickItem(this.state.active - 1);
     }
-  };
+  }
 
-  handleClickNext = () => {
+  handleClickNext() {
     if (this.state.active < this.state.pages) {
       this.handleClickItem(this.state.active + 1);
     }
-  };
+  }
 
   render() {
     const items = [];
@@ -51,7 +55,7 @@ class Component extends React.Component {
           type="number"
           label={'Page ' + i}
           active={this.state.active === i}
-          onClick={this.handleClickItem.bind(null, i)}>
+          onClick={this.handleClickItem.bind(this, i)}>
           {i}
         </PaginationItem>
       );
@@ -63,7 +67,7 @@ class Component extends React.Component {
           type="prev"
           label="Previous Page"
           disabled={this.state.active === 1}
-          onClick={this.handleClickPrev}>
+          onClick={this.handleClickPrev.bind(this)}>
           <Icon type="caret-left" label={false}/>
         </PaginationItem>
         {items}
@@ -71,7 +75,7 @@ class Component extends React.Component {
           type="next"
           label="Next Page"
           disabled={this.state.active === this.state.pages}
-          onClick={this.handleClickNext}>
+          onClick={this.handleClickNext.bind(this)}>
           <Icon type="caret-right" label={false}/>
         </PaginationItem>
       </Pagination>

--- a/packages/cf-component-pagination/example/basic/component.js
+++ b/packages/cf-component-pagination/example/basic/component.js
@@ -8,28 +8,32 @@ const {
 const Icon = require('cf-component-icon');
 
 class Component extends React.Component {
-  state = {
-    pages: 4,
-    active: 1
-  };
 
-  handleClickItem = page => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      pages: 4,
+      active: 1
+    };
+  }
+
+  handleClickItem(page) {
     if (page >= 1 && page <= this.state.pages) {
       this.setState({ active: page });
     }
-  };
+  }
 
-  handleClickPrev = () => {
+  handleClickPrev() {
     if (this.state.active > 1) {
       this.handleClickItem(this.state.active - 1);
     }
-  };
+  }
 
-  handleClickNext = () => {
+  handleClickNext() {
     if (this.state.active < this.state.pages) {
       this.handleClickItem(this.state.active + 1);
     }
-  };
+  }
 
   render() {
     const items = [];
@@ -41,7 +45,7 @@ class Component extends React.Component {
           type="number"
           label={'Page ' + i}
           active={this.state.active === i}
-          onClick={this.handleClickItem.bind(null, i)}>
+          onClick={this.handleClickItem.bind(this, i)}>
           {i}
         </PaginationItem>
       );
@@ -53,7 +57,7 @@ class Component extends React.Component {
           type="prev"
           label="Previous Page"
           disabled={this.state.active === 1}
-          onClick={this.handleClickPrev}>
+          onClick={this.handleClickPrev.bind(this)}>
           <Icon type="caret-left" label={false}/>
         </PaginationItem>
         {items}

--- a/packages/cf-component-progress/example/basic/component.js
+++ b/packages/cf-component-progress/example/basic/component.js
@@ -4,11 +4,15 @@ const {render} = require('react-dom');
 const Progress = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    activeStep: 'foo'
-  };
 
-  handleStepChange = step => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeStep: 'foo'
+    };
+  }
+
+  handleStepChange(step) {
     this.setState({
       activeStep: step
     });
@@ -18,7 +22,7 @@ class Component extends React.Component {
     return (
       <Progress
         active={this.state.activeStep}
-        onChange={this.handleStepChange}
+        onChange={this.handleStepChange.bind(this)}
         steps={[
           { id: 'foo', label: 'Foo', disabled: false },
           { id: 'bar', label: 'Bar', disabled: false },

--- a/packages/cf-component-radio/README.md
+++ b/packages/cf-component-radio/README.md
@@ -19,11 +19,16 @@ const {
 } = require('../../src/index');
 
 class Application extends React.Component {
-  state = {
-    radioValue: "option1"
-  };
 
-  onRadioChange = val => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      radioValue: "option1"
+    };
+    this.onRadioChange = this.onRadioChange.bind(this);
+  }
+
+  onRadioChange(val) {
     this.setState({
       radioValue: val
     });

--- a/packages/cf-component-radio/example/basic/component.js
+++ b/packages/cf-component-radio/example/basic/component.js
@@ -7,11 +7,16 @@ const {
 } = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    radioValue: "option1"
-  };
 
-  onRadioChange = val => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      radioValue: 'option1'
+    };
+    this.onRadioChange = this.onRadioChange.bind(this);
+  }
+
+  onRadioChange(val) {
     this.setState({
       radioValue: val
     });
@@ -23,17 +28,17 @@ class Component extends React.Component {
         <p>You can create them individually with <code>Radio</code></p>
 
         <Radio
-          label="Option 1"
-          name="radio-option-1"
-          value="option1"
-          checked={this.state.radioValue === "option1"}
+          label='Option 1'
+          name='radio-option-1'
+          value='option1'
+          checked={this.state.radioValue === 'option1'}
           onChange={this.onRadioChange}/>
 
         <Radio
-          label="Option 2"
-          name="radio-option-2"
-          value="option2"
-          checked={this.state.radioValue === "option2"}
+          label='Option 2'
+          name='radio-option-2'
+          value='option2'
+          checked={this.state.radioValue === 'option2'}
           onChange={this.onRadioChange}/>
 
         <p>Or as a group with <code>RadioGroup</code></p>
@@ -50,9 +55,9 @@ class Component extends React.Component {
 
         <Radio
           label={false}
-          name="radio-option-1-no-label"
-          value="option1"
-          checked={this.state.radioValue === "option1"}
+          name='radio-option-1-no-label'
+          value='option1'
+          checked={this.state.radioValue === 'option1'}
           onChange={this.onRadioChange}/>
       </div>
     );

--- a/packages/cf-component-select/example/basic/component.js
+++ b/packages/cf-component-select/example/basic/component.js
@@ -4,16 +4,21 @@ const {render} = require('react-dom');
 const Select = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    value: 1,
-    multiValue: [1, 3]
-  };
 
-  handleChange = value => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: 1,
+      multiValue: [1, 3]
+    };
+  }
+
+
+  handleChange(value) {
     this.setState({ value });
   };
 
-  handleMultiChange = value => {
+  handleMultiChange(value) {
     this.setState({
       multiValue: value.length ? value.split(',') : []
     });
@@ -30,7 +35,7 @@ class Component extends React.Component {
             { value: 2, label: 'Two' },
             { value: 3, label: 'Three' }
           ]}
-          onChange={this.handleChange}/>
+          onChange={this.handleChange.bind(this)}/>
 
         <Select searchable
           label="Searchable"
@@ -40,7 +45,7 @@ class Component extends React.Component {
             { value: 2, label: 'Two' },
             { value: 3, label: 'Three' }
           ]}
-          onChange={this.handleChange}/>
+          onChange={this.handleChange.bind(this)}/>
 
         <Select searchable multi
           label="Searchable Multi"
@@ -50,7 +55,7 @@ class Component extends React.Component {
             { value: 2, label: 'Two' },
             { value: 3, label: 'Three' }
           ]}
-          onChange={this.handleMultiChange}/>
+          onChange={this.handleMultiChange.bind(this)}/>
       </div>
     );
   }

--- a/packages/cf-component-tabs/README.md
+++ b/packages/cf-component-tabs/README.md
@@ -19,9 +19,13 @@ const {
 } = require('../../src/index');
 
 class Application extends React.Component {
-  state = {
-    activeTab: 'one'
-  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTab: 'one'
+    };
+  }
 
   handleTabChange(id) {
     this.setState({ activeTab: id });

--- a/packages/cf-component-tabs/example/basic/component.js
+++ b/packages/cf-component-tabs/example/basic/component.js
@@ -7,11 +7,15 @@ const {
 } = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    activeTab: 'one'
-  };
 
-  handleTabChange = id => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTab: 'one'
+    };
+  }
+
+  handleTabChange(id) {
     this.setState({ activeTab: id });
   };
 
@@ -24,7 +28,7 @@ class Component extends React.Component {
           { id: 'two',   label: 'Tab Two'   },
           { id: 'three', label: 'Tab Three' }
         ]}
-        onChange={this.handleTabChange}>
+        onChange={this.handleTabChange.bind(this)}>
 
         <TabsPanel id="one">
           <h1>Tab One</h1>

--- a/packages/cf-component-textarea/README.md
+++ b/packages/cf-component-textarea/README.md
@@ -15,22 +15,26 @@ const React = require('react');
 const Textarea = require('../../src/index');
 
 class Application extends React.Component {
-  state = {
-    textareaValue: ''
-  };
 
-  handleTextareaChange = value => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      textareaValue: ''
+    };
+  }
+
+  handleTextareaChange(value) {
     this.setState({
       textareaValue: value
     });
-  };
+  }
 
   render() {
     return (
       <Textarea
         name="example"
         value={this.state.textareaValue}
-        onChange={this.handleTextareaChange}/>
+        onChange={this.handleTextareaChange.bind(this)}/>
     );
   }
 }

--- a/packages/cf-component-textarea/example/basic/component.js
+++ b/packages/cf-component-textarea/example/basic/component.js
@@ -4,22 +4,26 @@ const {render} = require('react-dom');
 const Textarea = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    textareaValue: ''
-  };
 
-  handleTextareaChange = value => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      textareaValue: ''
+    };
+  }
+
+  handleTextareaChange(value) {
     this.setState({
       textareaValue: value
     });
-  };
+  }
 
   render() {
     return (
       <Textarea
         name="example"
         value={this.state.textareaValue}
-        onChange={this.handleTextareaChange}/>
+        onChange={this.handleTextareaChange.bind(this)}/>
     );
   }
 }

--- a/packages/cf-component-toggle/README.md
+++ b/packages/cf-component-toggle/README.md
@@ -15,11 +15,15 @@ const React = require('react');
 const Toggle = require('../../src/index');
 
 class Application extends React.Component {
-  state = {
-    toggleValue: false
-  };
 
-  handleToggle = value => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      toggleValue: false
+    };
+  }
+
+  handleToggle(value) {
     this.setState({
       toggleValue: value
     });
@@ -30,7 +34,7 @@ class Application extends React.Component {
       label="Example Toggle"
       name="example"
       value={this.state.toggleValue}
-      onChange={this.handleToggle}/>;
+      onChange={this.handleToggle.bind(this)}/>;
   }
 }
 ```

--- a/packages/cf-component-toggle/example/basic/component.js
+++ b/packages/cf-component-toggle/example/basic/component.js
@@ -4,15 +4,19 @@ const {render} = require('react-dom');
 const Toggle = require('../../src/index');
 
 class Component extends React.Component {
-  state = {
-    toggleValue: false
-  };
 
-  handleToggle = value => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      toggleValue: false
+    };
+  }
+
+  handleToggle(value) {
     this.setState({
       toggleValue: value
     });
-  };
+  }
 
   render() {
     return (
@@ -20,7 +24,7 @@ class Component extends React.Component {
         label="Example Toggle"
         name="example"
         value={this.state.toggleValue}
-        onChange={this.handleToggle}/>
+        onChange={this.handleToggle.bind(this)}/>
     );
   }
 }


### PR DESCRIPTION
The previous PR removed dependency `babel-preset-cf` and broke the examples, this fixes them.