### PR TITLE
Change the type of children from array of nodes to node

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -234,7 +234,7 @@ function parseSourceFile(source, fileName) {
 
   const ast = babylon.parse(source, {
     sourceType: 'module',
-    plugins: ['jsx' , 'classProperties', 'objectRestSpread']
+    plugins: ['jsx' , 'objectRestSpread']
   });
 
   let propTypes = [];
@@ -292,7 +292,7 @@ function parsePropTypeFile(source, fileName) {
 
   const ast = babylon.parse(source, {
     sourceType: 'module',
-    plugins: ['jsx' , 'classProperties', 'objectRestSpread']
+    plugins: ['jsx' , 'objectRestSpread']
   });
 
   traverse(ast, {

--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -38,7 +38,7 @@ Button.propTypes = {
   ]).isRequired,
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Button.defaultProps = {

--- a/packages/cf-component-button/src/ButtonGroup.js
+++ b/packages/cf-component-button/src/ButtonGroup.js
@@ -12,7 +12,7 @@ class ButtonGroup extends React.Component {
 }
 
 ButtonGroup.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = ButtonGroup;

--- a/packages/cf-component-card/src/Card.js
+++ b/packages/cf-component-card/src/Card.js
@@ -12,7 +12,7 @@ class Card extends React.Component {
 }
 
 Card.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Card;

--- a/packages/cf-component-card/src/CardContent.js
+++ b/packages/cf-component-card/src/CardContent.js
@@ -22,7 +22,7 @@ class CardContent extends React.Component {
 CardContent.propTypes = {
   title: PropTypes.any.isRequired,
   footerMessage: PropTypes.string,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = CardContent;

--- a/packages/cf-component-card/src/CardControl.js
+++ b/packages/cf-component-card/src/CardControl.js
@@ -12,7 +12,7 @@ class CardControl extends React.Component {
 }
 
 CardControl.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = CardControl;

--- a/packages/cf-component-card/src/CardSection.js
+++ b/packages/cf-component-card/src/CardSection.js
@@ -16,7 +16,7 @@ CardSection.propTypes = {
     'default',
     'error'
   ]),
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 CardSection.defaultProps = {

--- a/packages/cf-component-card/src/CardToolbarLink.js
+++ b/packages/cf-component-card/src/CardToolbarLink.js
@@ -33,7 +33,7 @@ CardToolbarLink.propTypes = {
   onClick: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
   id: PropTypes.string,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = CardToolbarLink;

--- a/packages/cf-component-code/src/Code.js
+++ b/packages/cf-component-code/src/Code.js
@@ -12,7 +12,7 @@ class Code extends React.Component {
 }
 
 Code.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Code;

--- a/packages/cf-component-code/src/CodeBlock.js
+++ b/packages/cf-component-code/src/CodeBlock.js
@@ -15,7 +15,7 @@ class CodeBlock extends React.Component {
 }
 
 CodeBlock.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = CodeBlock;

--- a/packages/cf-component-dropdown/src/Dropdown.js
+++ b/packages/cf-component-dropdown/src/Dropdown.js
@@ -62,7 +62,7 @@ class Dropdown extends React.Component {
 Dropdown.propTypes = {
   onClose: PropTypes.func.isRequired,
   align: PropTypes.oneOf(['left', 'right']),
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Dropdown.defaultProps = {

--- a/packages/cf-component-dropdown/src/DropdownLink.js
+++ b/packages/cf-component-dropdown/src/DropdownLink.js
@@ -55,7 +55,7 @@ class DropdownLink extends React.Component {
 DropdownLink.propTypes = {
   to: PropTypes.string,
   onClick: PropTypes.func,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 DropdownLink.contextTypes = {

--- a/packages/cf-component-flex/src/Flex.js
+++ b/packages/cf-component-flex/src/Flex.js
@@ -23,7 +23,7 @@ Flex.propTypes = {
     'thin',
     'wide'
   ]).isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Flex;

--- a/packages/cf-component-flex/src/FlexItem.js
+++ b/packages/cf-component-flex/src/FlexItem.js
@@ -15,7 +15,7 @@ class FlexItem extends React.Component {
 
 FlexItem.propTypes = {
   collapse: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 FlexItem.defaultProps = {

--- a/packages/cf-component-form/src/Form.js
+++ b/packages/cf-component-form/src/Form.js
@@ -15,7 +15,7 @@ class Form extends React.Component {
 Form.propTypes = {
   layout: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
   onSubmit: PropTypes.func.isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Form;

--- a/packages/cf-component-form/src/FormFieldset.js
+++ b/packages/cf-component-form/src/FormFieldset.js
@@ -18,7 +18,7 @@ class FormFieldset extends React.Component {
 
 FormFieldset.propTypes = {
   legend: PropTypes.string.isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = FormFieldset;

--- a/packages/cf-component-form/src/FormFooter.js
+++ b/packages/cf-component-form/src/FormFooter.js
@@ -12,7 +12,7 @@ class FormFooter extends React.Component {
 }
 
 FormFooter.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = FormFooter;

--- a/packages/cf-component-form/src/FormLabel.js
+++ b/packages/cf-component-form/src/FormLabel.js
@@ -19,7 +19,7 @@ class FormLabel extends React.Component {
 
 FormLabel.propTypes = {
   hidden: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = FormLabel;

--- a/packages/cf-component-heading/src/Heading.js
+++ b/packages/cf-component-heading/src/Heading.js
@@ -11,7 +11,7 @@ class Heading extends React.Component {
 
 Heading.propTypes = {
   size: PropTypes.oneOf([1, 2, 3, 4, 5, 6]).isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Heading;

--- a/packages/cf-component-heading/src/HeadingCaption.js
+++ b/packages/cf-component-heading/src/HeadingCaption.js
@@ -12,7 +12,7 @@ class HeadingCaption extends React.Component {
 }
 
 HeadingCaption.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = HeadingCaption;

--- a/packages/cf-component-label/src/Label.js
+++ b/packages/cf-component-label/src/Label.js
@@ -18,7 +18,7 @@ Label.propTypes = {
     'error'
   ]).isRequired,
   tagName: PropTypes.string,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Label.defaultProps = {

--- a/packages/cf-component-layout/src/LayoutColumn.js
+++ b/packages/cf-component-layout/src/LayoutColumn.js
@@ -14,7 +14,7 @@ class LayoutColumn extends React.Component {
 
 LayoutColumn.propTypes = {
   width: PropTypes.number.isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = LayoutColumn;

--- a/packages/cf-component-layout/src/LayoutContainer.js
+++ b/packages/cf-component-layout/src/LayoutContainer.js
@@ -12,7 +12,7 @@ class LayoutContainer extends React.Component {
 }
 
 LayoutContainer.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = LayoutContainer;

--- a/packages/cf-component-layout/src/LayoutRow.js
+++ b/packages/cf-component-layout/src/LayoutRow.js
@@ -12,7 +12,7 @@ class LayoutRow extends React.Component {
 }
 
 LayoutRow.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = LayoutRow;

--- a/packages/cf-component-link/src/Link.js
+++ b/packages/cf-component-link/src/Link.js
@@ -72,7 +72,7 @@ Link.propTypes = {
   tagName: PropTypes.string,
   disabled: PropTypes.bool,
   className: PropTypes.string,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Link.defaultProps = {

--- a/packages/cf-component-list/src/List.js
+++ b/packages/cf-component-list/src/List.js
@@ -22,7 +22,7 @@ class List extends React.Component {
 List.propTypes = {
   ordered: PropTypes.bool,
   unstyled: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 List.defaultProps = {

--- a/packages/cf-component-list/src/ListItem.js
+++ b/packages/cf-component-list/src/ListItem.js
@@ -12,7 +12,7 @@ class ListItem extends React.Component {
 }
 
 ListItem.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = ListItem;

--- a/packages/cf-component-modal/src/Modal.js
+++ b/packages/cf-component-modal/src/Modal.js
@@ -50,7 +50,7 @@ Modal.propTypes = {
   onRequestClose: PropTypes.func.isRequired,
   closeOnEsc: PropTypes.bool,
   closeOnBackdropClick: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Modal.defaultProps = {

--- a/packages/cf-component-modal/src/ModalActions.js
+++ b/packages/cf-component-modal/src/ModalActions.js
@@ -12,7 +12,7 @@ class ModalActions extends React.Component {
 }
 
 ModalActions.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = ModalActions;

--- a/packages/cf-component-modal/src/ModalBody.js
+++ b/packages/cf-component-modal/src/ModalBody.js
@@ -12,7 +12,7 @@ class ModalBody extends React.Component {
 }
 
 ModalBody.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = ModalBody;

--- a/packages/cf-component-modal/src/ModalFooter.js
+++ b/packages/cf-component-modal/src/ModalFooter.js
@@ -19,7 +19,7 @@ class ModalFooter extends React.Component {
 
 ModalFooter.propTypes = {
   simple: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 ModalFooter.defaultProps = {

--- a/packages/cf-component-modal/src/ModalHeader.js
+++ b/packages/cf-component-modal/src/ModalHeader.js
@@ -12,7 +12,7 @@ class ModalHeader extends React.Component {
 }
 
 ModalHeader.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = ModalHeader;

--- a/packages/cf-component-modal/src/ModalTitle.js
+++ b/packages/cf-component-modal/src/ModalTitle.js
@@ -15,7 +15,7 @@ class ModalTitle extends React.Component {
 }
 
 ModalTitle.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = ModalTitle;

--- a/packages/cf-component-notifications/src/NotificationGlobalContainer.js
+++ b/packages/cf-component-notifications/src/NotificationGlobalContainer.js
@@ -12,7 +12,7 @@ class NotificationGlobalContainer extends React.Component {
 }
 
 NotificationGlobalContainer.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = NotificationGlobalContainer;

--- a/packages/cf-component-notifications/src/NotificationList.js
+++ b/packages/cf-component-notifications/src/NotificationList.js
@@ -12,7 +12,7 @@ class NotificationList extends React.Component {
 }
 
 NotificationList.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = NotificationList;

--- a/packages/cf-component-page/src/Page.js
+++ b/packages/cf-component-page/src/Page.js
@@ -12,7 +12,7 @@ class Page extends React.Component {
 }
 
 Page.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Page;

--- a/packages/cf-component-pagination/src/Pagination.js
+++ b/packages/cf-component-pagination/src/Pagination.js
@@ -23,7 +23,7 @@ class Pagination extends React.Component {
 
 Pagination.propTypes = {
   info: PropTypes.string,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Pagination;

--- a/packages/cf-component-pagination/src/PaginationItem.js
+++ b/packages/cf-component-pagination/src/PaginationItem.js
@@ -56,7 +56,7 @@ PaginationItem.propTypes = {
   onClick: PropTypes.func.isRequired,
   active: PropTypes.bool,
   disabled: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = PaginationItem;

--- a/packages/cf-component-table/src/Table.js
+++ b/packages/cf-component-table/src/Table.js
@@ -23,7 +23,7 @@ Table.propTypes = {
   hover: PropTypes.bool,
   bordered: PropTypes.bool,
   condensed: PropTypes.bool,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Table.defaultProps = {

--- a/packages/cf-component-table/src/TableBody.js
+++ b/packages/cf-component-table/src/TableBody.js
@@ -12,7 +12,7 @@ class TableBody extends React.Component {
 }
 
 TableBody.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = TableBody;

--- a/packages/cf-component-table/src/TableCell.js
+++ b/packages/cf-component-table/src/TableCell.js
@@ -17,7 +17,7 @@ class TableCell extends React.Component {
 
 TableCell.propTypes = {
   align: PropTypes.oneOf(['left', 'center', 'right']),
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = TableCell;

--- a/packages/cf-component-table/src/TableFoot.js
+++ b/packages/cf-component-table/src/TableFoot.js
@@ -12,7 +12,7 @@ class TableFoot extends React.Component {
 }
 
 TableFoot.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = TableFoot;

--- a/packages/cf-component-table/src/TableHead.js
+++ b/packages/cf-component-table/src/TableHead.js
@@ -12,7 +12,7 @@ class TableHead extends React.Component {
 }
 
 TableHead.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = TableHead;

--- a/packages/cf-component-table/src/TableHeadCell.js
+++ b/packages/cf-component-table/src/TableHeadCell.js
@@ -12,7 +12,7 @@ class TableHeadCell extends React.Component {
 }
 
 TableHeadCell.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = TableHeadCell;

--- a/packages/cf-component-table/src/TableRow.js
+++ b/packages/cf-component-table/src/TableRow.js
@@ -21,7 +21,7 @@ class TableRow extends React.Component {
 TableRow.propTypes = {
   type: TablePropTypes.rowType,
   accent: TablePropTypes.rowAccent,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 TableRow.defaultProps = {

--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -75,7 +75,7 @@ Tabs.propTypes = {
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired
   })).isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Tabs.childContextTypes = {

--- a/packages/cf-component-tabs/src/TabsPanel.js
+++ b/packages/cf-component-tabs/src/TabsPanel.js
@@ -20,7 +20,7 @@ class TabsPanel extends React.Component {
 
 TabsPanel.propTypes = {
   id: PropTypes.string.isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 TabsPanel.contextTypes = {

--- a/packages/cf-component-tabs/test/TabsPanel.js
+++ b/packages/cf-component-tabs/test/TabsPanel.js
@@ -14,7 +14,7 @@ class Context extends React.Component {
 
 Context.propTypes = {
   activeTab: PropTypes.string.isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Context.childContextTypes = {

--- a/packages/cf-component-text/src/Text.js
+++ b/packages/cf-component-text/src/Text.js
@@ -34,7 +34,7 @@ Text.propTypes = {
   align: PropTypes.oneOf(['start', 'center', 'justify', 'end']),
   type: PropTypes.oneOf(['info', 'success', 'warning', 'error', 'muted']),
   'case': PropTypes.oneOf(['capitalize', 'titlecase', 'lowercase', 'uppercase']),
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Text;

--- a/packages/cf-component-tooltip/src/TooltipRegion.js
+++ b/packages/cf-component-tooltip/src/TooltipRegion.js
@@ -29,7 +29,7 @@ class TooltipRegion extends React.Component {
 TooltipRegion.propTypes = {
   position: PropTypes.string,
   querySelector: PropTypes.string,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 TooltipRegion.defaultProps = {

--- a/packages/cf-component-typography/src/Abbr.js
+++ b/packages/cf-component-typography/src/Abbr.js
@@ -13,7 +13,7 @@ class Abbr extends React.Component {
 
 Abbr.propTypes = {
   title: PropTypes.string.isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Abbr;

--- a/packages/cf-component-typography/src/Cite.js
+++ b/packages/cf-component-typography/src/Cite.js
@@ -12,7 +12,7 @@ class Cite extends React.Component {
 }
 
 Cite.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Cite;

--- a/packages/cf-component-typography/src/Del.js
+++ b/packages/cf-component-typography/src/Del.js
@@ -12,7 +12,7 @@ class Del extends React.Component {
 }
 
 Del.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Del;

--- a/packages/cf-component-typography/src/Em.js
+++ b/packages/cf-component-typography/src/Em.js
@@ -12,7 +12,7 @@ class Em extends React.Component {
 }
 
 Em.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Em;

--- a/packages/cf-component-typography/src/Ins.js
+++ b/packages/cf-component-typography/src/Ins.js
@@ -12,7 +12,7 @@ class Ins extends React.Component {
 }
 
 Ins.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Ins;

--- a/packages/cf-component-typography/src/Kbd.js
+++ b/packages/cf-component-typography/src/Kbd.js
@@ -12,7 +12,7 @@ class Kbd extends React.Component {
 }
 
 Kbd.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Kbd;

--- a/packages/cf-component-typography/src/Mark.js
+++ b/packages/cf-component-typography/src/Mark.js
@@ -12,7 +12,7 @@ class Mark extends React.Component {
 }
 
 Mark.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Mark;

--- a/packages/cf-component-typography/src/Samp.js
+++ b/packages/cf-component-typography/src/Samp.js
@@ -12,7 +12,7 @@ class Samp extends React.Component {
 }
 
 Samp.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Samp;

--- a/packages/cf-component-typography/src/Small.js
+++ b/packages/cf-component-typography/src/Small.js
@@ -12,7 +12,7 @@ class Small extends React.Component {
 }
 
 Small.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Small;

--- a/packages/cf-component-typography/src/Strike.js
+++ b/packages/cf-component-typography/src/Strike.js
@@ -12,7 +12,7 @@ class Strike extends React.Component {
 }
 
 Strike.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Strike;

--- a/packages/cf-component-typography/src/Strong.js
+++ b/packages/cf-component-typography/src/Strong.js
@@ -12,7 +12,7 @@ class Strong extends React.Component {
 }
 
 Strong.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Strong;

--- a/packages/cf-component-typography/src/Sub.js
+++ b/packages/cf-component-typography/src/Sub.js
@@ -12,7 +12,7 @@ class Sub extends React.Component {
 }
 
 Sub.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Sub;

--- a/packages/cf-component-typography/src/Sup.js
+++ b/packages/cf-component-typography/src/Sup.js
@@ -12,7 +12,7 @@ class Sup extends React.Component {
 }
 
 Sup.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Sup;

--- a/packages/cf-component-typography/src/Underline.js
+++ b/packages/cf-component-typography/src/Underline.js
@@ -12,7 +12,7 @@ class Underline extends React.Component {
 }
 
 Underline.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Underline;

--- a/packages/cf-component-typography/src/Var.js
+++ b/packages/cf-component-typography/src/Var.js
@@ -12,7 +12,7 @@ class Var extends React.Component {
 }
 
 Var.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 module.exports = Var;

--- a/packages/cf-component-viewport/src/Viewport.js
+++ b/packages/cf-component-viewport/src/Viewport.js
@@ -33,7 +33,7 @@ Viewport.propTypes = {
     'desktop',
     'desktopLarge'
   ]).isRequired,
-  children: PropTypes.arrayOf(PropTypes.node)
+  children: PropTypes.node
 };
 
 Viewport.defaultProps = {


### PR DESCRIPTION
A lot of our examples are just throwing anything into the child position, this should stop the example page from emitting warnings.

https://facebook.github.io/react/docs/typechecking-with-proptypes.html#react.proptypes