### PR TITLE
Pass the `style` prop down to input.

### DIFF
--- a/packages/cf-component-input/src/Input.js
+++ b/packages/cf-component-input/src/Input.js
@@ -20,6 +20,7 @@ class Input extends React.Component {
 
     return (
       <input
+        style={this.props.style}
         type={this.props.type}
         className={className}
         name={this.props.name}
@@ -44,11 +45,13 @@ Input.propTypes = {
   onChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
   autoComplete: PropTypes.string,
-  invalid: PropTypes.bool
+  invalid: PropTypes.bool,
+  style: PropTypes.object
 };
 
 Input.defaultProps = {
-  type: 'text'
+  type: 'text',
+  style: {}
 };
 
 module.exports = Input;


### PR DESCRIPTION
This is useful if you want in-line styles down to the input component overriding any styles already set. Provides flexibility when you want to slightly customize your component on the fly.