### PR TITLE
Upgrade to lerna beta 31

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.30",
+  "lerna": "2.0.0-beta.31",
   "version": "independent",
   "publishConfig": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "karma-sauce-launcher": "^1.1.0",
     "karma-tape-reporter": "^1.0.0",
     "language-babel": "github:gandm/language-babel",
-    "lerna": "^2.0.0-beta.30",
+    "lerna": "^2.0.0-beta.31",
     "lodash": "^4.3.0",
     "loose-envify": "^1.3.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
So `npm run bootstrap` doesn't die anymore