### PR TITLE
Optional custom class names for table components

### DIFF
--- a/packages/cf-component-table/src/Table.js
+++ b/packages/cf-component-table/src/Table.js
@@ -9,6 +9,7 @@ class Table extends React.Component {
     if (this.props.hover) className += ' cf-table--hover';
     if (this.props.bordered) className += ' cf-table--bordered';
     if (this.props.condensed) className += ' cf-table--condensed';
+    if (this.props.className.trim()) className += ' ' + this.props.className.trim();
 
     return (
       <table className={className}>
@@ -19,6 +20,7 @@ class Table extends React.Component {
 }
 
 Table.propTypes = {
+  className: PropTypes.string,
   striped: PropTypes.bool,
   hover: PropTypes.bool,
   bordered: PropTypes.bool,
@@ -27,6 +29,7 @@ Table.propTypes = {
 };
 
 Table.defaultProps = {
+  className: '',
   striped: false,
   hover: false,
   bordered: true,

--- a/packages/cf-component-table/src/TableBody.js
+++ b/packages/cf-component-table/src/TableBody.js
@@ -3,8 +3,11 @@ const {PropTypes} = React;
 
 class TableBody extends React.Component {
   render() {
+    let className = 'cf-table__body';
+    if (this.props.className.trim()) className += ' ' + this.props.className.trim();
+
     return (
-      <tbody className="cf-table__body">
+      <tbody className={className}>
         {this.props.children}
       </tbody>
     );
@@ -12,7 +15,12 @@ class TableBody extends React.Component {
 }
 
 TableBody.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node
+};
+
+TableBody.defaultProps = {
+  className: ''
 };
 
 module.exports = TableBody;

--- a/packages/cf-component-table/src/TableCell.js
+++ b/packages/cf-component-table/src/TableCell.js
@@ -4,8 +4,8 @@ const {PropTypes} = React;
 class TableCell extends React.Component {
   render() {
     let className = 'cf-table__cell';
-
     if (this.props.align) className += ' cf-table__cell--align-' + this.props.align;
+    if (this.props.className.trim()) className += ' ' + this.props.className.trim();
 
     return (
       <td className={className}>
@@ -16,8 +16,13 @@ class TableCell extends React.Component {
 }
 
 TableCell.propTypes = {
+  className: PropTypes.string,
   align: PropTypes.oneOf(['left', 'center', 'right']),
   children: PropTypes.node
+};
+
+TableCell.defaultProps = {
+  className: ''
 };
 
 module.exports = TableCell;

--- a/packages/cf-component-table/src/TableFoot.js
+++ b/packages/cf-component-table/src/TableFoot.js
@@ -3,8 +3,11 @@ const {PropTypes} = React;
 
 class TableFoot extends React.Component {
   render() {
+    let className = 'cf-table__foot';
+    if (this.props.className.trim()) className += ' ' + this.props.className.trim();
+
     return (
-      <tfoot className="cf-table__foot">
+      <tfoot className={className}>
         {this.props.children}
       </tfoot>
     );
@@ -12,7 +15,12 @@ class TableFoot extends React.Component {
 }
 
 TableFoot.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node
+};
+
+TableFoot.defaultProps = {
+  className: ''
 };
 
 module.exports = TableFoot;

--- a/packages/cf-component-table/src/TableHead.js
+++ b/packages/cf-component-table/src/TableHead.js
@@ -3,8 +3,11 @@ const {PropTypes} = React;
 
 class TableHead extends React.Component {
   render() {
+    let className = 'cf-table__head';
+    if (this.props.className.trim()) className += ' ' + this.props.className.trim();
+
     return (
-      <thead className="cf-table__head">
+      <thead className={className}>
         {this.props.children}
       </thead>
     );
@@ -12,7 +15,12 @@ class TableHead extends React.Component {
 }
 
 TableHead.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node
+};
+
+TableHead.defaultProps = {
+  className: ''
 };
 
 module.exports = TableHead;

--- a/packages/cf-component-table/src/TableHeadCell.js
+++ b/packages/cf-component-table/src/TableHeadCell.js
@@ -3,8 +3,11 @@ const {PropTypes} = React;
 
 class TableHeadCell extends React.Component {
   render() {
+    let className = 'cf-table__cell cf-table__cell--head';
+    if (this.props.className.trim()) className += ' ' + this.props.className.trim();
+
     return (
-      <th className="cf-table__cell cf-table__cell--head">
+      <th className={className}>
         {this.props.children}
       </th>
     );
@@ -12,7 +15,12 @@ class TableHeadCell extends React.Component {
 }
 
 TableHeadCell.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node
+};
+
+TableHeadCell.defaultProps = {
+  className: ''
 };
 
 module.exports = TableHeadCell;

--- a/packages/cf-component-table/src/TableRow.js
+++ b/packages/cf-component-table/src/TableRow.js
@@ -10,6 +10,10 @@ class TableRow extends React.Component {
       className += ` cf-table__row--accent-${this.props.accent}`;
     }
 
+    if (this.props.className.trim()) {
+      className += ' ' + this.props.className;
+    }
+
     return (
       <tr className={className}>
         {this.props.children}
@@ -19,12 +23,14 @@ class TableRow extends React.Component {
 }
 
 TableRow.propTypes = {
+  className: PropTypes.string,
   type: TablePropTypes.rowType,
   accent: TablePropTypes.rowAccent,
   children: PropTypes.node
 };
 
 TableRow.defaultProps = {
+  className: '',
   type: 'default',
   accent: false
 };

--- a/packages/cf-component-table/test/Table.js
+++ b/packages/cf-component-table/test/Table.js
@@ -6,15 +6,20 @@ describe('Table', function() {
   it('should render', function() {
     assertEqualJSX(
       <Table>Table</Table>,
-      // should equal
       <table className="cf-table cf-table--bordered">Table</table>
+    );
+  });
+
+  it('should render extra class names', function() {
+    assertEqualJSX(
+      <Table className="extra">Table</Table>,
+      <table className="cf-table cf-table--bordered extra">Table</table>
     );
   });
 
   it('should render striped', function() {
     assertEqualJSX(
       <Table striped>Table</Table>,
-      // should equal
       <table className="cf-table cf-table--striped cf-table--bordered">Table</table>
     );
   });
@@ -22,7 +27,6 @@ describe('Table', function() {
   it('should render hover', function() {
     assertEqualJSX(
       <Table hover>Table</Table>,
-      // should equal
       <table className="cf-table cf-table--hover cf-table--bordered">Table</table>
     );
   });
@@ -30,7 +34,6 @@ describe('Table', function() {
   it('should render not bordered', function() {
     assertEqualJSX(
       <Table bordered={false}>Table</Table>,
-      // should equal
       <table className="cf-table">Table</table>
     );
   });
@@ -38,7 +41,6 @@ describe('Table', function() {
   it('should render condensed', function() {
     assertEqualJSX(
       <Table condensed>Table</Table>,
-      // should equal
       <table className="cf-table cf-table--bordered cf-table--condensed">Table</table>
     );
   });

--- a/packages/cf-component-table/test/TableBody.js
+++ b/packages/cf-component-table/test/TableBody.js
@@ -10,4 +10,12 @@ describe('TableBody', function() {
       <tbody className="cf-table__body">TableBody</tbody>
     );
   });
+
+  it('should render extra class names', function() {
+    assertEqualJSX(
+      <TableBody className="extra">TableBody</TableBody>,
+      // should equal
+      <tbody className="cf-table__body extra">TableBody</tbody>
+    );
+  });
 });

--- a/packages/cf-component-table/test/TableCell.js
+++ b/packages/cf-component-table/test/TableCell.js
@@ -11,6 +11,14 @@ describe('TableCell', function() {
     );
   });
 
+  it('should render extra class name', function() {
+    assertEqualJSX(
+      <TableCell className="extra">TableCell</TableCell>,
+      // should equal
+      <td className="cf-table__cell extra">TableCell</td>
+    );
+  });
+
   it('should render with align', function() {
     assertEqualJSX(
       <TableCell align="center">TableCell</TableCell>,

--- a/packages/cf-component-table/test/TableFoot.js
+++ b/packages/cf-component-table/test/TableFoot.js
@@ -10,4 +10,12 @@ describe('TableFoot', function() {
       <tfoot className="cf-table__foot">TableFoot</tfoot>
     );
   });
+
+  it('should render extra class name', function() {
+    assertEqualJSX(
+      <TableFoot className="extra">TableFoot</TableFoot>,
+      // should equal
+      <tfoot className="cf-table__foot extra">TableFoot</tfoot>
+    );
+  });
 });

--- a/packages/cf-component-table/test/TableHead.js
+++ b/packages/cf-component-table/test/TableHead.js
@@ -10,4 +10,12 @@ describe('TableHead', function() {
       <thead className="cf-table__head">TableHead</thead>
     );
   });
+
+  it('should render extra class name', function() {
+    assertEqualJSX(
+      <TableHead className="extra">TableHead</TableHead>,
+      // should equal
+      <thead className="cf-table__head extra">TableHead</thead>
+    );
+  });
 });

--- a/packages/cf-component-table/test/TableHeadCell.js
+++ b/packages/cf-component-table/test/TableHeadCell.js
@@ -10,4 +10,12 @@ describe('TableHeadCell', function() {
       <th className="cf-table__cell cf-table__cell--head">TableHeadCell</th>
     );
   });
+
+  it('should render extra class name', function() {
+    assertEqualJSX(
+      <TableHeadCell className="extra">TableHeadCell</TableHeadCell>,
+      // should equal
+      <th className="cf-table__cell cf-table__cell--head extra">TableHeadCell</th>
+    );
+  });
 });

--- a/packages/cf-component-table/test/TableRow.js
+++ b/packages/cf-component-table/test/TableRow.js
@@ -11,6 +11,14 @@ describe('TableRow', function() {
     );
   });
 
+  it('should render extra class name', function() {
+    assertEqualJSX(
+      <TableRow className="extra">TableRow</TableRow>,
+      // should equal
+      <tr className="cf-table__row cf-table__row--default extra">TableRow</tr>
+    );
+  });
+
   it('should render with type', function() {
     assertEqualJSX(
       <TableRow type="error">TableRow</TableRow>,


### PR DESCRIPTION
This is a part of #33 

Sometimes, we'll need to have CSS classes that target the rows and columns. Since technically the HTML spec doesn't allow us to wrap elements around `<tr>`,`<th>` and `<td>`, we have to use custom class names to avoid having a mess of CSS selectors all over the place.

This PR fixes this issue.