### PR TITLE
Fix issue with not being able to focus and select the textarea

### DIFF
--- a/packages/cf-component-copyable-textarea/package.json
+++ b/packages/cf-component-copyable-textarea/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "cf-component-textarea": "^2.0.0",
-    "cf-util-text": "^2.0.0",
     "react": "^0.14.2 || ^15.0.0-0",
     "react-dom": "^0.14.2 || ^15.0.0-0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "assert-equal-jsx": "^1.0.3",
+    "react-addons-test-utils": "^15.4.1"
+  }
 }

--- a/packages/cf-component-copyable-textarea/src/CopyableTextarea.js
+++ b/packages/cf-component-copyable-textarea/src/CopyableTextarea.js
@@ -1,40 +1,24 @@
 const React = require('react');
 const {PropTypes} = React;
 const Textarea = require('cf-component-textarea');
-const {getText} = require('cf-util-text');
-
-const containerStyles = {
-  position: 'relative'
-};
-
-const overlayStyles = {
-  position: 'absolute',
-  top: 0,
-  bottom: 0,
-  left: 0,
-  right: 0
-};
 
 class CopyableTextarea extends React.Component {
 
   constructor(props) {
     super(props);
     this.state = {
-      focused: false,
+      helpText: this.props.clickToCopyText,
       copied: false
     };
 
-    this.handleOverlayClick = this.handleOverlayClick.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
   }
 
-  handleOverlayClick(e) {
-    e.preventDefault();
+  handleFocus(e) {
+    e.target.select();
 
-    const target = this.textarea;
     const {onCopy} = this.props;
-    target.focus();
-    target.select();
 
     let success;
     try {
@@ -48,43 +32,31 @@ class CopyableTextarea extends React.Component {
     }
 
     this.setState({
-      focused: true,
+      helpText: (success ?
+                 this.props.copiedTextToClipboardText :
+                 this.props.pressCommandOrCtrlCToCopyText),
       copied: success
     });
   }
 
   handleBlur() {
     this.setState({
-      focused: false,
+      helpText: this.props.clickToCopyText,
       copied: false
     });
   }
 
   render() {
-    let helpText;
-
-    if (!this.state.focused) {
-      helpText = getText('Click to copy');
-    } else if (this.state.copied) {
-      helpText = getText('Copied text to clipboard');
-    } else {
-      helpText = getText('Press Command/Ctrl+C to copy');
-    }
-
     return (
-      <div className="cf-copyable-textarea" style={containerStyles}>
-        {!this.state.focused && (
-          <div style={overlayStyles} onClick={this.handleOverlayClick}></div>
-        )}
+      <div className="cf-copyable-textarea">
         <Textarea
           ref={node => this.textarea = node}
           readOnly
           name={this.props.name}
           value={this.props.value}
-          onBlur={this.handleBlur}/>
-        <p className="cf-copyable-textarea__help-text">
-          {helpText}
-        </p>
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur} />
+        <p className="cf-copyable-textarea__help-text">{this.state.helpText}</p>
       </div>
     );
   }
@@ -93,7 +65,16 @@ class CopyableTextarea extends React.Component {
 CopyableTextarea.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
-  onCopy: PropTypes.func
+  onCopy: PropTypes.func,
+  clickToCopyText: PropTypes.string,
+  copiedTextToClipboardText: PropTypes.string,
+  pressCommandOrCtrlCToCopyText: PropTypes.string
+};
+
+CopyableTextarea.defaultProps = {
+  clickToCopyText: 'Click to copy',
+  copiedTextToClipboardText: 'Copied text to clipboard',
+  pressCommandOrCtrlCToCopyText: 'Press Command/Ctrl+C to copy'
 };
 
 module.exports = CopyableTextarea;

--- a/packages/cf-component-copyable-textarea/test/CopyableTextarea.js
+++ b/packages/cf-component-copyable-textarea/test/CopyableTextarea.js
@@ -1,1 +1,70 @@
-console.warn('No CopyableTextarea tests')
+const React = require('react');
+const TestUtils = require('react-addons-test-utils');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const assertEqualJSX = require('assert-equal-jsx');
+const CopyableTextarea = require('../src/CopyableTextarea');
+
+describe('CopyableTextarea', () => {
+
+  it('should render', () => {
+    assertEqualJSX(
+      <CopyableTextarea
+        name="example"
+        value="content"
+        clickToCopyText="click here"
+        copiedTextToClipboardText="copied"
+        pressCommandOrCtrlCToCopyText="press here" />,
+
+      <div className="cf-copyable-textarea">
+        <textarea
+          className="cf-textarea cf-textarea--readonly"
+          name="example"
+          readOnly
+          value="content"
+          onChange={() => {}} />
+          <p className="cf-copyable-textarea__help-text">click here</p>
+      </div>
+    );
+  });
+
+  it('should call onCopy on focus', () => {
+    // because under Karma, document.execCommand('copy') always returns false
+    sinon.stub(document, 'execCommand').returns(true);
+
+    let clicked = false;
+
+    const copyableTextarea = TestUtils.renderIntoDocument(<CopyableTextarea name="example" value="content" onCopy={() => clicked = true}/>);
+    const textarea = TestUtils.findRenderedDOMComponentWithClass(copyableTextarea, 'cf-textarea');
+
+    TestUtils.Simulate.focus(textarea);
+    expect(clicked).to.be.true;
+
+    document.execCommand.restore();
+  });
+
+  it('should render copied help text after copying', () => {
+    // because under Karma, document.execCommand('copy') always returns false
+    sinon.stub(document, 'execCommand').returns(true);
+
+    const copyableTextarea = TestUtils.renderIntoDocument(<CopyableTextarea name="example" value="content" copiedTextToClipboardText="copied" />);
+    const textarea = TestUtils.findRenderedDOMComponentWithClass(copyableTextarea, 'cf-textarea');
+    const helpText = TestUtils.findRenderedDOMComponentWithClass(copyableTextarea, 'cf-copyable-textarea__help-text');
+
+    TestUtils.Simulate.focus(textarea);
+
+    expect(helpText.innerText.trim()).to.be.equal('copied');
+
+    document.execCommand.restore();
+  });
+
+  it('should render press help text if copying was not successful', () => {
+    const copyableTextarea = TestUtils.renderIntoDocument(<CopyableTextarea name="example" value="content" pressCommandOrCtrlCToCopyText="press here" />);
+    const textarea = TestUtils.findRenderedDOMComponentWithClass(copyableTextarea, 'cf-textarea');
+    const helpText = TestUtils.findRenderedDOMComponentWithClass(copyableTextarea, 'cf-copyable-textarea__help-text');
+
+    TestUtils.Simulate.focus(textarea);
+
+    expect(helpText.innerText.trim()).to.be.equal('press here');
+  });
+});


### PR DESCRIPTION
React 15 upgrade broke CopyableTextarea and I didn't catch this because there were no tests. The ref returned was the Component instead of the wrapped DOM element, which has `focus()` and `select()`.

This rewrote CopyableTextarea to be more straightforward. An `onClick` prop has been added to Textarea as well to enable copying the programmatically selected text from CopyableTextarea.

You can also supply the help text from the props, just like what the README says.