### PR TITLE
Document 'disabled' option for cf-component-select

### DIFF
--- a/packages/cf-component-select/README.md
+++ b/packages/cf-component-select/README.md
@@ -38,7 +38,7 @@ export default class MyComponent extends React.Component {
           value={this.state.value}
           options={[
             { value: 1, label: 'One' },
-            { value: 2, label: 'Two' },
+            { value: 2, label: 'Two', disabled: true },
             { value: 3, label: 'Three' }
           ]}
           onChange={this.handleChange.bind(this)}/>

--- a/packages/cf-component-select/example/basic/component.js
+++ b/packages/cf-component-select/example/basic/component.js
@@ -32,7 +32,7 @@ class Component extends React.Component {
           value={this.state.value}
           options={[
             { value: 1, label: 'One' },
-            { value: 2, label: 'Two' },
+            { value: 2, label: 'Two', disabled: true },
             { value: 3, label: 'Three' }
           ]}
           onChange={this.handleChange.bind(this)}/>

--- a/packages/cf-component-select/src/Select.js
+++ b/packages/cf-component-select/src/Select.js
@@ -43,7 +43,8 @@ Select.propTypes = {
   value: PropTypes.any,
   options: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string.isRequired,
-    value: PropTypes.any.isRequired
+    value: PropTypes.any.isRequired,
+    disabled: PropTypes.bool
   })),
   placeholder: PropTypes.string
 };


### PR DESCRIPTION
Our implementation of `cf-component-select` allows us to pass in options with `disabled: true`, but we don't document this anywhere.