### PR TITLE
Add react test tools that were missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "examples:publish": "gulp examplesPublish"
   },
   "devDependencies": {
+    "assert-equal-jsx": "^1.0.3",
     "autoprefixer": "^6.3.6",
     "babel-core": "^6.18.0",
     "babel-generator": "^6.18.0",
@@ -79,6 +80,7 @@
     "path-exists": "^2.1.0",
     "react": "^15.0.0-0",
     "react-addons-css-transition-group": "^15.0.0-0",
+    "react-addons-test-utils": "^15.4.1",
     "react-dom": "^15.0.0-0",
     "react-redux": "^3.1.0",
     "redux": "^3.1.0",


### PR DESCRIPTION
I got errors about these packages being missing when I tried running `npm test`. Adding them in makes the tests run fine :)

Maybe we should setup something like codeship to catch things like this on PRs?