### PR TITLE
Remove `cache` default prop `true`

### DIFF
--- a/packages/cf-component-select/src/Select.js
+++ b/packages/cf-component-select/src/Select.js
@@ -22,8 +22,7 @@ class Select extends React.Component {
 Select.defaultProps = {
   multi: false,
   searchable: false,
-  async: false,
-  cache: true
+  async: false
 };
 
 module.exports = Select;


### PR DESCRIPTION
Cache is now a object in `react-select` as well as being set to a empty object in `react-select` :tophat:

https://github.com/JedWatson/react-select/blob/master/src/Async.js#L5-L45