### PR TITLE
Don't render tab panels unless they are clicked

### DIFF
--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -8,7 +8,6 @@ const find = (list, condition) => {
   list.forEach(element => {
     if (condition(element)) {
       foundElement = element;
-      return;
     }
   });
   return foundElement;

--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -92,7 +92,7 @@ Tabs.propTypes = {
       label: PropTypes.string.isRequired
     })
   ).isRequired,
-  children: PropTypes.node
+  children: PropTypes.arrayOf(PropTypes.element).isRequired
 };
 
 Tabs.childContextTypes = {

--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -64,7 +64,9 @@ class Tabs extends React.Component {
             })}
           </ul>
         </Viewport>
-        {this.props.children}
+        {this.props.children.find(child => {
+          return child.props.id === this.props.active;
+        })}
       </section>
     );
   }

--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -3,6 +3,17 @@ const { PropTypes } = React;
 const Viewport = require('cf-component-viewport');
 const Select = require('cf-component-select');
 
+const find = (list, condition) => {
+  let foundElement = undefined;
+  list.forEach(element => {
+    if (condition(element)) {
+      foundElement = element;
+      return;
+    }
+  });
+  return foundElement;
+};
+
 class Tabs extends React.Component {
   getChildContext() {
     return {
@@ -64,7 +75,7 @@ class Tabs extends React.Component {
             })}
           </ul>
         </Viewport>
-        {this.props.children.find(child => {
+        {find(this.props.children, child => {
           return child.props.id === this.props.active;
         })}
       </section>

--- a/packages/cf-component-tabs/src/TabsPanel.js
+++ b/packages/cf-component-tabs/src/TabsPanel.js
@@ -5,13 +5,14 @@ class TabsPanel extends React.Component {
   render() {
     const selected = this.context.active === this.props.id;
 
+    console.log(`Rendering tab ${this.props.id}`);
+
     return (
       <div
         className="cf-tabs__panel"
         role="tabpanel"
         aria-labelledby={this.props.id}
         aria-hidden={!selected}
-        style={{ display: selected ? 'block' : 'none' }}
       >
         {this.props.children}
       </div>

--- a/packages/cf-component-tabs/src/TabsPanel.js
+++ b/packages/cf-component-tabs/src/TabsPanel.js
@@ -5,8 +5,6 @@ class TabsPanel extends React.Component {
   render() {
     const selected = this.context.active === this.props.id;
 
-    console.log(`Rendering tab ${this.props.id}`);
-
     return (
       <div
         className="cf-tabs__panel"

--- a/packages/cf-component-tabs/test/Tabs.js
+++ b/packages/cf-component-tabs/test/Tabs.js
@@ -39,18 +39,8 @@ describe('Tabs', function() {
         <div
           className="cf-tabs__panel"
           role="tabpanel"
-          aria-labelledby="1"
-          aria-hidden="true"
-          style={{ display: 'none' }}
-        >
-          One
-        </div>
-        <div
-          className="cf-tabs__panel"
-          role="tabpanel"
           aria-labelledby="2"
           aria-hidden="false"
-          style={{ display: 'block' }}
         >
           Two
         </div>

--- a/packages/cf-component-tabs/test/TabsPanel.js
+++ b/packages/cf-component-tabs/test/TabsPanel.js
@@ -33,7 +33,6 @@ describe('TabsPanel', function() {
         role="tabpanel"
         aria-labelledby="tab"
         aria-hidden="true"
-        style={{ display: 'none' }}
       >
         TabsPanel
       </div>
@@ -51,7 +50,6 @@ describe('TabsPanel', function() {
         role="tabpanel"
         aria-labelledby="tab"
         aria-hidden="false"
-        style={{ display: 'block' }}
       >
         TabsPanel
       </div>


### PR DESCRIPTION
`cf-component-tabs` would render all the tabpanel components when a tab component would get rendered. This has the potential of loading a bunch of data over the network that the user will never see.

By changing it this way we are able to only request the data needed to render the tabs the user actually clicks on