### PR TITLE
Update PageHeader to render subtitle as an h2

### DIFF
--- a/packages/cf-component-page/src/PageHeader.js
+++ b/packages/cf-component-page/src/PageHeader.js
@@ -6,7 +6,7 @@ class PageHeader extends React.Component {
       <header className="cf-page__header">
         <h1 className="cf-page__title">{this.props.title}</h1>
         {this.props.subtitle &&
-          <p className="cf-page__subtitle">{this.props.subtitle}</p>}
+          <h2 className="cf-page__subtitle">{this.props.subtitle}</h2>}
       </header>
     );
   }

--- a/packages/cf-component-page/test/__snapshots__/PageHeader.js.snap
+++ b/packages/cf-component-page/test/__snapshots__/PageHeader.js.snap
@@ -21,10 +21,10 @@ exports[`should render title/subtitle 1`] = `
   >
     Title
   </h1>
-  <p
+  <h2
     className="cf-page__subtitle"
   >
     Subtitle
-  </p>
+  </h2>
 </header>
 `;


### PR DESCRIPTION
This is a super-simple SEMVER-major PR to make `cf-component-page`'s `PageHeader` render it's `subtitle` prop as an `h2`.

I've run `npm run update-snapshot` and committed the changes for `cf-component-page`. Is this correct? I couldn't find any documentation about how to do this so just picked the most relevant `script` 😄