### PR TITLE
Fix heading version in modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "updated": "lerna updated --only-explicit-updates",
     "prettier": "node prettier.js",
     "clean": "lerna clean --yes && rimraf .jest",
-    "publish": "git pull --rebase && check-installed-dependencies && npm run build && lerna publish --only-explicit-updates",
+    "publish": "git pull --rebase && check-installed-dependencies && npm run build && lerna publish",
     "update-snapshot": "cross-env BABEL_ENV=commonjs jest --no-cache --updateSnapshot"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
     "babel-core": "^6.18.0",
     "babel-eslint": "^7.1.1",
     "babel-jest": "^19.0.0",
-    "babel-loader": "7.0.0-alpha.3",
+    "babel-loader": "7.0.0-beta.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",

--- a/packages/cf-component-modal/package.json
+++ b/packages/cf-component-modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cf-component-modal",
   "description": "Cloudflare Modal Component",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
@@ -11,7 +11,7 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
-    "cf-component-heading": "^3.1.0",
+    "cf-component-heading": "^2.0.1",
     "cf-component-icon": "^2.2.0",
     "react-addons-css-transition-group": "^0.14.2 || ^15.0.0-0",
     "react-gateway": "^2.2.0",

--- a/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
+++ b/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
@@ -5,7 +5,7 @@ exports[`should render 1`] = `
   className="cf-modal__title"
 >
   <h3
-    className=""
+    className="cf-heading cf-heading--3"
   >
     ModalTitle
   </h3>


### PR DESCRIPTION
Lerna bumped heading's major version (fela version) and now cf-component-modal is failing in www-next because there is no fela yet. So I'm lowering the heading version to pre-fela version. 