### PR TITLE
Refactor cf-component-text, cf-component-header, small bugfixes

### DIFF
--- a/packages/cf-component-heading/src/Heading.js
+++ b/packages/cf-component-heading/src/Heading.js
@@ -1,26 +1,12 @@
 import React, { PropTypes } from 'react';
 import { createComponent } from 'cf-style-container';
 
-const styles = ({ theme, size }) => {
-  const t = {};
-
-  if (theme[`fontWeight${size}`]) {
-    t.fontWeight = theme[`fontWeight${size}`];
-  }
-
-  if (theme[`fontSize${size}`]) {
-    t.fontSize = theme[`fontSize${size}`];
-  }
-
-  if (theme[`lineHeight${size}`]) {
-    t.lineHeight = theme[`lineHeight${size}`];
-  }
-
-  if (theme[`marginTop${size}`]) {
-    t.marginTop = theme[`marginTop${size}`];
-  }
-  return t;
-};
+const styles = ({ theme, size }) => ({
+  fontWeight: theme[`fontWeight${size}`],
+  fontSize: theme[`fontSize${size}`],
+  lineHeight: theme[`lineHeight${size}`],
+  marginTop: theme[`marginTop${size}`]
+});
 
 const Heading = ({ size, className, children }) => {
   const tagName = 'h' + size;

--- a/packages/cf-component-heading/src/HeadingCaption.js
+++ b/packages/cf-component-heading/src/HeadingCaption.js
@@ -1,16 +1,13 @@
 import React, { PropTypes } from 'react';
 import { createComponent } from 'cf-style-container';
 
-const styles = props => {
-  const theme = props.theme;
-  return {
-    color: theme.color,
-    fontSize: theme.fontFize,
-    fontColor: theme.fontColor,
-    fontWeight: theme.fontWeight,
-    marginLeft: theme.marginLeft
-  };
-};
+const styles = ({ theme }) => ({
+  color: theme.color,
+  fontSize: theme.fontFize,
+  fontColor: theme.fontColor,
+  fontWeight: theme.fontWeight,
+  marginLeft: theme.marginLeft
+});
 
 const HeadingCaption = ({ className, children }) => (
   <small className={className}>

--- a/packages/cf-component-heading/test/Heading.js
+++ b/packages/cf-component-heading/test/Heading.js
@@ -1,14 +1,17 @@
 import React from 'react';
-import { Heading, HeadingTheme } from '../../cf-component-heading/src/index';
+import {
+  Heading as HeadingUnstyled,
+  HeadingTheme
+} from '../../cf-component-heading/src/index';
 import renderer from 'react-test-renderer';
 import felaTestContext from '../../../felaTestContext';
 import { applyTheme } from 'cf-style-container';
 
-const StyledHeading = applyTheme(Heading, HeadingTheme);
+const Heading = applyTheme(HeadingUnstyled, HeadingTheme);
 
 test('should render size', () => {
   const component = renderer.create(
-    felaTestContext(<StyledHeading size={2}>Heading</StyledHeading>)
+    felaTestContext(<Heading size={2}>Heading</Heading>)
   );
   expect(component.toJSON()).toMatchSnapshot();
 });

--- a/packages/cf-component-heading/test/HeadingCaption.js
+++ b/packages/cf-component-heading/test/HeadingCaption.js
@@ -1,19 +1,17 @@
 import React from 'react';
 import {
-  HeadingCaption,
+  HeadingCaption as HeadingCaptionUnstyled,
   HeadingCaptionTheme
 } from '../../cf-component-heading/src/index';
 import renderer from 'react-test-renderer';
 import felaTestContext from '../../../felaTestContext';
 import { applyTheme } from 'cf-style-container';
 
-const StyledHeadingCaption = applyTheme(HeadingCaption, HeadingCaptionTheme);
+const HeadingCaption = applyTheme(HeadingCaptionUnstyled, HeadingCaptionTheme);
 
 test('should render', () => {
   const component = renderer.create(
-    felaTestContext(
-      <StyledHeadingCaption>Heading Caption</StyledHeadingCaption>
-    )
+    felaTestContext(<HeadingCaption>Heading Caption</HeadingCaption>)
   );
   expect(component.toJSON()).toMatchSnapshot();
 });

--- a/packages/cf-component-text/src/Text.js
+++ b/packages/cf-component-text/src/Text.js
@@ -16,8 +16,8 @@ const styles = ({ theme, size, align, type, case: textCase }) => {
     t.color = theme[`color${capitalize(type)}`];
   }
 
-  if (theme[`lineHeight${capitalize(type)}`]) {
-    t.color = theme[`lineHeight${capitalize(type)}`];
+  if (theme[`lineHeight${capitalize(size)}`]) {
+    t.lineHeight = theme[`lineHeight${capitalize(size)}`];
   }
 
   if (theme[`fontSize${capitalize(size)}`]) {

--- a/packages/cf-component-text/src/Text.js
+++ b/packages/cf-component-text/src/Text.js
@@ -9,39 +9,17 @@ const capitalize = str =>
       )
     : str;
 
-const styles = ({ theme, size, align, type, case: textCase }) => {
-  const t = {};
-
-  if (theme[`color${capitalize(type)}`]) {
-    t.color = theme[`color${capitalize(type)}`];
+const styles = ({ theme, size, align, type, case: textCase }) => ({
+  color: theme[`color${capitalize(type)}`],
+  lineHeight: theme[`lineHeight${capitalize(size)}`],
+  fontSize: theme[`fontSize${capitalize(size)}`],
+  fontWeight: theme[`fontWeight${capitalize(size)}`],
+  textAlign: theme[`textAlign${capitalize(align)}`],
+  textTransform: theme[`textTransform${capitalize(textCase)}`],
+  '&:first-letter': {
+    textTransform: theme[`textTransform${capitalize(textCase)}:first-letter`]
   }
-
-  if (theme[`lineHeight${capitalize(size)}`]) {
-    t.lineHeight = theme[`lineHeight${capitalize(size)}`];
-  }
-
-  if (theme[`fontSize${capitalize(size)}`]) {
-    t.fontSize = theme[`fontSize${capitalize(size)}`];
-  }
-
-  if (theme[`fontWeight${capitalize(size)}`]) {
-    t.fontWeight = theme[`fontWeight${capitalize(size)}`];
-  }
-
-  if (theme[`textAlign${capitalize(align)}`]) {
-    t.textAlign = theme[`textAlign${capitalize(align)}`];
-  }
-
-  if (theme[`textTransform${capitalize(textCase)}`]) {
-    t.textTransform = theme[`textTransform${capitalize(textCase)}`];
-  }
-
-  if (theme[`textTransform${capitalize(textCase)}:first-word`]) {
-    t.textTransform = theme[`textTransform${capitalize(textCase)}:first-word`];
-  }
-
-  return t;
-};
+});
 
 const Text = ({ className, children }) => (
   <div className={className}>

--- a/packages/cf-component-text/src/TextTheme.js
+++ b/packages/cf-component-text/src/TextTheme.js
@@ -12,7 +12,7 @@ export default baseTheme => {
     textAlignJustify: 'justify',
     textAlignEnd: 'right',
     textTransformCapitalize: 'capitalize',
-    'textTransformCapitalize:first-word': 'capitalize',
+    'textTransformTitlecase:first-letter': 'capitalize',
     textTransformLowercase: 'lowercase',
     textTransformUppercase: 'uppercase',
     colorInfo: baseTheme.colorInfo,

--- a/packages/cf-component-text/src/TextTheme.js
+++ b/packages/cf-component-text/src/TextTheme.js
@@ -5,7 +5,7 @@ export default baseTheme => {
   return {
     fontSizeNormal: '1em',
     fontWeightNormal: 400,
-    fontSizeNormal: '.8em',
+    fontSizeSmall: '.8em',
     lineHeightSmall: 1.3,
     textAlignStart: 'left',
     textAlignCenter: 'center',

--- a/packages/cf-component-text/test/Text.js
+++ b/packages/cf-component-text/test/Text.js
@@ -4,7 +4,7 @@ import { Text } from '../../cf-component-text/src/index';
 import felaTestContext from '../../../felaTestContext';
 import { applyTheme } from 'cf-style-container';
 
-test('should render size', () => {
+test('should render normal size', () => {
   const StyledText = applyTheme(Text, () => ({
     fontSizeNormal: '1rem',
     fontWeightNormal: 400
@@ -12,6 +12,18 @@ test('should render size', () => {
 
   const component = renderer.create(
     felaTestContext(<StyledText size="normal">Hello</StyledText>)
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});
+
+test('should render small size', () => {
+  const StyledText = applyTheme(Text, () => ({
+    fontSizeSmallß: '0.8em',
+    lineHeightSmall: 1.3
+  }));
+
+  const component = renderer.create(
+    felaTestContext(<StyledText size="small">Hello</StyledText>)
   );
   expect(component.toJSON()).toMatchSnapshot();
 });

--- a/packages/cf-component-text/test/Text.js
+++ b/packages/cf-component-text/test/Text.js
@@ -1,62 +1,73 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { Text } from '../../cf-component-text/src/index';
+import { Text as TextUnstyled } from '../../cf-component-text/src/index';
 import felaTestContext from '../../../felaTestContext';
 import { applyTheme } from 'cf-style-container';
 
 test('should render normal size', () => {
-  const StyledText = applyTheme(Text, () => ({
+  const Text = applyTheme(TextUnstyled, () => ({
     fontSizeNormal: '1rem',
     fontWeightNormal: 400
   }));
 
   const component = renderer.create(
-    felaTestContext(<StyledText size="normal">Hello</StyledText>)
+    felaTestContext(<Text size="normal">Hello</Text>)
   );
   expect(component.toJSON()).toMatchSnapshot();
 });
 
 test('should render small size', () => {
-  const StyledText = applyTheme(Text, () => ({
-    fontSizeSmallß: '0.8em',
+  const Text = applyTheme(TextUnstyled, () => ({
+    fontSizeSmall: '0.8em',
     lineHeightSmall: 1.3
   }));
 
   const component = renderer.create(
-    felaTestContext(<StyledText size="small">Hello</StyledText>)
+    felaTestContext(<Text size="small">Hello</Text>)
   );
   expect(component.toJSON()).toMatchSnapshot();
 });
 
 test('should render align', () => {
-  const StyledText = applyTheme(Text, () => ({
+  const Text = applyTheme(TextUnstyled, () => ({
     textAlignCenter: 'center'
   }));
 
   const component = renderer.create(
-    felaTestContext(<StyledText align="center">Hello</StyledText>)
+    felaTestContext(<Text align="center">Hello</Text>)
   );
   expect(component.toJSON()).toMatchSnapshot();
 });
 
 test('should render type', () => {
-  const StyledText = applyTheme(Text, () => ({
+  const Text = applyTheme(TextUnstyled, () => ({
     colorInfo: '#434148'
   }));
 
   const component = renderer.create(
-    felaTestContext(<StyledText type="info">Hello</StyledText>)
+    felaTestContext(<Text type="info">Hello</Text>)
   );
   expect(component.toJSON()).toMatchSnapshot();
 });
 
-test('should render case', () => {
-  const StyledText = applyTheme(Text, () => ({
+test('should render lowercase', () => {
+  const Text = applyTheme(TextUnstyled, () => ({
     textTransformLowercase: 'lowercase'
   }));
 
   const component = renderer.create(
-    felaTestContext(<StyledText case="lowercase">Hello</StyledText>)
+    felaTestContext(<Text case="lowercase">Hello</Text>)
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});
+
+test('should render titlecase case', () => {
+  const Text = applyTheme(TextUnstyled, () => ({
+    'textTransformTitlecase:first-letter': 'capitalize'
+  }));
+
+  const component = renderer.create(
+    felaTestContext(<Text case="titlecase">Hello</Text>)
   );
   expect(component.toJSON()).toMatchSnapshot();
 });

--- a/packages/cf-component-text/test/__snapshots__/Text.js.snap
+++ b/packages/cf-component-text/test/__snapshots__/Text.js.snap
@@ -2,15 +2,15 @@
 
 exports[`should render align 1`] = `
 <div
-  className="cf-12to336"
+  className="cf-12kp2av"
 >
   Hello
 </div>
 `;
 
-exports[`should render case 1`] = `
+exports[`should render lowercase 1`] = `
 <div
-  className="cf-56txr3"
+  className="cf-1ez8i2i"
 >
   Hello
 </div>
@@ -18,7 +18,7 @@ exports[`should render case 1`] = `
 
 exports[`should render normal size 1`] = `
 <div
-  className="cf-1v2y3xx"
+  className="cf-1wd7cvk"
 >
   Hello
 </div>
@@ -26,7 +26,15 @@ exports[`should render normal size 1`] = `
 
 exports[`should render small size 1`] = `
 <div
-  className="cf-d6ndc4"
+  className="cf-xk5sq7"
+>
+  Hello
+</div>
+`;
+
+exports[`should render titlecase case 1`] = `
+<div
+  className="cf-w04jx1"
 >
   Hello
 </div>
@@ -34,7 +42,7 @@ exports[`should render small size 1`] = `
 
 exports[`should render type 1`] = `
 <div
-  className="cf-1lbcix5"
+  className="cf-1vjexbg"
 >
   Hello
 </div>

--- a/packages/cf-component-text/test/__snapshots__/Text.js.snap
+++ b/packages/cf-component-text/test/__snapshots__/Text.js.snap
@@ -16,9 +16,17 @@ exports[`should render case 1`] = `
 </div>
 `;
 
-exports[`should render size 1`] = `
+exports[`should render normal size 1`] = `
 <div
   className="cf-1v2y3xx"
+>
+  Hello
+</div>
+`;
+
+exports[`should render small size 1`] = `
+<div
+  className="cf-d6ndc4"
 >
   Hello
 </div>


### PR DESCRIPTION
according to feedback from @tajo:

* using plain object for applying styles
* exports components as `TextUnstyled`, `HeaderUnstyled` in tests to follow same style
* fix for text titlecase
* fix for text small size