### PR TITLE
Unpin cf-component-heading in cf-component-modal

### DIFF
--- a/packages/cf-component-modal/package.json
+++ b/packages/cf-component-modal/package.json
@@ -11,8 +11,9 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
-    "cf-component-heading": "^2.0.1",
+    "cf-component-heading": "^3.0.0",
     "cf-component-icon": "^2.2.0",
+    "cf-style-container": "^0.2.0",
     "react-addons-css-transition-group": "^0.14.2 || ^15.0.0-0",
     "react-gateway": "^2.2.0",
     "react-modal2": "^3.1.0"

--- a/packages/cf-component-modal/src/ModalTitle.js
+++ b/packages/cf-component-modal/src/ModalTitle.js
@@ -1,5 +1,8 @@
 import React, { PropTypes } from 'react';
-import { Heading } from 'cf-component-heading';
+import { Heading as HeadingUnstyled, HeadingTheme } from 'cf-component-heading';
+import { applyTheme } from 'cf-style-container';
+
+const Heading = applyTheme(HeadingUnstyled, HeadingTheme);
 
 class ModalTitle extends React.Component {
   render() {

--- a/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
+++ b/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
@@ -5,7 +5,7 @@ exports[`should render 1`] = `
   className="cf-modal__title"
 >
   <h3
-    className="cf-heading cf-heading--3"
+    className="cf-1phyxie"
   >
     ModalTitle
   </h3>


### PR DESCRIPTION
There is no reason why old components couldn't consume new Fela components if Fela is supported in www-next now. It's critical to not pin cross dependencies in order to make lerna and our workflow happy.

Heading is bumped to v3 (fela version) in cf-component-modal, so the theme needs to be applied. We still major bump cf-component-modal so it doesn't break anything.

