### PR TITLE
card: Keep a local state of drawers if no props

### DIFF
--- a/packages/cf-component-card/src/CardDrawers.js
+++ b/packages/cf-component-card/src/CardDrawers.js
@@ -26,7 +26,9 @@ class CardDrawers extends React.Component {
   }
 
   render() {
-    const active = this.props.active || this.state.active;
+    const active = this.props.hasOwnProperty('active')
+      ? this.props.active
+      : this.state.active;
 
     const links = [];
     const drawers = [];

--- a/packages/cf-component-card/src/CardDrawers.js
+++ b/packages/cf-component-card/src/CardDrawers.js
@@ -9,15 +9,30 @@ let UNIQUE_ID = 0;
 class CardDrawers extends React.Component {
   constructor(props) {
     super(props);
+
     this._cardId = UNIQUE_ID++;
+
+    this.state = {
+      active: null
+    };
+  }
+
+  handleLinkClick(id) {
+    this.props.onClick && this.props.onClick();
+
+    this.setState(state => ({
+      active: state.active === id ? null : id
+    }));
   }
 
   render() {
+    const active = this.props.active || this.state.active;
+
     const links = [];
     const drawers = [];
 
     this.props.drawers.forEach(drawer => {
-      const isActive = drawer.id === this.props.active;
+      const isActive = drawer.id === active;
       const id = `card-${this._cardId}-drawer-${drawer.id}`;
 
       links.push(
@@ -25,7 +40,7 @@ class CardDrawers extends React.Component {
           key={drawer.id}
           id={id}
           isActive={isActive}
-          onClick={this.props.onClick.bind(null, drawer.id)}
+          onClick={() => this.handleLinkClick(drawer.id)}
         >
           {drawer.name}
         </CardToolbarLink>
@@ -52,7 +67,7 @@ class CardDrawers extends React.Component {
 
     let containerClassName = 'cf-card__drawers_container';
 
-    if (this.props.active) {
+    if (active) {
       containerClassName += ' cf-card__drawers_container--open';
     }
 
@@ -68,7 +83,7 @@ class CardDrawers extends React.Component {
 }
 
 CardDrawers.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
 
   active: PropTypes.string,
   drawers: CardPropTypes.cardDrawers.isRequired,

--- a/packages/cf-component-card/test/CardDrawers.js
+++ b/packages/cf-component-card/test/CardDrawers.js
@@ -6,11 +6,23 @@ import {
   CardToolbarLink
 } from '../../cf-component-card/src/index';
 
-test('should render', () => {
+test('should render when given all the props', () => {
   const component = renderer.create(
     <CardDrawers
       onClick={() => {}}
       active="one"
+      drawers={[
+        { id: 'one', name: 'One', content: 'One Content' },
+        { id: 'two', name: 'Two', content: 'Two Content' }
+      ]}
+    />
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});
+
+test('should render when not given props', () => {
+  const component = renderer.create(
+    <CardDrawers
       drawers={[
         { id: 'one', name: 'One', content: 'One Content' },
         { id: 'two', name: 'Two', content: 'Two Content' }

--- a/packages/cf-component-card/test/__snapshots__/CardDrawers.js.snap
+++ b/packages/cf-component-card/test/__snapshots__/CardDrawers.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
+exports[`should render when given all the props 1`] = `
 <div
   className="cf-card__section cf-card__section--default"
 >
@@ -48,6 +48,59 @@ exports[`should render 1`] = `
     <div
       aria-hidden="true"
       aria-labelledby="card-0-drawer-two"
+      className="cf-card__drawer"
+      role="tabpanel"
+    />
+  </div>
+</div>
+`;
+
+exports[`should render when not given props 1`] = `
+<div
+  className="cf-card__section cf-card__section--default"
+>
+  <div
+    className="cf-card__toolbar"
+  >
+    <div
+      className="cf-card__toolbar_controls"
+    />
+    <div
+      className="cf-card__toolbar_links"
+      role="tablist"
+    >
+      <a
+        className="cf-link cf-card__toolbar_link"
+        href="#!"
+        id="card-1-drawer-one"
+        onClick={[Function]}
+        role="tab"
+      >
+        One
+      </a>
+      <a
+        className="cf-link cf-card__toolbar_link"
+        href="#!"
+        id="card-1-drawer-two"
+        onClick={[Function]}
+        role="tab"
+      >
+        Two
+      </a>
+    </div>
+  </div>
+  <div
+    className="cf-card__drawers_container"
+  >
+    <div
+      aria-hidden="true"
+      aria-labelledby="card-1-drawer-one"
+      className="cf-card__drawer"
+      role="tabpanel"
+    />
+    <div
+      aria-hidden="true"
+      aria-labelledby="card-1-drawer-two"
       className="cf-card__drawer"
       role="tabpanel"
     />


### PR DESCRIPTION
Whenever you're using the `CardDrawers` sub-component of `Card` you need
to add some keys to your state and handle all the events yourself. This
is fine if you want to control the flow very tightly but the most common
case is just to switch to the drawers selected.

This patch changes the `CardDrawers` sub-component so it still takes in
the props and those will control the component but falls back to the
local state if the props `active` and `onClick` are not present.

Not sure if there are more tests to be written or if the snapshots are enough.