### PR TITLE
#129 allow null as the 3rd parameter again

### DIFF
--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -104,9 +104,11 @@ function wrapResponse(headers, status, body, text, response) {
  * @see [Global Fetch on MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)
  * @see [WHATWG Fetch API Spec](https://fetch.spec.whatwg.org/)
  */
-export function request(method, url, opts = {}, callback) {
+export function request(method, url, opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
+    opts = {};
+  } else if (opts == null) {
     opts = {};
   }
 

--- a/packages/cf-util-http/test/http.js
+++ b/packages/cf-util-http/test/http.js
@@ -63,6 +63,19 @@ describe('request', () => {
     });
   });
 
+  test('should accept null as the 3rd parameter', done => {
+    fetch.mockResponse('', {
+      headers: { 'Content-Type': 'text/plain' },
+      status: 200
+    });
+
+    http.request('/GET', '/somewhere', null, (err, res) => {
+      expect(err).toBeUndefined();
+      expect(res).toBeDefined();
+      done();
+    });
+  });
+
   test('should call the success handler on success', done => {
     fetch.mockResponse(
       JSON.stringify({


### PR DESCRIPTION
This should make cf-util-http users happier.