### PR TITLE
Emulate superagent's ability to filter out headers with null or undefined values

### DIFF
--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -127,11 +127,21 @@ export function request(method, url, opts, callback) {
   url = opts.url;
   callback = opts.callback;
 
+  // Normalize the headers
+  opts.headers = new Headers(opts.headers || {});
+
+  // Emuluate superagent's questionable ability to filter out headers that's
+  // been set to null or undefined.
+  for (let [k, v] of opts.headers.entries()) {
+    if (v === 'null' || v === 'undefined') {
+      opts.headers.delete(k);
+    }
+  }
+
   // Emulate superagent's ability to automatically encode JSON body and set the
   // Content-Type
   if (BODYLESS_METHODS.every(m => method.toUpperCase() !== m) && opts.body) {
     opts.body = JSON.stringify(opts.body);
-    opts.headers = new Headers(opts.headers || {});
     if (!opts.headers.has('Content-Type')) {
       opts.headers.set('Content-Type', 'application/json');
     }

--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -140,7 +140,11 @@ export function request(method, url, opts, callback) {
 
   // Emulate superagent's ability to automatically encode JSON body and set the
   // Content-Type
-  if (BODYLESS_METHODS.every(m => method.toUpperCase() !== m) && opts.body) {
+  if (
+    BODYLESS_METHODS.every(m => method.toUpperCase() !== m) &&
+    opts.body &&
+    typeof opts.body === 'object'
+  ) {
     opts.body = JSON.stringify(opts.body);
     if (!opts.headers.has('Content-Type')) {
       opts.headers.set('Content-Type', 'application/json');

--- a/packages/cf-util-http/test/http.js
+++ b/packages/cf-util-http/test/http.js
@@ -104,11 +104,12 @@ describe('request', () => {
     http.request(
       'GET',
       '/somewhere',
-      { headers: { foo: null, bar: 'bar' } },
+      { headers: { foo: null, bar: 'bar', baz: undefined } },
       (err, res) => {}
     );
     expect(fetch.mock.calls[0][1].headers.has('foo')).toBeFalsy();
     expect(fetch.mock.calls[0][1].headers.has('bar')).toBeTruthy();
+    expect(fetch.mock.calls[0][1].headers.has('baz')).toBeFalsy();
     done();
   });
 

--- a/packages/cf-util-http/test/http.js
+++ b/packages/cf-util-http/test/http.js
@@ -82,6 +82,21 @@ describe('request', () => {
       'application/json'
     );
     expect(typeof fetch.mock.calls[0][1].body === 'string').toBeTruthy();
+    expect(fetch.mock.calls[0][1].body).toBe(JSON.stringify({ foo: 1 }));
+    done();
+  });
+
+  test("should not JSON.stringify the body if it's not an object", done => {
+    http.request(
+      'POST',
+      '/somewhere',
+      { body: 'hello world' },
+      (err, res) => {}
+    );
+    expect(fetch.mock.calls[0][1].headers.get('content-type')).not.toBe(
+      'application/json'
+    );
+    expect(fetch.mock.calls[0][1].body).toBe('hello world');
     done();
   });
 

--- a/packages/cf-util-http/test/http.js
+++ b/packages/cf-util-http/test/http.js
@@ -85,6 +85,18 @@ describe('request', () => {
     done();
   });
 
+  test('should ignore null header values', done => {
+    http.request(
+      'GET',
+      '/somewhere',
+      { headers: { foo: null, bar: 'bar' } },
+      (err, res) => {}
+    );
+    expect(fetch.mock.calls[0][1].headers.has('foo')).toBeFalsy();
+    expect(fetch.mock.calls[0][1].headers.has('bar')).toBeTruthy();
+    done();
+  });
+
   test('should call the success handler on success', done => {
     fetch.mockResponse(
       JSON.stringify({


### PR DESCRIPTION
This should be the last fix for cf-util-http where people were taking advantage of superagent's ability to filter out null headers and now have the their APIs broken by fetch.