### PR TITLE
Export styled components by default

### DIFF
--- a/packages/cf-component-button/README.md
+++ b/packages/cf-component-button/README.md
@@ -12,16 +12,7 @@ $ npm install cf-component-button
 
 ```jsx
 import React from 'react';
-import { applyTheme } from 'cf-style-container';
-import {
-  ButtonGroup as ButtonGroupUnstyled,
-  Button as ButtonUnstyled,
-  ButtonTheme,
-  ButtonGroupTheme
-} from 'cf-component-button';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
-const ButtonGroup = applyTheme(ButtonGroupUnstyled, ButtonGroupTheme);
+import { Button, ButtonGroup } from 'cf-component-button';
 
 const ButtonComponent = () => (
   <ButtonGroup>

--- a/packages/cf-component-button/example/basic/component.js
+++ b/packages/cf-component-button/example/basic/component.js
@@ -1,14 +1,5 @@
 import React from 'react';
-import { applyTheme } from 'cf-style-container';
-import {
-  ButtonGroup as ButtonGroupUnstyled,
-  Button as ButtonUnstyled,
-  ButtonTheme,
-  ButtonGroupTheme
-} from 'cf-component-button';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
-const ButtonGroup = applyTheme(ButtonGroupUnstyled, ButtonGroupTheme);
+import { Button, ButtonGroup } from 'cf-component-button';
 
 const ButtonComponent = () => (
   <ButtonGroup>

--- a/packages/cf-component-button/src/index.js
+++ b/packages/cf-component-button/src/index.js
@@ -1,6 +1,18 @@
-import Button from './Button';
+import ButtonUnstyled from './Button';
 import ButtonTheme from './ButtonTheme';
-import ButtonGroup from './ButtonGroup';
+import ButtonGroupUnstyled from './ButtonGroup';
 import ButtonGroupTheme from './ButtonGroupTheme';
 
-export { Button, ButtonTheme, ButtonGroup, ButtonGroupTheme };
+import { applyTheme } from 'cf-style-container';
+
+const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+const ButtonGroup = applyTheme(ButtonGroupUnstyled, ButtonGroupTheme);
+
+export {
+  Button,
+  ButtonTheme,
+  ButtonUnstyled,
+  ButtonGroup,
+  ButtonGroupTheme,
+  ButtonGroupUnstyled
+};

--- a/packages/cf-component-button/test/Button.js
+++ b/packages/cf-component-button/test/Button.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import felaTestContext from '../../../felaTestContext';
-import { applyTheme } from '../../cf-style-container/src/index';
-import {
-  Button as ButtonUnstyled,
-  ButtonTheme
-} from '../../cf-component-button/src/index';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from '../../cf-component-button/src/index';
 
 test('should render with type', () => {
   const component = renderer.create(

--- a/packages/cf-component-button/test/ButtonGroup.js
+++ b/packages/cf-component-button/test/ButtonGroup.js
@@ -1,16 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import felaTestContext from '../../../felaTestContext';
-import { applyTheme } from '../../cf-style-container/src/index';
-import {
-  ButtonGroup as ButtonGroupUnstyled,
-  ButtonGroupTheme,
-  Button as ButtonUnstyled,
-  ButtonTheme
-} from '../../cf-component-button/src/index';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
-const ButtonGroup = applyTheme(ButtonGroupUnstyled, ButtonGroupTheme);
+import { ButtonGroup, Button } from '../../cf-component-button/src/index';
 
 test('should render', () => {
   const component = renderer.create(

--- a/packages/cf-component-heading/README.md
+++ b/packages/cf-component-heading/README.md
@@ -17,7 +17,9 @@ import { Heading, HeadingCaption } from 'cf-component-heading';
 const HeadingComponent = () => (
   <Heading size={2}>
     Look at this nice heading!
-    <HeadingCaption>It even has a nice HeadingCaption</HeadingCaption>
+    <HeadingCaption>
+      It even has a nice HeadingCaption
+    </HeadingCaption>
   </Heading>
 );
 

--- a/packages/cf-component-heading/example/basic/component.js
+++ b/packages/cf-component-heading/example/basic/component.js
@@ -1,22 +1,13 @@
 import React from 'react';
-import {
-  Heading,
-  HeadingCaption,
-  HeadingTheme,
-  HeadingCaptionTheme
-} from 'cf-component-heading';
-import { applyTheme } from 'cf-style-container';
-
-const StyledHeading = applyTheme(Heading, HeadingTheme);
-const StyledHeadingCaption = applyTheme(HeadingCaption, HeadingCaptionTheme);
+import { Heading, HeadingCaption } from 'cf-component-heading';
 
 const HeadingComponent = () => (
-  <StyledHeading size={2}>
+  <Heading size={2}>
     Look at this nice heading!
-    <StyledHeadingCaption>
+    <HeadingCaption>
       It even has a nice HeadingCaption
-    </StyledHeadingCaption>
-  </StyledHeading>
+    </HeadingCaption>
+  </Heading>
 );
 
 export default HeadingComponent;

--- a/packages/cf-component-heading/src/index.js
+++ b/packages/cf-component-heading/src/index.js
@@ -1,6 +1,18 @@
-import Heading from './Heading';
-import HeadingCaption from './HeadingCaption';
+import HeadingUnstyled from './Heading';
+import HeadingCaptionUnstyled from './HeadingCaption';
 import HeadingTheme from './HeadingTheme';
 import HeadingCaptionTheme from './HeadingCaptionTheme';
 
-export { Heading, HeadingCaption, HeadingTheme, HeadingCaptionTheme };
+import { applyTheme } from 'cf-style-container';
+
+const Heading = applyTheme(HeadingUnstyled, HeadingTheme);
+const HeadingCaption = applyTheme(HeadingCaptionUnstyled, HeadingCaptionTheme);
+
+export {
+  Heading,
+  HeadingUnstyled,
+  HeadingCaption,
+  HeadingCaptionUnstyled,
+  HeadingTheme,
+  HeadingCaptionTheme
+};

--- a/packages/cf-component-heading/test/Heading.js
+++ b/packages/cf-component-heading/test/Heading.js
@@ -1,13 +1,7 @@
 import React from 'react';
-import {
-  Heading as HeadingUnstyled,
-  HeadingTheme
-} from '../../cf-component-heading/src/index';
+import { Heading } from '../../cf-component-heading/src/index';
 import renderer from 'react-test-renderer';
 import felaTestContext from '../../../felaTestContext';
-import { applyTheme } from 'cf-style-container';
-
-const Heading = applyTheme(HeadingUnstyled, HeadingTheme);
 
 test('should render size', () => {
   const component = renderer.create(

--- a/packages/cf-component-heading/test/HeadingCaption.js
+++ b/packages/cf-component-heading/test/HeadingCaption.js
@@ -1,13 +1,7 @@
 import React from 'react';
-import {
-  HeadingCaption as HeadingCaptionUnstyled,
-  HeadingCaptionTheme
-} from '../../cf-component-heading/src/index';
+import { HeadingCaption } from '../../cf-component-heading/src/index';
 import renderer from 'react-test-renderer';
 import felaTestContext from '../../../felaTestContext';
-import { applyTheme } from 'cf-style-container';
-
-const HeadingCaption = applyTheme(HeadingCaptionUnstyled, HeadingCaptionTheme);
 
 test('should render', () => {
   const component = renderer.create(

--- a/packages/cf-component-modal/src/ModalTitle.js
+++ b/packages/cf-component-modal/src/ModalTitle.js
@@ -1,8 +1,6 @@
 import React, { PropTypes } from 'react';
-import { Heading as HeadingUnstyled, HeadingTheme } from 'cf-component-heading';
+import { Heading } from 'cf-component-heading';
 import { applyTheme } from 'cf-style-container';
-
-const Heading = applyTheme(HeadingUnstyled, HeadingTheme);
 
 class ModalTitle extends React.Component {
   render() {

--- a/packages/cf-component-text/README.md
+++ b/packages/cf-component-text/README.md
@@ -12,7 +12,7 @@ $ npm install cf-component-text
 
 ```jsx
 import React from 'react';
-import Text from 'cf-component-text';
+import { Text } from 'cf-component-text';
 
 const TextComponent = () => (
   <div>

--- a/packages/cf-component-text/example/basic/component.js
+++ b/packages/cf-component-text/example/basic/component.js
@@ -1,33 +1,30 @@
 import React from 'react';
-import { Text, TextTheme } from 'cf-component-text';
-import { applyTheme } from 'cf-style-container';
-
-const StyledText = applyTheme(Text, TextTheme);
+import { Text } from 'cf-component-text';
 
 const TextComponent = () => (
   <div>
     <p>Specify a <code>size</code></p>
-    <StyledText size="normal">Hello World</StyledText>
-    <StyledText size="small">Hello World</StyledText>
+    <Text size="normal">Hello World</Text>
+    <Text size="small">Hello World</Text>
 
     <p>and/or an <code>align</code></p>
-    <StyledText align="start">Hello World</StyledText>
-    <StyledText align="center">Hello World</StyledText>
-    <StyledText align="justify">Hello World</StyledText>
-    <StyledText align="end">Hello World</StyledText>
+    <Text align="start">Hello World</Text>
+    <Text align="center">Hello World</Text>
+    <Text align="justify">Hello World</Text>
+    <Text align="end">Hello World</Text>
 
     <p>and/or a <code>type</code></p>
-    <StyledText type="info">Hello World</StyledText>
-    <StyledText type="success">Hello World</StyledText>
-    <StyledText type="warning">Hello World</StyledText>
-    <StyledText type="error">Hello World</StyledText>
-    <StyledText type="muted">Hello World</StyledText>
+    <Text type="info">Hello World</Text>
+    <Text type="success">Hello World</Text>
+    <Text type="warning">Hello World</Text>
+    <Text type="error">Hello World</Text>
+    <Text type="muted">Hello World</Text>
 
     <p>and/or a <code>case</code></p>
-    <StyledText case="capitalize">hello world</StyledText>
-    <StyledText case="titlecase">hello world</StyledText>
-    <StyledText case="lowercase">Hello World</StyledText>
-    <StyledText case="uppercase">Hello World</StyledText>
+    <Text case="capitalize">hello world</Text>
+    <Text case="titlecase">hello world</Text>
+    <Text case="lowercase">Hello World</Text>
+    <Text case="uppercase">Hello World</Text>
   </div>
 );
 

--- a/packages/cf-component-text/src/index.js
+++ b/packages/cf-component-text/src/index.js
@@ -1,4 +1,8 @@
-import Text from './Text';
+import TextUnstyled from './Text';
 import TextTheme from './TextTheme';
 
-export { Text, TextTheme };
+import { applyTheme } from 'cf-style-container';
+
+const Text = applyTheme(TextUnstyled, TextTheme);
+
+export { Text, TextUnstyled, TextTheme };

--- a/packages/cf-component-text/test/Text.js
+++ b/packages/cf-component-text/test/Text.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { Text as TextUnstyled } from '../../cf-component-text/src/index';
+import { Text, TextUnstyled } from '../../cf-component-text/src/index';
 import felaTestContext from '../../../felaTestContext';
 import { applyTheme } from 'cf-style-container';
 


### PR DESCRIPTION
The reasoning is here: https://github.com/cloudflare/cf-ui/issues/136

**TLDR;** Let's make our life easier. No need to ever change APIs because of Fela migration.

Major bumps for: 
- cf-component-button
- cf-component-heading
- cf-component-text

Minor bump for:
- cf-component-modal
