### PR TITLE
Fix JSON content-type detection in 'wrapResponse'

### DIFF
--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -29,6 +29,10 @@ export function clearBeforeSend() {
   beforeSendCallbacks = [];
 }
 
+function isJSON(contentType) {
+  return /[\/+]json\b/.test(contentType);
+}
+
 function toQueryParams(kvs) {
   const queryParams = [];
   // Clones the input
@@ -61,9 +65,7 @@ function wrapResponse(headers, status, body, text, response) {
   return {
     headers,
     status,
-    body: headers['content-type'] === 'application/json'
-      ? JSON.parse(text)
-      : text,
+    body: isJSON(headers['content-type']) ? JSON.parse(text) : text,
     text,
     response
   };

--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -129,6 +129,10 @@ export function request(method, url, opts, callback) {
   url = opts.url;
   callback = opts.callback;
 
+  // Fetch does not send cookies by default, this take fetch back to the
+  // behavior similar to XHR
+  if (!opts.credentials) opts.credentials = 'same-origin';
+
   // Normalize the headers
   opts.headers = new Headers(opts.headers || {});
 

--- a/packages/cf-util-http/test/http.js
+++ b/packages/cf-util-http/test/http.js
@@ -100,6 +100,22 @@ describe('request', () => {
     done();
   });
 
+  test('should parse the response body as JSON when appripriate', done => {
+    fetch.mockResponse(
+      JSON.stringify({
+        message: 'hello'
+      }),
+      {
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        status: 200
+      }
+    );
+    http.request('GET', '/somewhere', (err, res) => {
+      expect(res.body).toMatchObject({ message: 'hello' });
+      done();
+    });
+  });
+
   test('should ignore null header values', done => {
     http.request(
       'GET',
@@ -110,6 +126,12 @@ describe('request', () => {
     expect(fetch.mock.calls[0][1].headers.has('foo')).toBeFalsy();
     expect(fetch.mock.calls[0][1].headers.has('bar')).toBeTruthy();
     expect(fetch.mock.calls[0][1].headers.has('baz')).toBeFalsy();
+    done();
+  });
+
+  test('should send cookies to same origin by default', done => {
+    http.request('GET', '/somewhere', (err, res) => {});
+    expect(fetch.mock.calls[0][1].credentials).toBe('same-origin');
     done();
   });
 


### PR DESCRIPTION
This fixes an issue described in https://github.com/cloudflare/cf-ui/issues/139 where our detection of whether to parse a response `body` as JSON relied on strict string matching, rather than emulating how it's handled in `superagent`.

The practice for bumping the version isn't defined in CONTRIBUTING, so I won't include it here, but 🙏 *please please please please* 🙏 publish as a `PATCH`, as per the [Semver FAQ](http://semver.org/#what-if-i-inadvertently-alter-the-public-api-in-a-way-that-is-not-compliant-with-the-version-number-change-ie-the-code-incorrectly-introduces-a-major-breaking-change-in-a-patch-release).