### PR TITLE
Fix JSON content-type detection in 'wrapResponse' (#140)

### DIFF
--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -29,6 +29,10 @@ export function clearBeforeSend() {
   beforeSendCallbacks = [];
 }
 
+function isJSON(contentType) {
+  return /[\/+]json\b/.test(contentType);
+}
+
 function toQueryParams(kvs) {
   const queryParams = [];
   // Clones the input
@@ -61,9 +65,7 @@ function wrapResponse(headers, status, body, text, response) {
   return {
     headers,
     status,
-    body: headers['content-type'] === 'application/json'
-      ? JSON.parse(text)
-      : text,
+    body: isJSON(headers['content-type']) ? JSON.parse(text) : text,
     text,
     response
   };
@@ -126,6 +128,10 @@ export function request(method, url, opts, callback) {
   method = opts.method;
   url = opts.url;
   callback = opts.callback;
+
+  // Fetch does not send cookies by default, this take fetch back to the
+  // behavior similar to XHR
+  if (!opts.credentials) opts.credentials = 'same-origin';
 
   // Normalize the headers
   opts.headers = new Headers(opts.headers || {});

--- a/packages/cf-util-http/test/http.js
+++ b/packages/cf-util-http/test/http.js
@@ -100,6 +100,22 @@ describe('request', () => {
     done();
   });
 
+  test('should parse the response body as JSON when appripriate', done => {
+    fetch.mockResponse(
+      JSON.stringify({
+        message: 'hello'
+      }),
+      {
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        status: 200
+      }
+    );
+    http.request('GET', '/somewhere', (err, res) => {
+      expect(res.body).toMatchObject({ message: 'hello' });
+      done();
+    });
+  });
+
   test('should ignore null header values', done => {
     http.request(
       'GET',
@@ -110,6 +126,12 @@ describe('request', () => {
     expect(fetch.mock.calls[0][1].headers.has('foo')).toBeFalsy();
     expect(fetch.mock.calls[0][1].headers.has('bar')).toBeTruthy();
     expect(fetch.mock.calls[0][1].headers.has('baz')).toBeFalsy();
+    done();
+  });
+
+  test('should send cookies to same origin by default', done => {
+    http.request('GET', '/somewhere', (err, res) => {});
+    expect(fetch.mock.calls[0][1].credentials).toBe('same-origin');
     done();
   });
 


### PR DESCRIPTION
* #139 Fix JSON content-type detection in 'wrapResponse'

* add test for json content type in the response and add credentials to same origin by default