### PR TITLE
Fix cf-component-button usage in examples

### DIFF
--- a/packages/cf-builder-card/README.md
+++ b/packages/cf-builder-card/README.md
@@ -14,10 +14,8 @@ $ npm install cf-builder-card
 import React from 'react';
 import { CardBuilder } from 'cf-builder-card';
 import { Table, TableBody, TableRow, TableCell } from 'cf-component-table';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
+import { Button } from 'cf-component-button';
 
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
 const EXAMPLE_CARD = 'EXAMPLE_CARD';
 
 const MyButton = (

--- a/packages/cf-builder-card/example/basic/component.js
+++ b/packages/cf-builder-card/example/basic/component.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import { CardBuilder } from 'cf-builder-card';
 import { Table, TableBody, TableRow, TableCell } from 'cf-component-table';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
+import { Button } from 'cf-component-button';
 
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
 const EXAMPLE_CARD = 'EXAMPLE_CARD';
 
 const MyButton = (

--- a/packages/cf-builder-table/README.md
+++ b/packages/cf-builder-table/README.md
@@ -15,10 +15,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { TableBuilder, tableReducer, tableActions } from 'cf-builder-table';
 import { TableCell } from 'cf-component-table';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from 'cf-component-button';
 
 const EXAMPLE_TABLE = 'EXAMPLE_TABLE';
 

--- a/packages/cf-builder-table/example/basic/component.js
+++ b/packages/cf-builder-table/example/basic/component.js
@@ -2,10 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { TableBuilder, tableReducer, tableActions } from 'cf-builder-table';
 import { TableCell } from 'cf-component-table';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from 'cf-component-button';
 
 const EXAMPLE_TABLE = 'EXAMPLE_TABLE';
 

--- a/packages/cf-component-card/README.md
+++ b/packages/cf-component-card/README.md
@@ -20,10 +20,7 @@ import {
   CardMessages,
   CardSection
 } from 'cf-component-card';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from 'cf-component-button';
 
 class CardComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-card/example/basic/component.js
+++ b/packages/cf-component-card/example/basic/component.js
@@ -7,10 +7,7 @@ import {
   CardMessages,
   CardSection
 } from 'cf-component-card';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from 'cf-component-button';
 
 class CardComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-dropdown/README.md
+++ b/packages/cf-component-dropdown/README.md
@@ -17,16 +17,7 @@ import {
   DropdownLink,
   DropdownSeparator
 } from 'cf-component-dropdown';
-import {
-  Button as ButtonUnstyled,
-  ButtonTheme,
-  ButtonGroup as ButtonGroupUnstyled,
-  ButtonGroupTheme
-} from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
-const ButtonGroup = applyTheme(ButtonGroupUnstyled, ButtonGroupTheme);
+import { Button, ButtonTheme } from 'cf-component-button';
 
 class DropdownComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-dropdown/example/basic/component.js
+++ b/packages/cf-component-dropdown/example/basic/component.js
@@ -4,16 +4,7 @@ import {
   DropdownLink,
   DropdownSeparator
 } from 'cf-component-dropdown';
-import {
-  Button as ButtonUnstyled,
-  ButtonTheme,
-  ButtonGroup as ButtonGroupUnstyled,
-  ButtonGroupTheme
-} from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
-const ButtonGroup = applyTheme(ButtonGroupUnstyled, ButtonGroupTheme);
+import { Button, ButtonGroup } from 'cf-component-button';
 
 class DropdownComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-modal/README.md
+++ b/packages/cf-component-modal/README.md
@@ -23,10 +23,7 @@ import {
 } from 'cf-component-modal';
 import { GatewayDest, GatewayProvider } from 'react-gateway';
 import ReactModal2 from 'react-modal2';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from 'cf-component-button';
 
 class ModalComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-modal/example/basic/component.js
+++ b/packages/cf-component-modal/example/basic/component.js
@@ -10,10 +10,7 @@ import {
 } from 'cf-component-modal';
 import { GatewayDest, GatewayProvider } from 'react-gateway';
 import ReactModal2 from 'react-modal2';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from 'cf-component-button';
 
 class ModalComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-notifications/README.md
+++ b/packages/cf-component-notifications/README.md
@@ -17,10 +17,7 @@ import {
   Notification,
   NotificationGlobalContainer
 } from 'cf-component-notifications';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from 'cf-component-button';
 
 let UNIQUE_ID = 0;
 

--- a/packages/cf-component-notifications/example/basic/component.js
+++ b/packages/cf-component-notifications/example/basic/component.js
@@ -4,10 +4,7 @@ import {
   Notification,
   NotificationGlobalContainer
 } from 'cf-component-notifications';
-import { Button as ButtonUnstyled, ButtonTheme } from 'cf-component-button';
-import { applyTheme } from 'cf-style-container';
-
-const Button = applyTheme(ButtonUnstyled, ButtonTheme);
+import { Button } from 'cf-component-button';
 
 let UNIQUE_ID = 0;
 


### PR DESCRIPTION
**This doesn't change any component.** `cf-component-button` exports the styled component by default but we didn't update examples to reflect that so they look broken in the styleguide now. cf-component-heading and cf-component-text usage is already ok. I didn't fix the usage of button in cf-component-form because it's done in https://github.com/cloudflare/cf-ui/pull/133 instead. 