### PR TITLE
Styling component similar to cf-component-flex

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,7 @@
   "env": {
     "commonjs": {
       "plugins": [
-        ["transform-es2015-modules-commonjs"]
+        ["transform-es2015-modules-commonjs", "polished"]
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "react-test-renderer": "^15.4.2",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",
-    "rimraf": "^2.6.1"
-  }
+    "rimraf": "^2.6.1",
+    "babel-plugin-polished": "^1.0.3"
+  },
+  "dependencies": {}
 }

--- a/packages/cf-component-box/.npmignore
+++ b/packages/cf-component-box/.npmignore
@@ -1,0 +1,6 @@
+node_modules
+*.log
+src
+coverage
+test
+example

--- a/packages/cf-component-box/README.md
+++ b/packages/cf-component-box/README.md
@@ -1,0 +1,37 @@
+# cf-component-box
+
+> Cloudflare Box Component
+
+This is styling component similar to cf-component-flex which allows for arbitrary styling.
+
+This component should only be used when the built in style doesn't quite fit the bill and when
+it can't be done with fela. Ideally, cf-ui components should have the right styling built in for
+most cases. In the few edge cases that pop up in real world feature development, this is an alternative
+to wrapping your component in a `<div>` or `<span>` and styling it with css to accomodate one-offs.
+
+Also, note that using Box effectively performs a component level CSS reset, as all props
+not provided will be pulled from the default theme. These defaults, outlined in propertiesSpec,
+either match the browser defaults, or are taken from our global styles as defined by
+cf-style-const.
+
+## Installation
+
+```sh
+$ npm install cf-component-box
+```
+
+## Usage
+
+```jsx
+import React from 'react';
+import { Box } from 'cf-component-box';
+
+const SomeComponent = () => (
+  <Box margin="1rem" padding="1rem">
+    <Heading size={3}>Things</Heading>
+    <Text>Lorem ipsum</Text>
+  </Box>
+);
+
+export default SomeComponent;
+```

--- a/packages/cf-component-box/example/basic/component.js
+++ b/packages/cf-component-box/example/basic/component.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Box } from 'cf-component-box';
+
+const BoxComponent = () => (
+  <Box>
+    <Box margin="1rem" backgroundColor="thistle">
+      This is a box with a margin
+    </Box>
+
+    <Box padding="1rem" backgroundColor="blanchedalmond">
+      This is a box with padding
+    </Box>
+
+    <Box
+      padding="1rem"
+      marginTop="1rem"
+      borderTopColor="black"
+      borderTopWidth={1}
+      borderTopStyle="solid"
+      borderBottomColor="blue"
+      borderBottomWidth={1}
+      borderBottomStyle="groove"
+      borderLeftColor="teal"
+      borderLeftWidth={2}
+      borderLeftStyle="dashed"
+      borderRightColor="purple"
+      borderRightWidth={2}
+      borderRightStyle="dotted"
+    >
+      All the borders!
+    </Box>
+
+    <Box
+      display="inline-block"
+      margin="1rem"
+      padding="1rem"
+      width="40%"
+      textAlign="center"
+      backgroundColor="#3dd"
+    >
+      inline block
+    </Box>
+
+    <Box
+      margin="1rem"
+      padding="2rem"
+      backgroundColor="peachpuff"
+      display="inline-flex"
+      justifyContent="space-between"
+      width="40%"
+    >
+      <Box backgroundColor="lightsalmon" margin="1rem" padding="1rem">Flex</Box>
+      <Box backgroundColor="lightsalmon" margin="1rem" padding="1rem">Flex</Box>
+      <Box backgroundColor="lightsalmon" margin="1rem" padding="1rem">Flex</Box>
+    </Box>
+
+    <Box marginLeft="1rem">
+      <h4>Absolute Positioning</h4>
+    </Box>
+
+    <Box
+      marginLeft="1rem"
+      backgroundColor="aquamarine"
+      position="relative"
+      width={200}
+      height={200}
+      display="inline-block"
+    >
+      <Box
+        backgroundColor="pink"
+        position="absolute"
+        width={50}
+        height={50}
+        top={10}
+        left={10}
+      />
+      <Box
+        margin="1rem"
+        backgroundColor="azure"
+        position="absolute"
+        width={100}
+        height={100}
+        bottom={10}
+        right={10}
+      />
+    </Box>
+
+    <Box
+      margin="1rem"
+      padding="1rem"
+      backgroundColor="lightsalmon"
+      float="right"
+    >
+      Floated right
+    </Box>
+
+  </Box>
+);
+
+export default BoxComponent;

--- a/packages/cf-component-box/package.json
+++ b/packages/cf-component-box/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "cf-component-box",
+  "description": "Cloudflare Box Component",
+  "version": "1.0.0",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
+  "author": "James Culveyhouse <jculveyhouse@cloudflare.com>",
+  "license": "BSD-3-Clause",
+  "publishConfig": {
+    "registry": "http://registry.npmjs.org/"
+  },
+  "dependencies": {
+    "cf-style-const": "^0.3.1",
+    "cf-style-container": "^0.2.1",
+    "polished": "^1.0.2"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0"
+  }
+}

--- a/packages/cf-component-box/src/Box.js
+++ b/packages/cf-component-box/src/Box.js
@@ -1,0 +1,141 @@
+import React, { PropTypes } from 'react';
+import { createComponent } from 'cf-style-container';
+import propertiesSpec from './propertiesSpec';
+
+const propertyNames = Object.keys(propertiesSpec);
+
+// Generates styles given the provided props.
+//
+// This is driven by the metadata provided in propertiesSpec
+// and produces a data structure like this:
+//
+// {
+//   margin: props.margin || props.theme['margin']
+//   width: props.width || props.theme['width']
+//   ...
+// }
+//
+// See propertySpec.js for more detail
+//
+const styles = props => {
+  let styles = {};
+
+  const propKeys = Object.keys(props);
+
+  propKeys.forEach(name => {
+    // Lookup the spec for the property
+    const spec = propertiesSpec[name];
+
+    // Ignore non-style props
+    if (spec === undefined) {
+      return;
+    }
+
+    // Get the style value from props
+    let value = props[name];
+
+    // pre-process the value with all pre-processors
+    if (spec.preprocessWith) {
+      spec.preprocessWith.forEach(fn => {
+        value = fn(value);
+      });
+    }
+
+    styles[name] = value;
+  });
+
+  // Only do checks in dev mode
+  if (process.env.NODE_ENV !== 'production') {
+    checkForViolations(styles);
+  }
+
+  return styles;
+};
+
+const Box = props => {
+  const { className, children } = props;
+
+  // Render the div with the fela classname
+  return (
+    <div className={className}>
+      {children}
+    </div>
+  );
+};
+
+const checkForViolations = props => {
+  // Check for conflicts given the spec's conflictsWith property
+  // See propertySpec.js for more detail
+  propertyNames.forEach(propName => {
+    const spec = propertiesSpec[propName];
+    if (!props[propName] || !spec.conflictsWith) return;
+
+    spec.conflictsWith.forEach(otherPropName => {
+      if (props[propName] && props[otherPropName]) {
+        const msg = `${propName} cannot be set in conjunction with ${otherPropName}`;
+        console.error(msg);
+      }
+    });
+  });
+
+  // TODO: To pull this check off, we'll need re-evaluate our baseline.
+  // current is 22.5px
+  // checkLineHeightViolations(props);
+};
+
+const checkLineHeightViolations = props => {
+  const rem2px = rem => {
+    return parseFloat(rem) * props.fontSize;
+  };
+
+  const baseline = props.lineHeight * props.fontSize;
+
+  // Calculate total margin, padding, and border
+  let totalMargin = 0;
+  if (props.margin) {
+    totalMargin = rem2px(props.margin);
+  } else {
+    totalMargin += rem2px(props.marginTop) || 0;
+    totalMargin += rem2px(props.marginBottom) || 0;
+  }
+
+  let totalPadding = 0;
+  if (props.padding) {
+    totalPadding = rem2px(props.padding);
+  } else {
+    totalPadding += rem2px(props.paddingTop) || 0;
+    totalPadding += rem2px(props.paddingBottom) || 0;
+  }
+
+  let totalBorder = 0;
+  if (props.borderHeight) {
+    totalBorder = rem2px(props.borderHeight);
+  } else {
+    totalBorder += rem2px(props.borderTopHeight) || 0;
+    totalBorder += rem2px(props.borderBottomHeight) || 0;
+  }
+
+  // Warn the user if the total spacing isn't a multiple of the baseline
+  const spacing = totalMargin + totalBorder + totalPadding;
+  if (spacing && baseline % spacing !== 0) {
+    console.warn(
+      `Spacing from padding, border, and margin surrounding element should be a multiple of baseline ${baseline}.`
+    );
+  }
+};
+
+// Extract proptypes from the propertiesSpec
+const extractPropTypes = () => {
+  let propTypes = {};
+
+  // Loop through all property specs and pluck the prop type
+  propertyNames.forEach(name => {
+    propTypes[name] = propertiesSpec[name].propType;
+  });
+
+  return propTypes;
+};
+
+Box.propTypes = extractPropTypes();
+
+export default createComponent(styles, Box);

--- a/packages/cf-component-box/src/BoxTheme.js
+++ b/packages/cf-component-box/src/BoxTheme.js
@@ -1,0 +1,5 @@
+import propertiesSpec from './propertiesSpec';
+
+export default () => {
+  return {};
+};

--- a/packages/cf-component-box/src/index.js
+++ b/packages/cf-component-box/src/index.js
@@ -1,0 +1,7 @@
+import { applyTheme } from 'cf-style-container';
+import BoxUnstyled from './Box';
+import BoxTheme from './BoxTheme';
+
+const Box = applyTheme(BoxUnstyled, BoxTheme);
+
+export { BoxUnstyled, Box, BoxTheme };

--- a/packages/cf-component-box/src/propertiesSpec.js
+++ b/packages/cf-component-box/src/propertiesSpec.js
@@ -1,0 +1,440 @@
+import React, { PropTypes } from 'react';
+import { variables } from 'cf-style-const';
+
+import { rem } from 'polished';
+
+var numberOrString = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
+
+const pxToRem = value => {
+  if (typeof value === 'number' || /\d+px/.test(value)) {
+    return rem(value, variables.fontSize);
+  }
+  return value;
+};
+
+// The export of this module is a datastructuer containing metadata
+// which powers:
+//  - the creation of fela style rules
+//  - the creation of the theme in BoxTheme
+//  - a number of safety checks
+//
+// At a bare minimum, the propType must be specified to support a
+// new style property
+//
+// In addition, several other properties can be specified in the spec.
+//
+// Conflicts with shows an error if the developer tries to use both props.
+//
+// For example, given the following spec:
+//
+//    foo: {
+//      propType: numberOrString,
+//      conflictsWith: [
+//        'bar',
+//      ]
+//    },
+//
+//  passing the foo and bar props to the component will cause a warning.
+//
+//  Providing 'preprocessWith' will cause all the provided callbacks
+//  to be invoked on the passed prop when building the components styles
+//
+//  For example, given the following spec:
+//    foo: {
+//      propType: number,
+//      preprocessWith: [ 'pxToRem' ]
+//   },
+//
+//  The value of the 'foo' prop will be transformed with pxToRem.
+//
+//  The default property is currently un-used. They're left in place
+//  in case we arrive upon a performant solution to using them (like
+//  generating the code for the Box component).
+//
+export default {
+  margin: {
+    propType: numberOrString,
+    conflictsWith: ['marginTop', 'marginBottom', 'marginLeft', 'marginRight']
+  },
+  marginTop: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+  marginBottom: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+  marginLeft: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+  marginRight: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+
+  padding: {
+    propType: numberOrString,
+    conflictsWith: [
+      'paddingTop',
+      'paddingBottom',
+      'paddingLeft',
+      'paddingRight'
+    ]
+  },
+  paddingTop: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+  paddingBottom: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+  paddingLeft: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+  paddingRight: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+
+  overflow: {
+    propType: PropTypes.oneOf([
+      'visible',
+      'hidden',
+      'scroll',
+      'auto',
+      'inherit',
+      'initial',
+      'unset'
+    ])
+  },
+
+  borderColor: {
+    propType: PropTypes.string,
+    conflictsWith: [
+      'borderTopColor',
+      'borderBottomColor',
+      'borderLeftColor',
+      'borderRightColor'
+    ]
+  },
+  borderTopColor: {
+    propType: PropTypes.string
+  },
+  borderBottomColor: {
+    propType: PropTypes.string
+  },
+  borderLeftColor: {
+    propType: PropTypes.string
+  },
+  borderRightColor: {
+    propType: PropTypes.string
+  },
+
+  borderStyle: {
+    propType: PropTypes.string,
+    conflictsWith: [
+      'borderTopStyle',
+      'borderBottomStyle',
+      'borderLeftStyle',
+      'borderRightStyle'
+    ]
+  },
+  borderTopStyle: {
+    propType: PropTypes.string
+  },
+  borderBottomStyle: {
+    propType: PropTypes.string
+  },
+  borderLeftStyle: {
+    propType: PropTypes.string
+  },
+  borderRightStyle: {
+    propType: PropTypes.string
+  },
+
+  borderWidth: {
+    propType: PropTypes.number,
+    conflictsWith: [
+      'borderTopWidth',
+      'borderBottomWidth',
+      'borderLeftWidth',
+      'borderRightWidth'
+    ]
+  },
+  borderTopWidth: {
+    propType: PropTypes.number
+  },
+  borderBottomWidth: {
+    propType: PropTypes.number
+  },
+  borderLeftWidth: {
+    propType: PropTypes.number
+  },
+  borderRightWidth: {
+    propType: PropTypes.number
+  },
+
+  lineHeight: {
+    propType: PropTypes.number,
+    default: variables.lineHeight
+  },
+  fontSize: {
+    propType: PropTypes.number,
+    default: variables.fontSize
+  },
+  fontWeight: {
+    propType: PropTypes.number,
+    default: variables.fontWeight
+  },
+  fontFamily: {
+    propType: PropTypes.string,
+    default: variables.fontFamily
+  },
+  color: {
+    propType: PropTypes.string,
+    default: variables.fontColor
+  },
+
+  backgroundColor: {
+    propType: PropTypes.string,
+    default: 'transparent'
+  },
+
+  backgroundImage: {
+    propType: PropTypes.string
+  },
+
+  backgroundPosition: {
+    propType: PropTypes.string
+  },
+
+  backgroundPositionX: {
+    propType: PropTypes.string
+  },
+
+  backgroundPositionY: {
+    propType: PropTypes.string
+  },
+
+  display: {
+    propType: PropTypes.oneOf([
+      'inline',
+      'block',
+      'inline-block',
+      'flex',
+      'inline-flex'
+    ]),
+    default: 'block'
+  },
+
+  position: {
+    propType: PropTypes.oneOf(['static', 'relative', 'absolute', 'fixed']),
+    default: 'static'
+  },
+
+  float: {
+    propType: PropTypes.oneOf([
+      'left',
+      'right',
+      'none',
+      'inline-start',
+      'inline-end'
+    ])
+  },
+
+  top: {
+    propType: numberOrString,
+    default: 'auto',
+    preprocessWith: [pxToRem]
+  },
+  bottom: {
+    propType: numberOrString,
+    default: 'auto',
+    preprocessWith: [pxToRem]
+  },
+  left: {
+    propType: numberOrString,
+    default: 'auto',
+    preprocessWith: [pxToRem]
+  },
+  right: {
+    propType: numberOrString,
+    default: 'auto',
+    preprocessWith: [pxToRem]
+  },
+
+  width: {
+    propType: numberOrString,
+    default: 'auto',
+    preprocessWith: [pxToRem]
+  },
+  height: {
+    propType: numberOrString,
+    default: 'auto',
+    preprocessWith: [pxToRem]
+  },
+  minWidth: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+  minHeight: {
+    propType: numberOrString,
+    default: 0,
+    preprocessWith: [pxToRem]
+  },
+
+  transform: {
+    propType: PropTypes.string
+  },
+
+  flexDirection: {
+    propType: PropTypes.oneOf([
+      'row',
+      'row-reverse',
+      'column',
+      'column-reverse'
+    ]),
+    default: 'row'
+  },
+
+  flexWrap: {
+    propType: PropTypes.oneOf(['nowrap', 'wrap', 'wrap-reverse']),
+    default: 'nowrap'
+  },
+
+  justifyContent: {
+    propType: PropTypes.oneOf([
+      'flex-start',
+      'flex-end',
+      'center',
+      'space-between',
+      'space-around'
+    ]),
+    default: 'flex-start'
+  },
+
+  alignItems: {
+    propType: PropTypes.oneOf([
+      'flex-start',
+      'flex-end',
+      'center',
+      'baseline',
+      'stretch'
+    ]),
+    default: 'stretch'
+  },
+
+  alignContent: {
+    propType: PropTypes.oneOf([
+      'flex-start',
+      'flex-end',
+      'center',
+      'space-between',
+      'space-around',
+      'stretch'
+    ]),
+    default: 'stretch'
+  },
+
+  order: {
+    propType: PropTypes.number,
+    default: 0
+  },
+
+  flexGrow: {
+    propType: PropTypes.number,
+    default: 0
+  },
+
+  flexShrink: {
+    propType: PropTypes.number,
+    default: 1
+  },
+
+  flexBasis: {
+    propType: numberOrString,
+    default: 'auto'
+  },
+
+  flex: {
+    propType: PropTypes.string
+  },
+
+  alignSelf: {
+    propType: PropTypes.oneOf([
+      'auto',
+      'flex-start',
+      'flex-end',
+      'center',
+      'baseline',
+      'stretch'
+    ]),
+    default: 'auto'
+  },
+
+  zIndex: {
+    propType: numberOrString,
+    default: 'auto'
+  },
+
+  textAlign: {
+    propType: PropTypes.oneOf([
+      'left',
+      'right',
+      'center',
+      'justify',
+      'justify-all',
+      'start',
+      'end',
+      'match-parent'
+    ]),
+    default: 'start'
+  },
+
+  opacity: {
+    propType: numberOrString,
+    default: 1.0
+  },
+
+  userSelect: {
+    propType: PropTypes.oneOf(['none', 'auto', 'text', 'container', 'all']),
+    default: 'auto'
+  },
+
+  wordWrap: {
+    propType: PropTypes.oneOf([
+      'normal',
+      'break-word',
+      'inherit',
+      'initial',
+      'unset'
+    ]),
+    default: 'normal'
+  },
+
+  wordWrap: {
+    propType: PropTypes.string,
+    default: 'normal'
+  }
+};
+
+/*
+ * Need support for:
+   content
+   outline
+   border-radius
+   box-shadow
+   text-decoration
+*/

--- a/packages/cf-component-box/test/Box.js
+++ b/packages/cf-component-box/test/Box.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Box } from '../../cf-component-box/src/index';
+import renderer from 'react-test-renderer';
+import felaTestContext from '../../../felaTestContext';
+
+test('should render all props as styles', () => {
+  const component = renderer.create(
+    felaTestContext(
+      <Box
+        borderWidth={1}
+        borderStyle="solid"
+        borderColor="black"
+        margin="1rem"
+        padding="1rem"
+        display="inline-block"
+        position="relative"
+        top={1}
+        bottom={1}
+        minWidth={100}
+        width={100}
+        minHeight={100}
+        height={100}
+      >
+        Box
+      </Box>
+    )
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});

--- a/packages/cf-component-box/test/__snapshots__/Box.js.snap
+++ b/packages/cf-component-box/test/__snapshots__/Box.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render all props as styles 1`] = `
+<div
+  className="cf-k8v3yj"
+>
+  Box
+</div>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,6 +394,12 @@ babel-plugin-jest-hoist@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-19.0.0.tgz#4ae2a04ea612a6e73651f3fde52c178991304bea"
 
+babel-plugin-polished@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polished/-/babel-plugin-polished-1.0.3.tgz#ef50944d251a09f1d86eace0ed0686c640253134"
+  dependencies:
+    polished "^1.0.0"
+
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
@@ -779,10 +785,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bowser@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.0.tgz#37fc387b616cb6aef370dab4d6bd402b74c5c54d"
-
 brace-expansion@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
@@ -1103,12 +1105,6 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
-css-in-js-utils@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz#9ac7e02f763cf85d94017666565ed68a5b5f3215"
-  dependencies:
-    hyphenate-style-name "^1.0.2"
-
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -1121,10 +1117,6 @@ css-select@~1.2.0:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
-
-cssbeautify@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cssbeautify/-/cssbeautify-0.3.1.tgz#12dd1f734035c2e6faca67dcbdcef74e42811397"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -1574,55 +1566,6 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fela-beautifier@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela-beautifier/-/fela-beautifier-4.3.1.tgz#1f8b8dec4d69f60a2d67b0095c7a338e1fa25d6a"
-  dependencies:
-    cssbeautify "0.3.1"
-
-fela-font-renderer@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela-font-renderer/-/fela-font-renderer-4.3.1.tgz#6e4324c77f3e07379443648279b8112144e8186a"
-
-fela-monolithic@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela-monolithic/-/fela-monolithic-4.3.1.tgz#6eb5d56513ede149a33ef26efd8d63e10eb66a45"
-  dependencies:
-    css-in-js-utils "^1.0.3"
-
-fela-plugin-fallback-value@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela-plugin-fallback-value/-/fela-plugin-fallback-value-4.3.1.tgz#a05f7f99886b81949bc60d6ffb0673af1dda73af"
-  dependencies:
-    css-in-js-utils "^1.0.3"
-
-fela-plugin-lvha@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela-plugin-lvha/-/fela-plugin-lvha-4.3.1.tgz#63ea0f5ccda11e52cb2f6db4dd97814d3cf51077"
-
-fela-plugin-prefixer@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela-plugin-prefixer/-/fela-plugin-prefixer-4.3.1.tgz#c44dda0cca5c046d8e77edecee0ec602f4598be6"
-  dependencies:
-    css-in-js-utils "^1.0.3"
-    inline-style-prefixer "^3.0.0"
-
-fela-plugin-unit@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela-plugin-unit/-/fela-plugin-unit-4.3.1.tgz#dd06b2361db5e1f4e6011c8be01e9e4843fd720d"
-  dependencies:
-    css-in-js-utils "^1.0.3"
-
-fela-plugin-validator@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela-plugin-validator/-/fela-plugin-validator-4.3.1.tgz#507ed743ae098c513aa40edfda0dccaaf4c5a46f"
-
-fela@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/fela/-/fela-4.3.1.tgz#173a55487c51d9cc1d634cb9fc20416c24306686"
-  dependencies:
-    css-in-js-utils "^1.0.3"
-
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -1950,10 +1893,6 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-hyphenate-style-name@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
 iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -1986,13 +1925,6 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-inline-style-prefixer@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.2.tgz#989865e0c5de7a946acbea71e16e02741efe0dd7"
-  dependencies:
-    bowser "^1.6.0"
-    css-in-js-utils "^1.0.3"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -3173,6 +3105,10 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
+polished@^1.0.0, polished@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-1.0.2.tgz#8adb00d57c4be81ddd03e0aaa3bafb8a9bdb4057"
+
 postcss-value-parser@^3.2.3:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
@@ -3286,10 +3222,6 @@ react-dom@^15.0.0-0:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-
-react-fela@^4.2.6:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/react-fela/-/react-fela-4.3.1.tgz#0bd002f4b82c9a77ab9bb3ff1db6d49842e5e3ca"
 
 react-redux@^5.0.3:
   version "5.0.3"


### PR DESCRIPTION
We're embarking on a massive overhaul of some recent feature work and I'd like to clean house while we have the chance. I'd like to avoid the further proliferation of div and span with custom css in our growing codebase. 

This is sort of a stop gap as we implement fela in all of our cf-ui components and work out the kinks in usage, which may take a little time. The cf-component-flex overhaul was super awesome, and fixed most of the styling problems we hit in our recent LB work.

My thinking is that replacing the usage of a single component in several places will be easier to undo than transitioning a ton of css to css-in-js. To make this component conducive to that, the interface is identical to a fela rule.

I'm not super fond of the name box, but I could really thing of a better name. <antidiv/> perhaps? 

As an added benefit, we can add some safety for developers by checking for styling gotchas, should they attempt to do reckless things. 
