### PR TITLE
Fixes cf-util-http in Edge

### DIFF
--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -128,15 +128,16 @@ export function request(method, url, opts, callback) {
   callback = opts.callback;
 
   // Normalize the headers
-  opts.headers = new Headers(opts.headers || {});
+  opts.headers = Object.assign({}, opts.headers);
 
   // Emuluate superagent's questionable ability to filter out headers that's
   // been set to null or undefined.
-  for (let [k, v] of opts.headers.entries()) {
-    if (v === 'null' || v === 'undefined') {
-      opts.headers.delete(k);
+  for (const h in opts.headers) {
+    if (opts.headers[h] === null || opts.headers[h] === undefined) {
+      delete opts.headers[h];
     }
   }
+  opts.headers = new Headers(opts.headers || {});
 
   // Emulate superagent's ability to automatically encode JSON body and set the
   // Content-Type
@@ -162,7 +163,7 @@ export function request(method, url, opts, callback) {
 
   return fetch(url, opts)
     .then(response => {
-      const headers = toHash(response.headers);
+      const headers = toHash(new Map(response.headers));
       const status = response.status;
       logMessage = `${logMessage} (${status} ${response.statusText})`;
 

--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -50,7 +50,9 @@ function toQueryParams(kvs) {
 
 function toHash(headers) {
   const hash = {};
-  for (let [k, v] of headers) {
+  // converting to Map allows for .. of in Edge
+  const headersMap = new Map(headers);
+  for (let [k, v] of headersMap) {
     hash[k] = v;
     hash[k.toLowerCase()] = v;
   }
@@ -133,7 +135,7 @@ export function request(method, url, opts, callback) {
   // Emuluate superagent's questionable ability to filter out headers that's
   // been set to null or undefined.
   for (const h in opts.headers) {
-    if (opts.headers[h] === null || opts.headers[h] === undefined) {
+    if (opts.headers[h] == null) {
       delete opts.headers[h];
     }
   }
@@ -163,7 +165,7 @@ export function request(method, url, opts, callback) {
 
   return fetch(url, opts)
     .then(response => {
-      const headers = toHash(new Map(response.headers));
+      const headers = toHash(response.headers);
       const status = response.status;
       logMessage = `${logMessage} (${status} ${response.statusText})`;
 


### PR DESCRIPTION
avoid use of Headers.entries() and for .. of because of limited support in Edge browser.

more details: https://developer.mozilla.org/en-US/docs/Web/API/Headers\#Browser_compatibility