### PR TITLE
Spaced ButtonGroup

### DIFF
--- a/packages/cf-component-button/README.md
+++ b/packages/cf-component-button/README.md
@@ -15,17 +15,28 @@ import React from 'react';
 import { Button, ButtonGroup } from 'cf-component-button';
 
 const ButtonComponent = () => (
-  <ButtonGroup>
-    <Button type="primary" onClick={() => console.log('Clicked One!')}>
-      Button One
-    </Button>
-    <Button type="default" onClick={() => console.log('Clicked Two!')}>
-      Button Two
-    </Button>
-    <Button type="success" onClick={() => console.log('Clicked Three!')}>
-      Button Three
-    </Button>
-  </ButtonGroup>
+  <div>
+    <ButtonGroup>
+      <Button type="primary" onClick={() => console.log('Clicked One!')}>
+        Button One
+      </Button>
+      <Button type="default" onClick={() => console.log('Clicked Two!')}>
+        Button Two
+      </Button>
+      <Button type="success" onClick={() => console.log('Clicked Three!')}>
+        Button Three
+      </Button>
+    </ButtonGroup>
+    <p>Button group with spacing</p>
+    <ButtonGroup spaced>
+      <Button type="success" onClick={() => console.log('Clicked Four!')}>
+        Button Four
+      </Button>
+      <Button type="danger" onClick={() => console.log('Clicked Five!')}>
+        Button Five
+      </Button>
+    </ButtonGroup>
+  </div>
 );
 
 export default ButtonComponent;

--- a/packages/cf-component-button/example/basic/component.js
+++ b/packages/cf-component-button/example/basic/component.js
@@ -2,17 +2,28 @@ import React from 'react';
 import { Button, ButtonGroup } from 'cf-component-button';
 
 const ButtonComponent = () => (
-  <ButtonGroup>
-    <Button type="primary" onClick={() => console.log('Clicked One!')}>
-      Button One
-    </Button>
-    <Button type="default" onClick={() => console.log('Clicked Two!')}>
-      Button Two
-    </Button>
-    <Button type="success" onClick={() => console.log('Clicked Three!')}>
-      Button Three
-    </Button>
-  </ButtonGroup>
+  <div>
+    <ButtonGroup>
+      <Button type="primary" onClick={() => console.log('Clicked One!')}>
+        Button One
+      </Button>
+      <Button type="default" onClick={() => console.log('Clicked Two!')}>
+        Button Two
+      </Button>
+      <Button type="success" onClick={() => console.log('Clicked Three!')}>
+        Button Three
+      </Button>
+    </ButtonGroup>
+    <p>Button group with spacing</p>
+    <ButtonGroup spaced>
+      <Button type="success" onClick={() => console.log('Clicked Four!')}>
+        Button Four
+      </Button>
+      <Button type="danger" onClick={() => console.log('Clicked Five!')}>
+        Button Five
+      </Button>
+    </ButtonGroup>
+  </div>
 );
 
 export default ButtonComponent;

--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { createComponent } from 'cf-style-container';
 
-const getRadius = (borderRadius, group) => {
+const radius = (borderRadius, group) => {
   if (group) {
     return {
       borderTopRightRadius: group === 'last' ? borderRadius : 0,
@@ -13,17 +13,17 @@ const getRadius = (borderRadius, group) => {
   return { borderRadius };
 };
 
-const getOpacity = props => {
-  if (props.loading) {
-    return 0.8;
+const opacity = (loading, disabled) => {
+  if (loading) {
+    return { opacity: 0.8 };
   }
-  if (props.disabled) {
-    return 0.5;
+  if (disabled) {
+    return { opacity: 0.5 };
   }
-  return 'inherit';
+  return { opacity: 'inherit' };
 };
 
-const getLoadingBefore = (fadeZoomIn, loading) => {
+const before = (fadeZoomIn, loading) => {
   if (!loading) {
     return null;
   }
@@ -43,75 +43,83 @@ const getLoadingBefore = (fadeZoomIn, loading) => {
   };
 };
 
+const marginLeft = (marginLeft, group, spaced) => {
+  if (!group) {
+    return { marginLeft };
+  }
+  if (spaced && group !== 'first') {
+    return { marginLeft: '0.4rem' };
+  }
+  return { marginLeft: 0 };
+};
+
 const styles = props => {
   const theme = props.theme;
-  return Object.assign(
-    {
-      '&:hover': {
-        backgroundColor: props.loading
-          ? theme.disabledBackground
-          : theme[`${props.type}HoverBackground`],
-        borderColor: theme[`${props.type}HoverBorder`],
-        color: props.loading
-          ? theme.disabledBackground
-          : theme[`${props.type}HoverColor`]
-      },
-      '&:active': {
-        backgroundColor: theme[`${props.type}ActiveBackground`],
-        borderColor: theme[`${props.type}ActiveBorder`],
-        color: theme[`${props.type}ActiveColor`]
-      },
-      '&:focus': {
-        backgroundColor: props.loading
-          ? theme.backgroundColor
-          : theme[`${props.type}Background`],
-        boxShadow: `inset 0px 0px 0px ${theme.borderSize} ${theme[`${props.type}focusOutlineColor`]}`,
-        color: props.loading
-          ? theme.disabledBackground
-          : theme[`${props.type}FocusColor`],
-        outline: props.loading ? 'none' : 'inherit'
-      },
-      '&[title]': {
-        pointerEvents: props.disabled ? 'auto' : 'none'
-      },
+  return {
+    '&:hover': {
       backgroundColor: props.loading
         ? theme.disabledBackground
-        : theme[`${props.type}Background`],
-      borderBottom: theme.borderBottom,
-      borderBottomWidth: theme.borderBottomWidth,
-      borderColor: theme[`${props.type}Border`],
-      borderLeft: props.group && props.group !== 'first' ? 0 : theme.borderLeft,
-      borderRight: theme.borderRight,
-      borderStyle: theme.borderStyle,
-      borderTop: theme.borderTop,
-      borderWidth: theme.borderWidth,
+        : theme[`${props.type}HoverBackground`],
+      borderColor: theme[`${props.type}HoverBorder`],
       color: props.loading
         ? theme.disabledBackground
-        : theme[`${props.type}Color`],
-      cursor: props.disabled || props.loading ? 'default' : theme.cursor,
-      display: theme.display,
-      fontFamily: theme.fontFamily,
-      fontSize: theme.fontSize,
-      fontWeight: theme.fontWeight,
-      lineHeight: theme.lineHeight,
-      marginBottom: props.group ? 0 : theme.marginBottom,
-      marginLeft: props.group ? 0 : theme.marginLeft,
-      marginRight: props.group ? 0 : theme.marginRight,
-      marginTop: props.group ? 0 : theme.marginTop,
-      opacity: getOpacity(props),
-      paddingBottom: theme.paddingBottom,
-      paddingLeft: theme.paddingLeft,
-      paddingRight: theme.paddingRight,
-      paddingTop: theme.paddingTop,
-      pointerEvents: props.disabled ? 'none' : 'auto',
-      position: theme.position,
-      textAlign: theme.textAlign,
-      transition: theme.transition,
-      userSelect: theme.userSelect
+        : theme[`${props.type}HoverColor`]
     },
-    getRadius(theme.borderRadius, props.group),
-    getLoadingBefore(theme.fadeZoomIn, props.loading)
-  );
+    '&:active': {
+      backgroundColor: theme[`${props.type}ActiveBackground`],
+      borderColor: theme[`${props.type}ActiveBorder`],
+      color: theme[`${props.type}ActiveColor`]
+    },
+    '&:focus': {
+      backgroundColor: props.loading
+        ? theme.backgroundColor
+        : theme[`${props.type}Background`],
+      boxShadow: `inset 0px 0px 0px ${theme.borderSize} ${theme[`${props.type}focusOutlineColor`]}`,
+      color: props.loading
+        ? theme.disabledBackground
+        : theme[`${props.type}FocusColor`],
+      outline: props.loading ? 'none' : 'inherit'
+    },
+    ...before(theme.fadeZoomIn, props.loading),
+    '&[title]': {
+      pointerEvents: props.disabled ? 'auto' : 'none'
+    },
+    backgroundColor: props.loading
+      ? theme.disabledBackground
+      : theme[`${props.type}Background`],
+    borderBottom: theme.borderBottom,
+    borderBottomWidth: theme.borderBottomWidth,
+    borderColor: theme[`${props.type}Border`],
+    borderLeft: props.group && props.group !== 'first' ? 0 : theme.borderLeft,
+    borderRight: theme.borderRight,
+    borderStyle: theme.borderStyle,
+    borderTop: theme.borderTop,
+    borderWidth: theme.borderWidth,
+    color: props.loading
+      ? theme.disabledBackground
+      : theme[`${props.type}Color`],
+    cursor: props.disabled || props.loading ? 'default' : theme.cursor,
+    display: theme.display,
+    fontFamily: theme.fontFamily,
+    fontSize: theme.fontSize,
+    fontWeight: theme.fontWeight,
+    lineHeight: theme.lineHeight,
+    marginBottom: props.group ? 0 : theme.marginBottom,
+    marginRight: props.group ? 0 : theme.marginRight,
+    marginTop: props.group ? 0 : theme.marginTop,
+    ...marginLeft(theme.marginLeft, props.group, props.spaced),
+    ...opacity(props.loading, props.disabled),
+    paddingBottom: theme.paddingBottom,
+    paddingLeft: theme.paddingLeft,
+    paddingRight: theme.paddingRight,
+    paddingTop: theme.paddingTop,
+    pointerEvents: props.disabled ? 'none' : 'auto',
+    position: theme.position,
+    ...radius(theme.borderRadius, props.group),
+    textAlign: theme.textAlign,
+    transition: theme.transition,
+    userSelect: theme.userSelect
+  };
 };
 
 class Button extends React.Component {
@@ -140,6 +148,7 @@ class Button extends React.Component {
 Button.propTypes = {
   onClick: PropTypes.func.isRequired,
   submit: PropTypes.bool,
+  spaced: PropTypes.bool,
   className: PropTypes.string.isRequired,
   group: PropTypes.oneOf(['first', 'inbetween', 'last']),
   type: PropTypes.oneOf([

--- a/packages/cf-component-button/src/ButtonGroup.js
+++ b/packages/cf-component-button/src/ButtonGroup.js
@@ -21,11 +21,12 @@ const getGroupByIndex = (index, length) => {
   return 'inbetween';
 };
 
-const addGroupProps = children =>
+const addGroupProps = (children, spaced) =>
   React.Children.map(children, (child, index) => {
     if (React.isValidElement(child)) {
       return React.cloneElement(child, {
-        group: getGroupByIndex(index, React.Children.count(children))
+        group: getGroupByIndex(index, React.Children.count(children)),
+        spaced
       });
     }
     return child;
@@ -33,13 +34,14 @@ const addGroupProps = children =>
 
 class ButtonGroup extends React.Component {
   render() {
-    const { className, children } = this.props;
-    return <div className={className}>{addGroupProps(children)}</div>;
+    const { className, children, spaced } = this.props;
+    return <div className={className}>{addGroupProps(children, spaced)}</div>;
   }
 }
 
 ButtonGroup.propTypes = {
   children: PropTypes.node,
+  spaced: PropTypes.bool,
   className: PropTypes.string.isRequired
 };
 

--- a/packages/cf-component-button/test/ButtonGroup.js
+++ b/packages/cf-component-button/test/ButtonGroup.js
@@ -45,3 +45,16 @@ test('should render 3 buttons', () => {
   );
   expect(component.toJSON()).toMatchSnapshot();
 });
+
+test('should render 3 buttons with spacing', () => {
+  const component = renderer.create(
+    felaTestContext(
+      <ButtonGroup spaced>
+        <Button type="primary" onClick={() => {}}>Button</Button>
+        <Button type="primary" onClick={() => {}}>Button</Button>
+        <Button type="primary" onClick={() => {}}>Button</Button>
+      </ButtonGroup>
+    )
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});

--- a/packages/cf-component-button/test/__snapshots__/Button.js.snap
+++ b/packages/cf-component-button/test/__snapshots__/Button.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should render as submit 1`] = `
 <button
-  className="cf-yp66z7"
+  className="cf-ecqzwz"
   disabled={undefined}
   onClick={[Function]}
   type="submit"
@@ -13,7 +13,7 @@ exports[`should render as submit 1`] = `
 
 exports[`should render with loading 1`] = `
 <button
-  className="cf-uydyf0"
+  className="cf-366jy4"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -24,7 +24,7 @@ exports[`should render with loading 1`] = `
 
 exports[`should render with loading and disabled overridden 1`] = `
 <button
-  className="cf-uydyf0"
+  className="cf-366jy4"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -35,7 +35,7 @@ exports[`should render with loading and disabled overridden 1`] = `
 
 exports[`should render with type 1`] = `
 <button
-  className="cf-yp66z7"
+  className="cf-ecqzwz"
   disabled={undefined}
   onClick={[Function]}
   type="button"
@@ -46,7 +46,7 @@ exports[`should render with type 1`] = `
 
 exports[`should render with type/disabled 1`] = `
 <button
-  className="cf-1903je5"
+  className="cf-1fbkjot"
   disabled={true}
   onClick={[Function]}
   type="button"

--- a/packages/cf-component-button/test/__snapshots__/ButtonGroup.js.snap
+++ b/packages/cf-component-button/test/__snapshots__/ButtonGroup.js.snap
@@ -13,7 +13,7 @@ exports[`should render 1 button 1`] = `
   className="cf-cmkk1"
 >
   <button
-    className="cf-p3cuuj"
+    className="cf-7dyzwr"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -28,7 +28,7 @@ exports[`should render 2 buttons 1`] = `
   className="cf-cmkk1"
 >
   <button
-    className="cf-zpemqz"
+    className="cf-m1dhvv"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -36,7 +36,7 @@ exports[`should render 2 buttons 1`] = `
     Button
   </button>
   <button
-    className="cf-p3cuuj"
+    className="cf-7dyzwr"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -51,7 +51,7 @@ exports[`should render 3 buttons 1`] = `
   className="cf-cmkk1"
 >
   <button
-    className="cf-zpemqz"
+    className="cf-m1dhvv"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -59,7 +59,7 @@ exports[`should render 3 buttons 1`] = `
     Button
   </button>
   <button
-    className="cf-1p3fv1n"
+    className="cf-c39saz"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -67,7 +67,38 @@ exports[`should render 3 buttons 1`] = `
     Button
   </button>
   <button
-    className="cf-p3cuuj"
+    className="cf-7dyzwr"
+    disabled={undefined}
+    onClick={[Function]}
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`should render 3 buttons with spacing 1`] = `
+<div
+  className="cf-cmkk1"
+>
+  <button
+    className="cf-m1dhvv"
+    disabled={undefined}
+    onClick={[Function]}
+    type="button"
+  >
+    Button
+  </button>
+  <button
+    className="cf-10f2fib"
+    disabled={undefined}
+    onClick={[Function]}
+    type="button"
+  >
+    Button
+  </button>
+  <button
+    className="cf-irfuir"
     disabled={undefined}
     onClick={[Function]}
     type="button"


### PR DESCRIPTION
The original button CSS styles had this rule:

```css
'& + &': {
  marginLeft: '0.4rem'
}
```

If you put two cf-component-buttons next to each other, the right one would get the left margin. However, this selector doesn't work with Fela since all classNames are random and atomic. So we need a different solution.

This PR adds a new prop `spaced` to the component `<ButtonGroup>`, so if you want to have spaces between `<Button>`s wrap them by `<ButtonGroup spaced>...</ButtonGroup>`.

Also, I made the `styles` function a little bit cleaner with `...function()` replacing `Object.assign()`.

<img width="704" alt="screen shot 2017-04-03 at 11 05 07 pm" src="https://cloud.githubusercontent.com/assets/1387913/24643398/92d16360-18c2-11e7-8dd1-36505b2043e7.png">
