### PR TITLE
Back to ES6 classes

### DIFF
--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -114,25 +114,28 @@ const styles = props => {
   );
 };
 
-const Button = (
-  {
-    onClick,
-    submit,
-    className,
-    disabled,
-    loading,
-    children
+class Button extends React.Component {
+  render() {
+    const {
+      onClick,
+      submit,
+      className,
+      disabled,
+      loading,
+      children
+    } = this.props;
+    return (
+      <button
+        type={submit ? 'submit' : 'button'}
+        disabled={disabled || loading}
+        className={className}
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    );
   }
-) => (
-  <button
-    type={submit ? 'submit' : 'button'}
-    disabled={disabled || loading}
-    className={className}
-    onClick={onClick}
-  >
-    {children}
-  </button>
-);
+}
 
 Button.propTypes = {
   onClick: PropTypes.func.isRequired,

--- a/packages/cf-component-button/src/ButtonGroup.js
+++ b/packages/cf-component-button/src/ButtonGroup.js
@@ -31,9 +31,12 @@ const addGroupProps = children =>
     return child;
   });
 
-const ButtonGroup = ({ children, className }) => (
-  <div className={className}>{addGroupProps(children)}</div>
-);
+class ButtonGroup extends React.Component {
+  render() {
+    const { className, children } = this.props;
+    return <div className={className}>{addGroupProps(children)}</div>;
+  }
+}
 
 ButtonGroup.propTypes = {
   children: PropTypes.node,

--- a/packages/cf-component-heading/src/HeadingCaption.js
+++ b/packages/cf-component-heading/src/HeadingCaption.js
@@ -9,11 +9,16 @@ const styles = ({ theme }) => ({
   marginLeft: theme.marginLeft
 });
 
-const HeadingCaption = ({ className, children }) => (
-  <small className={className}>
-    {children}
-  </small>
-);
+class HeadingCaption extends React.Component {
+  render() {
+    const { className, children } = this.props;
+    return (
+      <small className={className}>
+        {children}
+      </small>
+    );
+  }
+}
 
 HeadingCaption.propTypes = {
   className: PropTypes.string.isRequired,

--- a/packages/cf-component-notifications/test/Notification.js
+++ b/packages/cf-component-notifications/test/Notification.js
@@ -24,7 +24,6 @@ afterEach(function() {
 });
 
 test('should call onClose after a set delay', done => {
-
   let onClose = () => {
     done();
   };

--- a/packages/cf-component-pagination/src/Pagination.js
+++ b/packages/cf-component-pagination/src/Pagination.js
@@ -23,20 +23,23 @@ const styles = ({ theme }) => ({
   boxShadow: theme.boxShadow
 });
 
-const Pagination = ({ info, children, className }) => {
-  const id = info ? uniqueId('cf-pagination-') : null;
-  return (
-    <PaginationRoot>
-      <ul className={className} role="navigation" aria-describedby={id}>
-        {children}
-      </ul>
-      {info &&
-        <span id={id}>
-          {info}
-        </span>}
-    </PaginationRoot>
-  );
-};
+class Pagination extends React.Component {
+  render() {
+    const { info, children, className } = this.props;
+    const id = info ? uniqueId('cf-pagination-') : null;
+    return (
+      <PaginationRoot>
+        <ul className={className} role="navigation" aria-describedby={id}>
+          {children}
+        </ul>
+        {info &&
+          <span id={id}>
+            {info}
+          </span>}
+      </PaginationRoot>
+    );
+  }
+}
 
 Pagination.propTypes = {
   className: PropTypes.string.isRequired,

--- a/packages/cf-component-pagination/src/PaginationItem.js
+++ b/packages/cf-component-pagination/src/PaginationItem.js
@@ -45,35 +45,38 @@ const normal = ({ theme }) => ({
 
 const styles = combineRules(normal, active, disabled);
 
-const PaginationItem = props => {
-  const isEllipsis = props.type === 'ellipsis';
-  const isLoading = props.type === 'loading';
+class PaginationItem extends React.Component {
+  render() {
+    const props = this.props;
+    const isEllipsis = props.type === 'ellipsis';
+    const isLoading = props.type === 'loading';
 
-  const role = isEllipsis ? 'presentation' : null;
+    const role = isEllipsis ? 'presentation' : null;
 
-  let children;
+    let children;
 
-  if (isEllipsis) {
-    children = <span>…</span>;
-  } else if (isLoading) {
-    children = <Icon type="loading" label={false} />;
-  } else {
-    children = props.children;
+    if (isEllipsis) {
+      children = <span>…</span>;
+    } else if (isLoading) {
+      children = <Icon type="loading" label={false} />;
+    } else {
+      children = props.children;
+    }
+    const clickable = !(props.active || props.disabled || isEllipsis);
+    return (
+      <li className={props.className} role={role}>
+        <PaginationLink
+          onClick={props.onClick}
+          clickable={clickable}
+          children={children}
+          label={props.label}
+          active={props.active}
+          disabled={props.disabled}
+        />
+      </li>
+    );
   }
-  const clickable = !(props.active || props.disabled || isEllipsis);
-  return (
-    <li className={props.className} role={role}>
-      <PaginationLink
-        onClick={props.onClick}
-        clickable={clickable}
-        children={children}
-        label={props.label}
-        active={props.active}
-        disabled={props.disabled}
-      />
-    </li>
-  );
-};
+}
 
 PaginationItem.propTypes = {
   type: PropTypes.oneOf([

--- a/packages/cf-component-text/src/Text.js
+++ b/packages/cf-component-text/src/Text.js
@@ -15,11 +15,16 @@ const styles = ({ theme, size, align, type, case: textCase }) => ({
   }
 });
 
-const Text = ({ className, children }) => (
-  <div className={className}>
-    {children}
-  </div>
-);
+class Text extends React.Component {
+  render() {
+    const { className, children } = this.props;
+    return (
+      <div className={className}>
+        {children}
+      </div>
+    );
+  }
+}
 
 Text.propTypes = {
   size: PropTypes.oneOf(['normal', 'small']),


### PR DESCRIPTION
This PR revert functional components back to ES6 classes. The reasons are:

1. We need the refs for form components because we are using redux-form on the product.
2. All of the cf-ui components were in ES6 classes, which gives us refs. Nobody was complaining about them.
3. cf-ui itself is using refs now in [4 different places](https://github.com/cloudflare/cf-ui/search?utf8=%E2%9C%93&q=ref&type=)
4. Refs are needed, when we need to focus or deal with text selection or animation. I'm fine to selectively convert some to functional components if we can identify a list of components that we have a high degree of certainty that we'll never need refs for, which usually are non-interactive components. Form controls, links, tabs, dropdowns, and tables probably need to be in classes. Let's have this discussion first before jumping the gun.
5. We may even be able to use [Pure Components](https://facebook.github.io/react/docs/react-api.html#react.purecomponent) for some of the really simple stuff, assuming we haven't eliminated them by then. Let's ID a list of them first.

We have only migrated 4 components to fela. Two of which are of questionable utility. Let's go back to where it was, have a discussion, then decide what to do.