### PR TITLE
Move checkBaseTheme from cf-style-const to cf-style-container

### DIFF
--- a/packages/cf-component-button/package.json
+++ b/packages/cf-component-button/package.json
@@ -11,7 +11,6 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
-    "cf-style-const": "^0.3.4",
     "cf-style-container": "^0.2.3",
     "polished": "^1.0.2"
   },

--- a/packages/cf-component-button/src/ButtonTheme.js
+++ b/packages/cf-component-button/src/ButtonTheme.js
@@ -1,5 +1,5 @@
 import { darken, lighten } from 'polished';
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'ButtonTheme');

--- a/packages/cf-component-button/src/ButtonTheme.js
+++ b/packages/cf-component-button/src/ButtonTheme.js
@@ -1,8 +1,6 @@
 import { darken, lighten } from 'polished';
-import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
-  checkBaseTheme(baseTheme, 'ButtonTheme');
   const defaultBorder = darken(
     baseTheme.colorOffsetDark,
     baseTheme.colorGrayLight

--- a/packages/cf-component-form/package.json
+++ b/packages/cf-component-form/package.json
@@ -14,7 +14,6 @@
     "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0"
   },
   "dependencies": {
-    "cf-style-const": "^0.3.4",
     "cf-style-container": "^0.2.3",
     "polished": "^1.0.0"
   }

--- a/packages/cf-component-form/src/FormFieldErrorTheme.js
+++ b/packages/cf-component-form/src/FormFieldErrorTheme.js
@@ -1,16 +1,11 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'FormFieldErrorTheme');
-  return {
-    position: 'relative',
-    marginTop: '-0.75em',
-    padding: '0.5em 1em',
-    border: `1px solid  ${baseTheme.colorRedDark}`,
-    fontSize: '0.8em',
-    fontWeight: baseTheme.weightSemiBold,
-    background: baseTheme.colorRed,
-    color: baseTheme.colorWhite,
-    boxShadow: '0 1px 1px rgba(0, 0, 0, 0.1)'
-  };
-};
+export default baseTheme => ({
+  position: 'relative',
+  marginTop: '-0.75em',
+  padding: '0.5em 1em',
+  border: `1px solid  ${baseTheme.colorRedDark}`,
+  fontSize: '0.8em',
+  fontWeight: baseTheme.weightSemiBold,
+  background: baseTheme.colorRed,
+  color: baseTheme.colorWhite,
+  boxShadow: '0 1px 1px rgba(0, 0, 0, 0.1)'
+});

--- a/packages/cf-component-form/src/FormFieldErrorTheme.js
+++ b/packages/cf-component-form/src/FormFieldErrorTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'FormFieldErrorTheme');

--- a/packages/cf-component-form/src/FormFieldsetTheme.js
+++ b/packages/cf-component-form/src/FormFieldsetTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'FormFieldsetTheme');

--- a/packages/cf-component-form/src/FormFieldsetTheme.js
+++ b/packages/cf-component-form/src/FormFieldsetTheme.js
@@ -1,26 +1,21 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'FormFieldsetTheme');
-  return {
-    main: {
-      margin: 0,
-      padding: 0,
-      borderTop: 'none',
-      borderLeft: 'none',
-      borderRight: 'none',
-      borderBottom: `1px solid ${baseTheme.colorGrayLight}`
-    },
-    legend: {
-      padding: '1em',
-      borderBottom: 'none',
-      marginBottom: 0
-    },
-    content: {
-      padding: '1em',
-      border: `0 solid ${baseTheme.colorGrayLight}`,
-      borderTopWidth: '1px',
-      background: '#eee'
-    }
-  };
-};
+export default baseTheme => ({
+  main: {
+    margin: 0,
+    padding: 0,
+    borderTop: 'none',
+    borderLeft: 'none',
+    borderRight: 'none',
+    borderBottom: `1px solid ${baseTheme.colorGrayLight}`
+  },
+  legend: {
+    padding: '1em',
+    borderBottom: 'none',
+    marginBottom: 0
+  },
+  content: {
+    padding: '1em',
+    border: `0 solid ${baseTheme.colorGrayLight}`,
+    borderTopWidth: '1px',
+    background: '#eee'
+  }
+});

--- a/packages/cf-component-form/src/FormFooterTheme.js
+++ b/packages/cf-component-form/src/FormFooterTheme.js
@@ -1,10 +1,5 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'FormFooterTheme');
-  return {
-    padding: '1em',
-    borderTop: `1px solid ${baseTheme.colorGrayLight}`,
-    textAlign: 'right'
-  };
-};
+export default baseTheme => ({
+  padding: '1em',
+  borderTop: `1px solid ${baseTheme.colorGrayLight}`,
+  textAlign: 'right'
+});

--- a/packages/cf-component-form/src/FormFooterTheme.js
+++ b/packages/cf-component-form/src/FormFooterTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'FormFooterTheme');

--- a/packages/cf-component-form/src/FormHeaderTheme.js
+++ b/packages/cf-component-form/src/FormHeaderTheme.js
@@ -1,9 +1,4 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'FormHeaderTheme');
-  return {
-    padding: '1em',
-    borderBottom: `1px solid ${baseTheme.colorGrayLight}`
-  };
-};
+export default baseTheme => ({
+  padding: '1em',
+  borderBottom: `1px solid ${baseTheme.colorGrayLight}`
+});

--- a/packages/cf-component-form/src/FormHeaderTheme.js
+++ b/packages/cf-component-form/src/FormHeaderTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'FormHeaderTheme');

--- a/packages/cf-component-form/src/FormLabelTheme.js
+++ b/packages/cf-component-form/src/FormLabelTheme.js
@@ -1,12 +1,8 @@
-import { checkBaseTheme } from 'cf-style-container';
 import { em } from 'polished';
 
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'FormLabelTheme');
-  return {
-    fontSize: em('13px', baseTheme.fontSize),
-    display: 'block',
-    marginBottom: '0.2em',
-    color: baseTheme.colorGrayDark
-  };
-};
+export default baseTheme => ({
+  fontSize: em('13px', baseTheme.fontSize),
+  display: 'block',
+  marginBottom: '0.2em',
+  color: baseTheme.colorGrayDark
+});

--- a/packages/cf-component-form/src/FormLabelTheme.js
+++ b/packages/cf-component-form/src/FormLabelTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 import { em } from 'polished';
 
 export default baseTheme => {

--- a/packages/cf-component-form/src/FormTheme.js
+++ b/packages/cf-component-form/src/FormTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'FormTheme');

--- a/packages/cf-component-form/src/FormTheme.js
+++ b/packages/cf-component-form/src/FormTheme.js
@@ -1,10 +1,5 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'FormTheme');
-  return {
-    background: 'white',
-    border: `1px solid ${baseTheme.colorGrayLight}`,
-    boxShadow: '0 1px 1px rgba(0, 0, 0, 0.05)'
-  };
-};
+export default baseTheme => ({
+  background: 'white',
+  border: `1px solid ${baseTheme.colorGrayLight}`,
+  boxShadow: '0 1px 1px rgba(0, 0, 0, 0.05)'
+});

--- a/packages/cf-component-heading/src/HeadingCaptionTheme.js
+++ b/packages/cf-component-heading/src/HeadingCaptionTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'HeadingCaptionTheme');

--- a/packages/cf-component-heading/src/HeadingCaptionTheme.js
+++ b/packages/cf-component-heading/src/HeadingCaptionTheme.js
@@ -1,12 +1,7 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'HeadingCaptionTheme');
-  return {
-    marginLeft: '.5em',
-    color: baseTheme.colorGray,
-    fontSize: '80%',
-    fontColor: baseTheme.fontColor,
-    fontWeight: baseTheme.fontWeight
-  };
-};
+export default baseTheme => ({
+  marginLeft: '.5em',
+  color: baseTheme.colorGray,
+  fontSize: '80%',
+  fontColor: baseTheme.fontColor,
+  fontWeight: baseTheme.fontWeight
+});

--- a/packages/cf-component-pagination/src/PaginationItemTheme.js
+++ b/packages/cf-component-pagination/src/PaginationItemTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'PaginationItemTheme');

--- a/packages/cf-component-pagination/src/PaginationItemTheme.js
+++ b/packages/cf-component-pagination/src/PaginationItemTheme.js
@@ -1,24 +1,19 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'PaginationItemTheme');
-  return {
-    float: 'left',
-    position: 'relative',
-    backgroundColor: baseTheme.colorWhite,
-    color: baseTheme.colorInfo,
-    backgroundColorActive: baseTheme.colorInfo,
-    backgroundColorDisabled: baseTheme.disabledBackground,
-    borderColorActive: baseTheme.colorBlueLight,
-    colorActive: baseTheme.colorWhite,
-    colorDisabled: baseTheme.colorGrayBorder,
-    zIndexActive: 1,
-    border: '1px solid rgba(0, 0, 0, .15)',
-    borderBottomWidth: '2px',
-    'borderTopLeftRadius:first-child': '3px',
-    'borderBottomLeftRadius:first-child': '3px',
-    'borderTopLeftRadius:last-child': '3px',
-    'borderBottomLeftRadius:last-child': '3px',
-    'marginLeft&+&': '-1px'
-  };
-};
+export default baseTheme => ({
+  float: 'left',
+  position: 'relative',
+  backgroundColor: baseTheme.colorWhite,
+  color: baseTheme.colorInfo,
+  backgroundColorActive: baseTheme.colorInfo,
+  backgroundColorDisabled: baseTheme.disabledBackground,
+  borderColorActive: baseTheme.colorBlueLight,
+  colorActive: baseTheme.colorWhite,
+  colorDisabled: baseTheme.colorGrayBorder,
+  zIndexActive: 1,
+  border: '1px solid rgba(0, 0, 0, .15)',
+  borderBottomWidth: '2px',
+  'borderTopLeftRadius:first-child': '3px',
+  'borderBottomLeftRadius:first-child': '3px',
+  'borderTopLeftRadius:last-child': '3px',
+  'borderBottomLeftRadius:last-child': '3px',
+  'marginLeft&+&': '-1px'
+});

--- a/packages/cf-component-pagination/src/PaginationLinkTheme.js
+++ b/packages/cf-component-pagination/src/PaginationLinkTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'PaginationLinkTheme');

--- a/packages/cf-component-pagination/src/PaginationLinkTheme.js
+++ b/packages/cf-component-pagination/src/PaginationLinkTheme.js
@@ -1,19 +1,14 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'PaginationLinkTheme');
-  return {
-    position: 'relative',
-    display: 'block',
-    paddingTop: '.5em',
-    paddingBottom: '.5em',
-    paddingLeft: '1em',
-    paddingRight: '1em',
-    textDecoration: 'none',
-    fontWeight: 700,
-    color: 'inherit',
-    'zIndex:focus': 1,
-    cursorDisabled: 'default',
-    cursorActive: 'default'
-  };
-};
+export default baseTheme => ({
+  position: 'relative',
+  display: 'block',
+  paddingTop: '.5em',
+  paddingBottom: '.5em',
+  paddingLeft: '1em',
+  paddingRight: '1em',
+  textDecoration: 'none',
+  fontWeight: 700,
+  color: 'inherit',
+  'zIndex:focus': 1,
+  cursorDisabled: 'default',
+  cursorActive: 'default'
+});

--- a/packages/cf-component-pagination/src/PaginationRootTheme.js
+++ b/packages/cf-component-pagination/src/PaginationRootTheme.js
@@ -1,10 +1,5 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'PaginationRootTheme');
-  return {
-    content: '""',
-    display: 'table',
-    clear: 'both'
-  };
-};
+export default baseTheme => ({
+  content: '""',
+  display: 'table',
+  clear: 'both'
+});

--- a/packages/cf-component-pagination/src/PaginationRootTheme.js
+++ b/packages/cf-component-pagination/src/PaginationRootTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'PaginationRootTheme');

--- a/packages/cf-component-pagination/src/PaginationTheme.js
+++ b/packages/cf-component-pagination/src/PaginationTheme.js
@@ -1,22 +1,17 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'PaginationTheme');
-  return {
-    content: '""',
-    display: 'table',
-    clear: 'both',
-    listStyle: 'none',
-    marginTop: 0,
-    marginLeft: 0,
-    marginRight: 0,
-    marginBottom: 0,
-    paddingTop: 0,
-    paddingLeft: 0,
-    paddingRight: 0,
-    paddingBottom: 0,
-    float: 'left',
-    borderRadius: '3px',
-    boxShadow: '0 1px 1px rgba(0, 0, 0, .05)'
-  };
-};
+export default baseTheme => ({
+  content: '""',
+  display: 'table',
+  clear: 'both',
+  listStyle: 'none',
+  marginTop: 0,
+  marginLeft: 0,
+  marginRight: 0,
+  marginBottom: 0,
+  paddingTop: 0,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingBottom: 0,
+  float: 'left',
+  borderRadius: '3px',
+  boxShadow: '0 1px 1px rgba(0, 0, 0, .05)'
+});

--- a/packages/cf-component-pagination/src/PaginationTheme.js
+++ b/packages/cf-component-pagination/src/PaginationTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'PaginationTheme');

--- a/packages/cf-component-text/package.json
+++ b/packages/cf-component-text/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "cf-style-container": "^0.2.3",
-    "cf-style-const": "^0.3.4",
     "capitalize": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/cf-component-text/src/TextTheme.js
+++ b/packages/cf-component-text/src/TextTheme.js
@@ -1,24 +1,19 @@
-import { checkBaseTheme } from 'cf-style-container';
-
-export default baseTheme => {
-  checkBaseTheme(baseTheme, 'TextTheme');
-  return {
-    fontSizeNormal: '1em',
-    fontWeightNormal: 400,
-    fontSizeSmall: '.8em',
-    lineHeightSmall: 1.3,
-    textAlignStart: 'left',
-    textAlignCenter: 'center',
-    textAlignJustify: 'justify',
-    textAlignEnd: 'right',
-    textTransformCapitalize: 'capitalize',
-    'textTransformTitlecase:first-letter': 'capitalize',
-    textTransformLowercase: 'lowercase',
-    textTransformUppercase: 'uppercase',
-    colorInfo: baseTheme.colorInfo,
-    colorSuccess: baseTheme.colorSuccess,
-    colorWarning: baseTheme.colorWarning,
-    colorError: baseTheme.colorError,
-    colorMuted: baseTheme.colorMuted
-  };
-};
+export default baseTheme => ({
+  fontSizeNormal: '1em',
+  fontWeightNormal: 400,
+  fontSizeSmall: '.8em',
+  lineHeightSmall: 1.3,
+  textAlignStart: 'left',
+  textAlignCenter: 'center',
+  textAlignJustify: 'justify',
+  textAlignEnd: 'right',
+  textTransformCapitalize: 'capitalize',
+  'textTransformTitlecase:first-letter': 'capitalize',
+  textTransformLowercase: 'lowercase',
+  textTransformUppercase: 'uppercase',
+  colorInfo: baseTheme.colorInfo,
+  colorSuccess: baseTheme.colorSuccess,
+  colorWarning: baseTheme.colorWarning,
+  colorError: baseTheme.colorError,
+  colorMuted: baseTheme.colorMuted
+});

--- a/packages/cf-component-text/src/TextTheme.js
+++ b/packages/cf-component-text/src/TextTheme.js
@@ -1,4 +1,4 @@
-import { checkBaseTheme } from 'cf-style-const';
+import { checkBaseTheme } from 'cf-style-container';
 
 export default baseTheme => {
   checkBaseTheme(baseTheme, 'TextTheme');

--- a/packages/cf-style-const/README.md
+++ b/packages/cf-style-const/README.md
@@ -2,7 +2,7 @@
 
 > Cloudflare Style Constants
 
-Constast used to theme cf-ui components.
+Constants used to theme cf-ui and cf-ux and all other Fela components. This should not be used (required) directly. `variables` are already passed as `this.context.theme` through the whole React codebase in all our projects that use CSS in JS. You might want to use some HOC as `createComponent()` from `cf-style-container` that wires `this.context.theme` into `props.theme`.
 
 ## Installation
 

--- a/packages/cf-style-const/src/index.js
+++ b/packages/cf-style-const/src/index.js
@@ -1,14 +1,3 @@
 import variables from './variables';
 
-const checkBaseTheme = (baseTheme, name) => {
-  if (!baseTheme) {
-    throw Error(
-      `
-      You can't use ${name} without providing global theme from
-      cf-style-consts. You should wrap your app by <ThemeProvider />!
-    `
-    );
-  }
-};
-
-export { variables, checkBaseTheme };
+export { variables };

--- a/packages/cf-style-container/README.md
+++ b/packages/cf-style-container/README.md
@@ -104,3 +104,22 @@ const Heading = applyTheme(HeadingUnstyled, HeadingTheme);
 <Heading />
 ```
 
+### checkBaseTheme(theme, name)
+
+Source code explains it
+
+```js
+const checkBaseTheme = (baseTheme, name) => {
+  if (!baseTheme) {
+    throw Error(
+      `
+      You can't use ${name} without providing global theme from
+      cf-style-consts. You should wrap your app by <StyleProvider />!
+    `
+    );
+  }
+};
+```
+
+It should be included in all component themes so if someone tries to use our Fela components without the proper setup, they should get a nice error message.
+

--- a/packages/cf-style-container/README.md
+++ b/packages/cf-style-container/README.md
@@ -103,23 +103,3 @@ const Heading = applyTheme(HeadingUnstyled, HeadingTheme);
 // themed component
 <Heading />
 ```
-
-### checkBaseTheme(theme, name)
-
-Source code explains it
-
-```js
-const checkBaseTheme = (baseTheme, name) => {
-  if (!baseTheme) {
-    throw Error(
-      `
-      You can't use ${name} without providing global theme from
-      cf-style-consts. You should wrap your app by <StyleProvider />!
-    `
-    );
-  }
-};
-```
-
-It should be included in all component themes so if someone tries to use our Fela components without the proper setup, they should get a nice error message.
-

--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -48,23 +48,11 @@ const createComponentStyles = (styleFunctions, component) => {
   return connect(mapStylesToProps)(component);
 };
 
-const checkBaseTheme = (baseTheme, name) => {
-  if (!baseTheme) {
-    throw Error(
-      `
-      You can't use ${name} without providing global theme from
-      cf-style-consts. You should wrap your app by <StyleProvider />!
-    `
-    );
-  }
-};
-
 export {
   createComponent,
   applyTheme,
   ThemeProvider,
   connect,
   combineRules,
-  createComponentStyles,
-  checkBaseTheme
+  createComponentStyles
 };

--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -48,11 +48,23 @@ const createComponentStyles = (styleFunctions, component) => {
   return connect(mapStylesToProps)(component);
 };
 
+const checkBaseTheme = (baseTheme, name) => {
+  if (!baseTheme) {
+    throw Error(
+      `
+      You can't use ${name} without providing global theme from
+      cf-style-consts. You should wrap your app by <StyleProvider />!
+    `
+    );
+  }
+};
+
 export {
   createComponent,
   applyTheme,
   ThemeProvider,
   connect,
   combineRules,
-  createComponentStyles
+  createComponentStyles,
+  checkBaseTheme
 };


### PR DESCRIPTION
- `cf-style-container` is a "toolbox" for writing Fela based components, so it's a natural place for this function
- we will be able to remove `cf-style-const` dependency from all our packages except `cf-style-provider`, components should access these consts (variables) through `this.context.theme`, even better through HOCs in `cf-style-provider` like `createComponent()` that passes `this.context.theme` into `props.theme`
- we will be updating `cf-style-const` frequently so lerna prompts updates for all fela components very often (all fela components has `cf-style-const` as dependency)
- `cf-style-container` should be very stable (very few releases) and it should be the only dependency for all Fela components

I hope it makes sense. // @hturan related to my PR review