### PR TITLE
#170 Fix cf-component-box fontSize proptype

### DIFF
--- a/packages/cf-component-box/src/propertiesSpec.js
+++ b/packages/cf-component-box/src/propertiesSpec.js
@@ -211,7 +211,7 @@ export default {
     default: variables.lineHeight
   },
   fontSize: {
-    propType: PropTypes.number,
+    propType: numberOrString,
     default: variables.fontSize
   },
   fontWeight: {


### PR DESCRIPTION
We currently fail our CI on invalid PropTypes, and this is stopping us use cf-component-box for a lot of use cases. Would be nice to have!