### PR TITLE
Add styleguide colors

### DIFF
--- a/packages/cf-style-const/src/variables.js
+++ b/packages/cf-style-const/src/variables.js
@@ -14,6 +14,20 @@ export default {
     seven: 'linear-gradient(left, #F69259, #FFDB6F)',
     eight: 'linear-gradient(left, #85CBA8, #FFDB6F)'
   },
+  color: {
+    rain: '#408BC9',
+    sky: '#76C4E2',
+    dew: '#85CBA8',
+    twilight: '#8176B5',
+    sunset: '#BA77B1',
+    dawn: '#F16975',
+    sunrise: '#F69259',
+    lightning: '#FFDB6F',
+    night: '#404041',
+    dusk: '#4D4D4F',
+    storm: '#808285',
+    hail: '#BCBEC0'
+  },
   fontSize: '16px',
   boxShadow: '0 0 20px 0 rgba(136,136,136,0.50)',
   inputFontSize: '13px',


### PR DESCRIPTION
Adding the style guide colors into the consts. The names were proposed by designers. Every new design should use only these colors. If not push back. This is a fresh start for colors.

<img width="588" alt="screen shot 2017-04-16 at 7 08 45 pm" src="https://cloud.githubusercontent.com/assets/1387913/25076714/22ec5530-22d8-11e7-8e2f-3c6cdfb4c7bd.png">
