### PR TITLE
Removing cf-component-heading dependency for cf-component-modal::Moda…

### DIFF
--- a/packages/cf-component-modal/package.json
+++ b/packages/cf-component-modal/package.json
@@ -11,7 +11,6 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
-    "cf-component-heading": "^4.2.1",
     "cf-component-icon": "^2.2.0",
     "cf-style-container": "^1.0.0",
     "react-addons-css-transition-group": "^0.14.2 || ^15.0.0-0",

--- a/packages/cf-component-modal/src/ModalTitle.js
+++ b/packages/cf-component-modal/src/ModalTitle.js
@@ -1,15 +1,12 @@
 import React, { PropTypes } from 'react';
-import { Heading } from 'cf-component-heading';
 import { applyTheme } from 'cf-style-container';
 
 class ModalTitle extends React.Component {
   render() {
     return (
-      <div className="cf-modal__title">
-        <Heading size={3}>
-          {this.props.children}
-        </Heading>
-      </div>
+      <h3 className="cf-modal__title">
+        {this.props.children}
+      </h3>
     );
   }
 }

--- a/packages/cf-component-modal/src/ModalTitle.js
+++ b/packages/cf-component-modal/src/ModalTitle.js
@@ -4,9 +4,9 @@ import { applyTheme } from 'cf-style-container';
 class ModalTitle extends React.Component {
   render() {
     return (
-      <h3 className="cf-modal__title">
+      <h1 className="cf-modal__title">
         {this.props.children}
-      </h3>
+      </h1>
     );
   }
 }

--- a/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
+++ b/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should render 1`] = `
-<h3
+<h1
   className="cf-modal__title"
 >
   ModalTitle
-</h3>
+</h1>
 `;

--- a/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
+++ b/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
@@ -1,13 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should render 1`] = `
-<div
+<h3
   className="cf-modal__title"
 >
-  <h3
-    className="cf-1phyxie"
-  >
-    ModalTitle
-  </h3>
-</div>
+  ModalTitle
+</h3>
 `;


### PR DESCRIPTION
`cf-component-page` and `cf-component-card` already don't have dependencies on `cf-component-heading`.  This PR removes the dependency from `<ModalTitle/>`