### PR TITLE
#171 Update cf-component-tooltip to re-render when props change

### DIFF
--- a/packages/cf-component-tooltip/src/Tooltip.js
+++ b/packages/cf-component-tooltip/src/Tooltip.js
@@ -16,6 +16,20 @@ class Tooltip extends React.Component {
     this.destroyTooltip();
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (
+      this.props.content !== nextProps.content ||
+      this.props.position !== nextProps.position
+    ) {
+      this.destroyTooltip();
+      this.destroyTooltip = createTooltip(
+        findDOMNode(this),
+        nextProps.content,
+        nextProps.position
+      );
+    }
+  }
+
   render() {
     return this.props.children;
   }


### PR DESCRIPTION
This fixes #171. Currently, the tooltip never updates to reflect new props. With this change, it'll compare props and re-create the tooltip if needed.