### PR TITLE
button: make `onClick` optional

### DIFF
--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -148,7 +148,7 @@ class Button extends React.Component {
 }
 
 Button.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   submit: PropTypes.bool,
   spaced: PropTypes.bool,
   className: PropTypes.string.isRequired,


### PR DESCRIPTION
We can render a button without a `onClick` function and this patch will make sure we don't get prop types errors while developing.