### PR TITLE
Remove duplicate keys

### DIFF
--- a/packages/cf-component-box/src/propertiesSpec.js
+++ b/packages/cf-component-box/src/propertiesSpec.js
@@ -449,11 +449,6 @@ export default {
       'unset'
     ]),
     default: 'normal'
-  },
-
-  wordWrap: {
-    propType: PropTypes.string,
-    default: 'normal'
   }
 };
 

--- a/packages/cf-component-heading/src/HeadingTheme.js
+++ b/packages/cf-component-heading/src/HeadingTheme.js
@@ -7,7 +7,6 @@ export default () => ({
   fontWeight3: 700,
   fontSize3: '1.46667rem',
   lineHeight3: 1.3,
-  fontWeight3: 700,
   fontSize4: '1.2rem',
   lineHeight4: 1.3,
   fontWeight4: 700,


### PR DESCRIPTION
This fix is brought to you by the @Microsoft typescript compiler:

```
packages/cf-component-heading/src/HeadingTheme.js(10,3): error TS1117: An object literal cannot have multiple properties with the same name in strict mode.
```

```
packages/cf-component-box/src/propertiesSpec.js(454,3): error TS1117: An object literal cannot have multiple properties with the same name in strict mode.
```