### PR TITLE
introduce new gray color moonshine

### DIFF
--- a/packages/cf-style-const/src/variables.js
+++ b/packages/cf-style-const/src/variables.js
@@ -28,6 +28,7 @@ export default {
     dusk: '#4D4D4F',
     storm: '#808285',
     hail: '#BCBEC0',
+    moonshine: '#F7F7F7',
     //current colors
     cement: '#7D7D7D',
     grass: '#9BCA3E',


### PR DESCRIPTION
This is a continuation on https://github.com/cloudflare/cf-ui/pull/203. I will deprecate now `colorGrayLightOnboarding` and remove it after migration to `moonshine`