### PR TITLE
Use em for 'dots' pagination

### DIFF
--- a/packages/cf-component-pagination/src/PaginationItemMinimalTheme.js
+++ b/packages/cf-component-pagination/src/PaginationItemMinimalTheme.js
@@ -13,9 +13,9 @@ export default baseTheme => ({
   cursorDisabled: 'default',
   cursorActive: 'default',
   dot: {
-    width: '.5rem',
-    height: '.5rem',
-    margin: '1rem',
+    width: '.5em',
+    height: '.5em',
+    margin: '1em',
     borderRadius: '50%',
     border: '1px solid rgba(0, 0, 0, .15)'
   },

--- a/packages/cf-component-pagination/src/PaginationItemTheme.js
+++ b/packages/cf-component-pagination/src/PaginationItemTheme.js
@@ -13,9 +13,9 @@ export default baseTheme => ({
   cursorDisabled: 'default',
   cursorActive: 'default',
   dot: {
-    width: '.5rem',
-    height: '.5rem',
-    margin: '1rem',
+    width: '.5em',
+    height: '.5em',
+    margin: '1em',
     borderRadius: '50%',
     border: `1px solid ${baseTheme.color.rain}`
   },

--- a/packages/cf-component-pagination/test/__snapshots__/PaginationItem.js.snap
+++ b/packages/cf-component-pagination/test/__snapshots__/PaginationItem.js.snap
@@ -38,7 +38,7 @@ exports[`should render active 1`] = `
 
 exports[`should render active dot 1`] = `
 <li
-  className="cf-fguc2k"
+  className="cf-1xpv85q"
   role={null}
 >
   <a
@@ -110,7 +110,7 @@ exports[`should render disabled 1`] = `
 
 exports[`should render disabled dot 1`] = `
 <li
-  className="cf-xa3msm"
+  className="cf-18awel0"
   role={null}
 >
   <a


### PR DESCRIPTION
dots looks weird with fontSize 15px, font size should be an even number.

with fontSize 15px:
![screen shot 2017-06-05 at 2 51 52 pm](https://cloud.githubusercontent.com/assets/125466/26786480/bb61b95c-49fe-11e7-8740-ff6b49523da6.png)

with fontSize 16px:
![screen shot 2017-06-05 at 2 52 24 pm](https://cloud.githubusercontent.com/assets/125466/26786494/c382f5b0-49fe-11e7-809c-4961477bb6eb.png)

After this change we could set fontSize to 16px on the parent container.
