### PR TITLE
fix: make the margins between pagination items larger

### DIFF
--- a/packages/cf-component-pagination/src/PaginationItemMinimalTheme.js
+++ b/packages/cf-component-pagination/src/PaginationItemMinimalTheme.js
@@ -35,8 +35,8 @@ export default baseTheme => ({
     display: 'block',
     paddingTop: '0',
     paddingBottom: '0',
-    paddingLeft: '.1em',
-    paddingRight: '.1em',
+    paddingLeft: '0.5em',
+    paddingRight: '0.5em',
     textDecoration: 'none',
     color: 'inherit',
     'zIndex:focus': 1


### PR DESCRIPTION
Make em bigger.

I took the value from our existing codebase and it looks like this:

![image](https://user-images.githubusercontent.com/318208/26836274-52510984-4ad2-11e7-8f09-024266f08e2b.png)
