### PR TITLE
Update cf-util-http so the promises returned resolve to json

### DIFF
--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -68,13 +68,7 @@ function wrapResponse(headers, status, text, response) {
   if (isJSON(headers['content-type'])) {
     body = text ? JSON.parse(text) : undefined;
   }
-  return {
-    headers,
-    status,
-    body,
-    text,
-    response
-  };
+  return { headers, status, body, text, response };
 }
 
 const BODYLESS_METHODS = ['GET', 'HEAD'];
@@ -114,11 +108,9 @@ const BODYLESS_METHODS = ['GET', 'HEAD'];
  * @see [Global Fetch on MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)
  * @see [WHATWG Fetch API Spec](https://fetch.spec.whatwg.org/)
  */
-export function request(method, url, opts, callback) {
+export function request(method, url, opts = {}, callback) {
   if (typeof opts === 'function') {
     callback = opts;
-    opts = {};
-  } else if (opts == null) {
     opts = {};
   }
 
@@ -142,8 +134,8 @@ export function request(method, url, opts, callback) {
   // Normalize the headers
   opts.headers = Object.assign({}, opts.headers);
 
-  // Emuluate superagent's questionable ability to filter out headers that's
-  // been set to null or undefined.
+  // Emulate superagent's questionable ability to filter out headers that are
+  // null or undefined.
   for (const h in opts.headers) {
     if (opts.headers[h] == null) {
       delete opts.headers[h];
@@ -179,28 +171,19 @@ export function request(method, url, opts, callback) {
       const status = response.status;
       logMessage = `${logMessage} (${status} ${response.statusText})`;
 
-      if (response.ok) {
-        logSuccess(logMessage);
-
-        return response.text().then(text => {
-          if (callback) {
-            callback(undefined, wrapResponse(headers, status, text, response));
-          }
-          return response;
-        });
-      }
-
-      logError(logMessage);
       return response.text().then(text => {
-        if (callback) {
-          callback(wrapResponse(headers, status, text, response));
+        const wrappedResponse = wrapResponse(headers, status, text, response);
+        if (response.ok) {
+          logSuccess(logMessage);
+          callback && callback(undefined, wrappedResponse);
+          return wrappedResponse;
         }
-        return response;
+        throw wrappedResponse;
       });
     })
     .catch(err => {
-      // Unrecoverable errors
-      callback(err);
+      logError(logMessage);
+      callback && callback(err);
       console.trace(err);
       throw err;
     });

--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -108,9 +108,11 @@ const BODYLESS_METHODS = ['GET', 'HEAD'];
  * @see [Global Fetch on MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)
  * @see [WHATWG Fetch API Spec](https://fetch.spec.whatwg.org/)
  */
-export function request(method, url, opts = {}, callback) {
+export function request(method, url, opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
+    opts = {};
+  } else if (opts == null) {
     opts = {};
   }
 

--- a/packages/cf-util-http/test/http.js
+++ b/packages/cf-util-http/test/http.js
@@ -63,7 +63,7 @@ describe('request', () => {
     });
   });
 
-  test('should accept 3-args form where the opts is optional (promise)', done => {
+  test('should accept 2-args form where the opts is optional (promise)', done => {
     fetch.mockResponse('', {
       headers: { 'Content-Type': 'text/plain' },
       status: 200

--- a/packages/cf-util-http/test/http.js
+++ b/packages/cf-util-http/test/http.js
@@ -63,6 +63,18 @@ describe('request', () => {
     });
   });
 
+  test('should accept 3-args form where the opts is optional (promise)', done => {
+    fetch.mockResponse('', {
+      headers: { 'Content-Type': 'text/plain' },
+      status: 200
+    });
+
+    http.request('GET', '/somewhere').then(res => {
+      expect(res).toBeDefined();
+      done();
+    });
+  });
+
   test('should accept null as the 3rd parameter', done => {
     fetch.mockResponse('', {
       headers: { 'Content-Type': 'text/plain' },
@@ -71,6 +83,18 @@ describe('request', () => {
 
     http.request('GET', '/somewhere', null, (err, res) => {
       expect(err).toBeUndefined();
+      expect(res).toBeDefined();
+      done();
+    });
+  });
+
+  test('should accept null as the 3rd parameter (promise)', done => {
+    fetch.mockResponse('', {
+      headers: { 'Content-Type': 'text/plain' },
+      status: 200
+    });
+
+    http.request('GET', '/somewhere', null).then(res => {
       expect(res).toBeDefined();
       done();
     });
@@ -100,7 +124,7 @@ describe('request', () => {
     done();
   });
 
-  test('should parse the response body as JSON when appripriate', done => {
+  test('should parse the response body as JSON when appropriate', done => {
     fetch.mockResponse(
       JSON.stringify({
         message: 'hello'
@@ -111,6 +135,22 @@ describe('request', () => {
       }
     );
     http.request('GET', '/somewhere', (err, res) => {
+      expect(res.body).toMatchObject({ message: 'hello' });
+      done();
+    });
+  });
+
+  test('should parse the response body as JSON when appropriate (promise)', done => {
+    fetch.mockResponse(
+      JSON.stringify({
+        message: 'hello'
+      }),
+      {
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        status: 200
+      }
+    );
+    http.request('GET', '/somewhere').then(res => {
       expect(res.body).toMatchObject({ message: 'hello' });
       done();
     });
@@ -155,7 +195,26 @@ describe('request', () => {
     });
   });
 
-  test('should call the error handler on error', done => {
+  test('should resolve the promise successfully', done => {
+    fetch.mockResponse(
+      JSON.stringify({
+        message: 'Hello World'
+      }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200
+      }
+    );
+
+    http.request('DELETE', '/posts/3').then(res => {
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('application/json');
+      expect(res.body.message).toBe('Hello World');
+      done();
+    });
+  });
+
+  test('should reject the promise for an unsuccessful request', done => {
     fetch.mockResponse(
       JSON.stringify({
         message: 'Not Found'
@@ -166,10 +225,9 @@ describe('request', () => {
       }
     );
 
-    http.request('GET', '/missing', undefined, (err, res) => {
+    http.request('GET', '/missing').catch(err => {
       expect(err.status).toBe(404);
       expect(err.headers['content-type']).toBe('application/json');
-      expect(res).toBeUndefined();
       expect(err.body.message).toBe('Not Found');
       done();
     });
@@ -190,6 +248,24 @@ describe('get', () => {
 
     http.get('/posts', undefined, (err, res) => {
       if (err) return done(err);
+      expect(res.body[0].id).toBe(1);
+      done();
+    });
+  });
+
+  test('should make a GET request (promise)', done => {
+    fetch.mockResponse(
+      JSON.stringify([
+        { id: 1, title: 'Post 1', content: 'Contents of Post 1' },
+        { id: 2, title: 'Post 2', content: 'Contents of Post 2' }
+      ]),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200
+      }
+    );
+
+    http.get('/posts').then(res => {
       expect(res.body[0].id).toBe(1);
       done();
     });
@@ -219,6 +295,29 @@ describe('post', () => {
       }
     );
   });
+
+  test('should make a POST request (promise)', done => {
+    fetch.mockResponse(
+      JSON.stringify({
+        id: 3,
+        title: 'Post 3',
+        content: 'Contents of Post 3'
+      }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200
+      }
+    );
+
+    http
+      .post('/posts', {
+        body: { title: 'Post 3', content: 'Contents of Post 3' }
+      })
+      .then(res => {
+        expect(res.body.id).toBe(3);
+        done();
+      });
+  });
 });
 
 describe('put', () => {
@@ -246,6 +345,29 @@ describe('put', () => {
       }
     );
   });
+
+  test('should make a PUT request (promise)', done => {
+    fetch.mockResponse(
+      JSON.stringify({
+        id: 3,
+        title: 'Post 3',
+        content: 'Contents of Post 3 (edit)'
+      }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200
+      }
+    );
+
+    http
+      .put('/posts/3', {
+        body: { id: 3, title: 'Post 3', content: 'Contents of Post 3 (edit)' }
+      })
+      .then(res => {
+        expect(res.body.content).toBe('Contents of Post 3 (edit)');
+        done();
+      });
+  });
 });
 
 describe('patch', () => {
@@ -254,7 +376,8 @@ describe('patch', () => {
       JSON.stringify({
         id: 3,
         title: 'Post 3',
-        content: 'Contents of Post 3 (edit 2)'
+        content: 'Contents of Post 3 (edit 2)',
+        ok: true
       }),
       {
         headers: { 'Content-Type': 'application/json' }
@@ -270,6 +393,27 @@ describe('patch', () => {
         done();
       }
     );
+  });
+
+  test('should make a PATCH request (promise)', done => {
+    fetch.mockResponse(
+      JSON.stringify({
+        id: 3,
+        title: 'Post 3',
+        content: 'Contents of Post 3 (edit 2)'
+      }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200
+      }
+    );
+
+    http
+      .patch('/posts/3', { body: { content: 'Contents of Post 3 (edit 2)' } })
+      .then(res => {
+        expect(res.body.content).toBe('Contents of Post 3 (edit 2)');
+        done();
+      });
   });
 });
 
@@ -288,6 +432,25 @@ describe('del', () => {
 
     http.del('/posts/3', undefined, (err, res) => {
       if (err) return done(err);
+      expect(res.body.content).toBe('Contents of Post 3');
+      done();
+    });
+  });
+
+  test('should make a DELETE request (promise)', done => {
+    fetch.mockResponse(
+      JSON.stringify({
+        id: 3,
+        title: 'Post 3',
+        content: 'Contents of Post 3'
+      }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200
+      }
+    );
+
+    http.del('/posts/3').then(res => {
       expect(res.body.content).toBe('Contents of Post 3');
       done();
     });


### PR DESCRIPTION
The fetch promise resolves to a stream with methods such as text() and json(). These methods cannot be called twice, and text() is called internally in the request method. This means that response body can only be accessed in the callback and not via the object resolved by the promise.

This PR updates the request method so that the promise resolves with the same object that's passed to the success callback, and throws with the same object that's passed to the error callback.