### PR TITLE
Added package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages/*/npm-debug.log.*
 es
 dist
 \.jest
+package-lock.json


### PR DESCRIPTION
TLDR; This PR ignores the auto generated NPM5 `package-lock.json` file.

Not that NPM@5 is out, it generates a `package-lock.json` file by default. But since we're using yarn we don't need the `package-lock.json`. 

If anyone feels strongly about committing the `package-lock.json` to the repo, I'll open another PR that commits the `package-lock.json` files.
