### PR TITLE
CSS-in-JS Fela v5

### DIFF
--- a/packages/cf-builder-pagination/test/__snapshots__/PaginationBuilder.js.snap
+++ b/packages/cf-builder-pagination/test/__snapshots__/PaginationBuilder.js.snap
@@ -3,8 +3,6 @@
 exports[`should render pagination 1`] = `
 <div
   className="cf-1bek1ug"
-  id={undefined}
-  style={undefined}
 >
   <ul
     aria-describedby={null}
@@ -19,9 +17,7 @@ exports[`should render pagination 1`] = `
         aria-label={undefined}
         className="cf-109b087"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-left"
@@ -37,9 +33,7 @@ exports[`should render pagination 1`] = `
         aria-label={undefined}
         className="cf-109b087"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         1
       </a>
@@ -52,9 +46,7 @@ exports[`should render pagination 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         2
       </a>
@@ -67,9 +59,7 @@ exports[`should render pagination 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         3
       </a>
@@ -82,9 +72,7 @@ exports[`should render pagination 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         4
       </a>
@@ -97,9 +85,7 @@ exports[`should render pagination 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         5
       </a>
@@ -112,9 +98,7 @@ exports[`should render pagination 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-right"
@@ -129,8 +113,6 @@ exports[`should render pagination 1`] = `
 exports[`should render pagination loading 1`] = `
 <div
   className="cf-1bek1ug"
-  id={undefined}
-  style={undefined}
 >
   <ul
     aria-describedby={null}
@@ -145,9 +127,7 @@ exports[`should render pagination loading 1`] = `
         aria-label={undefined}
         className="cf-109b087"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-left"
@@ -163,9 +143,7 @@ exports[`should render pagination loading 1`] = `
         aria-label={undefined}
         className="cf-109b087"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--loading"
@@ -181,9 +159,7 @@ exports[`should render pagination loading 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         2
       </a>
@@ -196,9 +172,7 @@ exports[`should render pagination loading 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         3
       </a>
@@ -211,9 +185,7 @@ exports[`should render pagination loading 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         4
       </a>
@@ -226,9 +198,7 @@ exports[`should render pagination loading 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         5
       </a>
@@ -241,9 +211,7 @@ exports[`should render pagination loading 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-right"
@@ -258,8 +226,6 @@ exports[`should render pagination loading 1`] = `
 exports[`should render pagination with an infoFormatter 1`] = `
 <div
   className="cf-1bek1ug"
-  id={undefined}
-  style={undefined}
 >
   <ul
     aria-describedby={null}
@@ -274,9 +240,7 @@ exports[`should render pagination with an infoFormatter 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-left"
@@ -292,9 +256,7 @@ exports[`should render pagination with an infoFormatter 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         1
       </a>
@@ -307,9 +269,7 @@ exports[`should render pagination with an infoFormatter 1`] = `
         aria-label={undefined}
         className="cf-109b087"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         2
       </a>
@@ -322,9 +282,7 @@ exports[`should render pagination with an infoFormatter 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         3
       </a>
@@ -337,9 +295,7 @@ exports[`should render pagination with an infoFormatter 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         4
       </a>
@@ -352,9 +308,7 @@ exports[`should render pagination with an infoFormatter 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         5
       </a>
@@ -367,9 +321,7 @@ exports[`should render pagination with an infoFormatter 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-right"
@@ -384,8 +336,6 @@ exports[`should render pagination with an infoFormatter 1`] = `
 exports[`should render pagination with the last page active 1`] = `
 <div
   className="cf-1bek1ug"
-  id={undefined}
-  style={undefined}
 >
   <ul
     aria-describedby={null}
@@ -400,9 +350,7 @@ exports[`should render pagination with the last page active 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-left"
@@ -418,9 +366,7 @@ exports[`should render pagination with the last page active 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         1
       </a>
@@ -433,9 +379,7 @@ exports[`should render pagination with the last page active 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         2
       </a>
@@ -448,9 +392,7 @@ exports[`should render pagination with the last page active 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         3
       </a>
@@ -463,9 +405,7 @@ exports[`should render pagination with the last page active 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         4
       </a>
@@ -478,9 +418,7 @@ exports[`should render pagination with the last page active 1`] = `
         aria-label={undefined}
         className="cf-109b087"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         5
       </a>
@@ -493,9 +431,7 @@ exports[`should render pagination with the last page active 1`] = `
         aria-label={undefined}
         className="cf-109b087"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-right"
@@ -510,8 +446,6 @@ exports[`should render pagination with the last page active 1`] = `
 exports[`should render with collapsed items 1`] = `
 <div
   className="cf-1bek1ug"
-  id={undefined}
-  style={undefined}
 >
   <ul
     aria-describedby={null}
@@ -526,9 +460,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-left"
@@ -544,9 +476,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         1
       </a>
@@ -559,9 +489,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <span>
           …
@@ -576,9 +504,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         4
       </a>
@@ -591,9 +517,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         5
       </a>
@@ -606,9 +530,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-109b087"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         6
       </a>
@@ -621,9 +543,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         7
       </a>
@@ -636,9 +556,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         8
       </a>
@@ -651,9 +569,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <span>
           …
@@ -668,9 +584,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         20
       </a>
@@ -683,9 +597,7 @@ exports[`should render with collapsed items 1`] = `
         aria-label={undefined}
         className="cf-32iz07"
         href="#"
-        id={undefined}
         onClick={[Function]}
-        style={undefined}
       >
         <i
           className="cf-icon cf-icon--caret-right"

--- a/packages/cf-component-pagination/test/__snapshots__/Pagination.js.snap
+++ b/packages/cf-component-pagination/test/__snapshots__/Pagination.js.snap
@@ -3,8 +3,6 @@
 exports[`should render 1`] = `
 <div
   className="cf-1bek1ug"
-  id={undefined}
-  style={undefined}
 >
   <ul
     aria-describedby={null}
@@ -19,8 +17,6 @@ exports[`should render 1`] = `
 exports[`should render with info 1`] = `
 <div
   className="cf-1bek1ug"
-  id={undefined}
-  style={undefined}
 >
   <ul
     aria-describedby="cf-pagination-1"

--- a/packages/cf-component-pagination/test/__snapshots__/PaginationItem.js.snap
+++ b/packages/cf-component-pagination/test/__snapshots__/PaginationItem.js.snap
@@ -9,9 +9,7 @@ exports[`should render 1`] = `
     aria-label={undefined}
     className="cf-32iz07"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>
@@ -27,9 +25,7 @@ exports[`should render active 1`] = `
     aria-label={undefined}
     className="cf-109b087"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>
@@ -45,9 +41,7 @@ exports[`should render active dot 1`] = `
     aria-label={undefined}
     className="cf-109b087"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>
@@ -63,9 +57,7 @@ exports[`should render active next 1`] = `
     aria-label={undefined}
     className="cf-109b087"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>
@@ -81,9 +73,7 @@ exports[`should render active prev 1`] = `
     aria-label={undefined}
     className="cf-109b087"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>
@@ -99,9 +89,7 @@ exports[`should render disabled 1`] = `
     aria-label={undefined}
     className="cf-109b087"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>
@@ -117,9 +105,7 @@ exports[`should render disabled dot 1`] = `
     aria-label={undefined}
     className="cf-109b087"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>
@@ -135,9 +121,7 @@ exports[`should render disabled next 1`] = `
     aria-label={undefined}
     className="cf-109b087"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>
@@ -153,9 +137,7 @@ exports[`should render disabled prev 1`] = `
     aria-label={undefined}
     className="cf-109b087"
     href="#"
-    id={undefined}
     onClick={[Function]}
-    style={undefined}
   >
     PaginationItem
   </a>

--- a/packages/cf-style-container/package.json
+++ b/packages/cf-style-container/package.json
@@ -11,9 +11,9 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
-    "fela": "4.3.2",
+    "fela": "^5.0.0",
     "merge-options": "0.0.64",
-    "react-fela": "4.3.2",
+    "react-fela": "^5.0.0",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -44,16 +44,8 @@ const applyTheme = (ComponentToWrap, primaryTheme = () => {}, ...themes) => {
   return ThemedComponent;
 };
 
-const createComponentStyles = (styleFunctions, component) => {
-  const mapStylesToProps = props => renderer => {
-    const toRender = {};
-    for (const style in styleFunctions) {
-      toRender[style] = renderer.renderRule(styleFunctions[style], props);
-    }
-    return toRender;
-  };
-  return connect(mapStylesToProps)(component);
-};
+const createComponentStyles = (styleFunctions, component) =>
+  connect(styleFunctions)(component);
 
 export {
   createComponent,

--- a/packages/cf-style-container/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-container/test/__snapshots__/index.js.snap
@@ -3,24 +3,18 @@
 exports[`applyTheme should overwrite the baseTheme and update the context 1`] = `
 <div
   className="cf-iy1jc0"
-  id={undefined}
-  style={undefined}
 />
 `;
 
 exports[`applyTheme should overwrite the mainTheme and update the context 1`] = `
 <div
   className="cf-1tsdo2i"
-  id={undefined}
-  style={undefined}
 />
 `;
 
 exports[`createComponent creates empty component 1`] = `
 <div
   className=""
-  id={undefined}
-  style={undefined}
 />
 `;
 

--- a/packages/cf-style-provider/package.json
+++ b/packages/cf-style-provider/package.json
@@ -17,6 +17,7 @@
     "fela": "^5.0.0",
     "fela-beautifier": "^5.0.0",
     "fela-monolithic": "^5.0.0",
+    "fela-plugin-embedded": "^5.0.0",
     "fela-plugin-fallback-value": "^5.0.0",
     "fela-plugin-lvha": "^5.0.0",
     "fela-plugin-prefixer": "^5.0.0",

--- a/packages/cf-style-provider/package.json
+++ b/packages/cf-style-provider/package.json
@@ -14,18 +14,17 @@
     "cf-style-const": "^1.4.2",
     "cf-style-container": "^1.1.2",
     "cssbeautify": "^0.3.1",
-    "fela": "4.3.2",
-    "fela-beautifier": "4.3.2",
-    "fela-font-renderer": "4.3.2",
-    "fela-monolithic": "4.3.2",
-    "fela-plugin-fallback-value": "4.3.2",
-    "fela-plugin-lvha": "4.3.2",
-    "fela-plugin-prefixer": "4.3.2",
-    "fela-plugin-unit": "4.3.2",
-    "fela-plugin-validator": "4.3.2",
+    "fela": "^5.0.0",
+    "fela-beautifier": "^5.0.0",
+    "fela-monolithic": "^5.0.0",
+    "fela-plugin-fallback-value": "^5.0.0",
+    "fela-plugin-lvha": "^5.0.0",
+    "fela-plugin-prefixer": "^5.0.0",
+    "fela-plugin-unit": "^5.0.0",
+    "fela-plugin-validator": "^5.0.0",
     "inline-style-prefixer": "^3.0.5",
     "prop-types": "^15.5.8",
-    "react-fela": "4.3.2"
+    "react-fela": "^5.0.0"
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.0.0-0 || ^16.0.0-0"

--- a/packages/cf-style-provider/src/index.js
+++ b/packages/cf-style-provider/src/index.js
@@ -10,7 +10,6 @@ import prefixer from 'fela-plugin-prefixer';
 import fallbackValue from 'fela-plugin-fallback-value';
 import unit from 'fela-plugin-unit';
 import lvha from 'fela-plugin-lvha';
-import fontRenderer from 'fela-font-renderer';
 import validator from 'fela-plugin-validator';
 import beautifier from 'fela-beautifier';
 import monolithic from 'fela-monolithic';
@@ -20,15 +19,13 @@ import { ThemeProvider } from 'cf-style-container';
 
 const defaultOpts = {
   selectorPrefix: 'cf-',
-  dev: false,
-  fontNode: undefined,
-  cssNode: undefined
+  dev: false
 };
 
 export const createRenderer = opts => {
   const usedOpts = Object.assign({}, defaultOpts, opts);
   const plugins = [prefixer(), fallbackValue(), unit(), lvha()];
-  const enhancers = [fontRenderer(usedOpts.fontNode)];
+  const enhancers = [];
 
   if (usedOpts.dev === true) {
     plugins.push(validator());
@@ -46,19 +43,16 @@ export const createRenderer = opts => {
 export const StyleProvider = ({
   selectorPrefix,
   dev,
-  cssNode,
-  fontNode,
   children,
   ...restProps
 }) => {
   const renderer = createRenderer({
     selectorPrefix,
-    dev,
-    fontNode
+    dev
   });
   const child = Children.only(children);
   return (
-    <Provider renderer={renderer} mountNode={cssNode}>
+    <Provider renderer={renderer}>
       <ThemeProvider theme={variables}>
         {isValidElement(child) ? cloneElement(child, { ...restProps }) : child}
       </ThemeProvider>
@@ -69,8 +63,5 @@ export const StyleProvider = ({
 StyleProvider.defaultProps = defaultOpts;
 StyleProvider.propTypes = {
   dev: PropTypes.bool,
-  selectorPrefix: PropTypes.string,
-  cssNode: PropTypes.object,
-  fontNode: PropTypes.object,
-  children: PropTypes.node.isRequired
+  selectorPrefix: PropTypes.string
 };

--- a/packages/cf-style-provider/src/index.js
+++ b/packages/cf-style-provider/src/index.js
@@ -11,6 +11,7 @@ import fallbackValue from 'fela-plugin-fallback-value';
 import unit from 'fela-plugin-unit';
 import lvha from 'fela-plugin-lvha';
 import validator from 'fela-plugin-validator';
+import embedded from 'fela-plugin-embedded';
 import beautifier from 'fela-beautifier';
 import monolithic from 'fela-monolithic';
 import { Provider } from 'react-fela';
@@ -24,7 +25,7 @@ const defaultOpts = {
 
 export const createRenderer = opts => {
   const usedOpts = Object.assign({}, defaultOpts, opts);
-  const plugins = [prefixer(), fallbackValue(), unit(), lvha()];
+  const plugins = [prefixer(), fallbackValue(), unit(), lvha(), embedded()];
   const enhancers = [];
 
   if (usedOpts.dev === true) {

--- a/packages/cf-style-provider/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-provider/test/__snapshots__/index.js.snap
@@ -7,15 +7,7 @@ exports[`StyleProvider should render styles 1`] = `
 <html>
 
 <head>
-  <style id=\\"stylesheet\\" data-fela-stylesheet=\\"\\">
-    .cf-a {
-      margin: 10px
-    }
-
-    .cf-b {
-      color: red
-    }
-  </style>
+  <style id=\\"stylesheet\\"></style>
 </head>
 
 <body>

--- a/packages/cf-style-provider/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-provider/test/__snapshots__/index.js.snap
@@ -3,18 +3,24 @@
 exports[`StyleProvider should render 1`] = `<div />`;
 
 exports[`StyleProvider should render styles 1`] = `
-"<!DOCTYPE html>
-<html>
+"<html>
 
 <head>
-  <style id=\\"stylesheet\\"></style>
+  <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
+    .cf-a {
+      margin: 10px
+    }
+
+    .cf-b {
+      color: red
+    }
+  </style>
 </head>
 
 <body>
-  <div id=\\"react-app\\">
+  <div>
     <div data-reactroot=\\"\\" class=\\"cf-a cf-b\\"></div>
   </div>
-
 </body>
 
 </html>"

--- a/packages/cf-style-provider/test/index.js
+++ b/packages/cf-style-provider/test/index.js
@@ -6,7 +6,6 @@ import { Button } from '../../cf-component-button/src/index';
 import renderer from 'react-test-renderer';
 import { render } from 'react-dom';
 import { mount } from 'enzyme';
-import jsdom from 'jsdom';
 import { html as beautify } from 'js-beautify';
 
 test('StyleProvider should render', () => {
@@ -15,23 +14,8 @@ test('StyleProvider should render', () => {
 });
 
 test('StyleProvider should render styles', () => {
-  const doc = jsdom.jsdom(
-    `<!doctype html>
-     <html>
-     <head>
-       <style id="stylesheet"></style>
-     </head>
-     <body>
-       <div id="react-app"></div>
-     </body>
-     </html>`
-  );
-
-  global.document = doc;
-  global.window = doc.defaultView;
-
-  const cssNode = doc.getElementById('stylesheet');
-  const htmlNode = doc.getElementById('react-app');
+  const htmlNode = document.createElement('div');
+  document.body.appendChild(htmlNode);
 
   const Foo = createComponent(() => ({
     margin: '10px',
@@ -39,14 +23,14 @@ test('StyleProvider should render styles', () => {
   }));
 
   render(
-    <StyleProvider cssNode={cssNode}>
+    <StyleProvider>
       <Foo />
     </StyleProvider>,
     htmlNode
   );
 
   expect(
-    beautify(jsdom.serializeDocument(doc), { indent_size: 2 })
+    beautify(document.documentElement.outerHTML, { indent_size: 2 })
   ).toMatchSnapshot();
 });
 


### PR DESCRIPTION
:star: New major version of CSS-in-JS Fela [just landed](https://twitter.com/rofrischmann/status/872552144045559808) :star:

**This PR updates cf-ui to v5:**
- it removes `id={undefined}` and `style={undefined}` from our snapshots
- `react-fela/connect` has a new API that matches our `cf-style-provider/createComponentStyles` perfectly, so that is updated
- font renderer is deprecated and replaced by [fela-plugin-embedded](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-embedded), @koddsson should like this
- no need to specify style nodes, fela is now smarter and creates its own nodes automatically (one node for rules, one node for every media query, one node for fonts, ... -> better performance)
- should remove a lot of React.PropType warnings, there are still some left, I'm actually not sure where they are coming from
- fixes fela validator that was unhappy with any media queries
- tree shaking

(The biggest change in v5 fela in on the background. It now uses lerna and does builds correctly. Also, it has better test coverage.)

I already have (tested) PRs ready for next and styleguide once this is published.