### PR TITLE
#219 migrate cf-component-table to fela

### DIFF
--- a/packages/cf-builder-table/src/TableBuilder.js
+++ b/packages/cf-builder-table/src/TableBuilder.js
@@ -43,7 +43,7 @@ class TableBuilder extends React.Component {
           {rows.map(row => {
             const type = flashes[row.id] || row.type;
             return (
-              <TableRow key={row.id} type={type} accent={row.accent}>
+              <TableRow key={row.id} type={type}>
                 {columns.map(column => {
                   return column.cell(row.cells);
                 })}

--- a/packages/cf-builder-table/src/TableBuilderPropTypes.js
+++ b/packages/cf-builder-table/src/TableBuilderPropTypes.js
@@ -5,8 +5,7 @@ import { TablePropTypes } from 'cf-component-table';
 const row = PropTypes.shape({
   id: PropTypes.string.isRequired,
   cells: PropTypes.object.isRequired,
-  type: TablePropTypes.rowType,
-  accent: TablePropTypes.rowAccent
+  type: TablePropTypes.rowType
 });
 
 const rows = PropTypes.arrayOf(row);

--- a/packages/cf-builder-table/test/TableBuilder.js
+++ b/packages/cf-builder-table/test/TableBuilder.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
@@ -15,6 +15,7 @@ import {
   TableRow,
   TableCell
 } from '../../cf-component-table/src/index';
+import { felaTestContext } from 'cf-style-provider';
 
 let store;
 
@@ -28,88 +29,97 @@ beforeEach(() => {
 });
 
 test('should render a table', () => {
-  const component = renderer.create(
+  const wrapper = mount(
     <Provider store={store}>
-      <TableBuilder tableName="test-table" rows={[]} columns={[]} />
+      {felaTestContext(
+        <TableBuilder tableName="test-table" rows={[]} columns={[]} />
+      )}
     </Provider>
   );
 
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(toJSON(wrapper)).toMatchSnapshot();
 });
 
 test('should render the dataset in columns', () => {
-  const component = renderer.create(
+  const wrapper = mount(
     <Provider store={store}>
-      <TableBuilder
-        tableName="test-table"
-        rows={[
-          { id: '1', cells: { name: 'Foo', value: 'foo' } },
-          { id: '2', cells: { name: 'Bar', value: 'bar' } }
-        ]}
-        columns={[
-          {
-            label: 'Name',
-            cell: cells => {
-              return <TableCell key="name">{cells.name}</TableCell>;
+      {felaTestContext(
+        <TableBuilder
+          tableName="test-table"
+          rows={[
+            { id: '1', cells: { name: 'Foo', value: 'foo' } },
+            { id: '2', cells: { name: 'Bar', value: 'bar' } }
+          ]}
+          columns={[
+            {
+              label: 'Name',
+              cell: cells => {
+                return <TableCell key="name">{cells.name}</TableCell>;
+              }
+            },
+            {
+              label: 'Value',
+              cell: cells => {
+                return <TableCell key="value">{cells.value}</TableCell>;
+              }
             }
-          },
-          {
-            label: 'Value',
-            cell: cells => {
-              return <TableCell key="value">{cells.value}</TableCell>;
-            }
-          }
-        ]}
-      />
+          ]}
+        />
+      )}
     </Provider>
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(toJSON(wrapper)).toMatchSnapshot();
 });
 
 test('should support table props', () => {
-  const component = renderer.create(
+  const wrapper = mount(
     <Provider store={store}>
-      <TableBuilder
-        tableName="test-table"
-        rows={[]}
-        columns={[]}
-        striped
-        hover
-        bordered
-        condensed
-      />
+      {felaTestContext(
+        <TableBuilder
+          tableName="test-table"
+          rows={[]}
+          columns={[]}
+          striped
+          hover
+          bordered
+          condensed
+        />
+      )}
     </Provider>
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(toJSON(wrapper)).toMatchSnapshot();
 });
 
 test('should support row type/accent', () => {
-  const component = renderer.create(
+  const wrapper = mount(
     <Provider store={store}>
-      <TableBuilder
-        tableName="test-table"
-        rows={[
-          { id: '1', type: 'success', cells: {} },
-          { id: '2', accent: 'red', cells: {} }
-        ]}
-        columns={[]}
-      />
+      {felaTestContext(
+        <TableBuilder
+          tableName="test-table"
+          rows={[
+            { id: '1', type: 'success', cells: {} },
+            { id: '2', accent: 'red', cells: {} }
+          ]}
+          columns={[]}
+        />
+      )}
     </Provider>
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(toJSON(wrapper)).toMatchSnapshot();
 });
 
 test('should support flashes', () => {
   const wrapper = mount(
     <Provider store={store}>
-      <TableBuilder
-        tableName="test-table"
-        rows={[{ id: '1', cells: {} }, { id: '2', cells: {} }]}
-        columns={[]}
-      />
+      {felaTestContext(
+        <TableBuilder
+          tableName="test-table"
+          rows={[{ id: '1', cells: {} }, { id: '2', cells: {} }]}
+          columns={[]}
+        />
+      )}
     </Provider>
   );
   store.dispatch(tableActions.flashRow('test-table', '1', 'success'));
-  const row = wrapper.find('tbody').find('tr').at(0);
-  expect(row.prop('className')).toBe('cf-table__row cf-table__row--success');
+  expect(toJSON(wrapper)).toMatchSnapshot();
 });

--- a/packages/cf-builder-table/test/TableBuilder.js
+++ b/packages/cf-builder-table/test/TableBuilder.js
@@ -15,7 +15,7 @@ import {
   TableRow,
   TableCell
 } from '../../cf-component-table/src/index';
-import { felaTestContext } from 'cf-style-provider';
+import felaTestContext from 'cf-style-provider/src/felaTestContext';
 
 let store;
 

--- a/packages/cf-builder-table/test/__snapshots__/TableBuilder.js.snap
+++ b/packages/cf-builder-table/test/__snapshots__/TableBuilder.js.snap
@@ -22,10 +22,10 @@ exports[`should render a table 1`] = `
           "_renderStyleToCache": [Function],
           "_renderStyleToClassNames": [Function],
           "cache": Object {
-            "1b0jccb": true,
-            "46sr0r": true,
-            "d1fi02": true,
-            "zos2pn": true,
+            "cf-1b0jccb": true,
+            "cf-46sr0r": true,
+            "cf-d1fi02": true,
+            "cf-zos2pn": true,
           },
           "clear": [Function],
           "fontFaces": "",
@@ -41,51 +41,51 @@ exports[`should render a table 1`] = `
           ],
           "mediaQueryOrder": Array [],
           "mediaRules": Object {
-            "(max-width: 47.2em)": ".46sr0r {
+            "(max-width: 47.2em)": ".cf-46sr0r {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block;
           width: 100%;
           box-sizing: border-box
         }",
-            "screen and (max-width: 47.2em)": ".46sr0r {
+            "screen and (max-width: 47.2em)": ".cf-46sr0r {
           display: block
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: none
         }
         
-        .1b0jccb:after {
+        .cf-1b0jccb:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block
         }",
           },
@@ -104,7 +104,7 @@ exports[`should render a table 1`] = `
           "renderRule": [Function],
           "renderStatic": [Function],
           "renderToString": [Function],
-          "rules": ".46sr0r {
+          "rules": ".cf-46sr0r {
           background: #fff;
           border-collapse: collapse;
           border-spacing: 0px;
@@ -112,35 +112,35 @@ exports[`should render a table 1`] = `
           width: 100%
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           background: #dedede
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           border-color: #dedede
         }",
-          "selectorPrefix": "",
+          "selectorPrefix": "cf-",
           "statics": "",
           "styleNodes": Object {
             "RULE": <style
               data-fela-type="RULE"
               type="text/css"
         >
-              .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede }
+              .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-d1fi02 { background: #dedede } .cf-1b0jccb { border-color: #dedede }
         </style>,
             "RULE(max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="(max-width: 47.2em)"
         >
-              .46sr0r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box }
+              .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-d1fi02 { display: block; width: 100%; box-sizing: border-box } .cf-1b0jccb { display: block; width: 100%; box-sizing: border-box } .cf-zos2pn { display: block; width: 100%; box-sizing: border-box }
         </style>,
             "RULEscreen and (max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="screen and (max-width: 47.2em)"
         >
-              .46sr0r { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .zos2pn { display: block }
+              .cf-46sr0r { display: block } .cf-d1fi02 { display: none } .cf-1b0jccb:after { content: ""; display: table; clear: both } .cf-1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-zos2pn { display: block }
         </style>,
           },
           "subscribe": [Function],
@@ -277,14 +277,14 @@ exports[`should render a table 1`] = `
                 <Table
                   bare={false}
                   bordered={true}
-                  className="46sr0r"
+                  className="cf-46sr0r"
                   condensed={false}
                   hover={false}
                   is="table"
                   striped={false}
                 >
                   <table
-                    className="46sr0r"
+                    className="cf-46sr0r"
                   >
                     <ThemedComponent
                       bare={false}
@@ -303,14 +303,14 @@ exports[`should render a table 1`] = `
                         <TableHead
                           bare={false}
                           bordered={true}
-                          className="d1fi02"
+                          className="cf-d1fi02"
                           condensed={false}
                           hover={false}
                           is="thead"
                           striped={false}
                         >
                           <thead
-                            className="d1fi02"
+                            className="cf-d1fi02"
                           >
                             <ThemedComponent
                               bare={false}
@@ -333,7 +333,7 @@ exports[`should render a table 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="1b0jccb"
+                                  className="cf-1b0jccb"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -343,7 +343,7 @@ exports[`should render a table 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="1b0jccb"
+                                    className="cf-1b0jccb"
                                   />
                                 </TableRow>
                               </FelaComponent>
@@ -369,14 +369,14 @@ exports[`should render a table 1`] = `
                         <TableBody
                           bare={false}
                           bordered={true}
-                          className="zos2pn"
+                          className="cf-zos2pn"
                           condensed={false}
                           hover={false}
                           is="tbody"
                           striped={false}
                         >
                           <tbody
-                            className="zos2pn"
+                            className="cf-zos2pn"
                           />
                         </TableBody>
                       </FelaComponent>
@@ -415,21 +415,21 @@ exports[`should render the dataset in columns 1`] = `
           "_renderStyleToCache": [Function],
           "_renderStyleToClassNames": [Function],
           "cache": Object {
-            "1b0jccb": true,
-            "1c6l5ki": true,
-            "1f59ksd": true,
-            "1fm7xdg": true,
-            "1k2myrb": true,
-            "1uiy02g": true,
-            "1ypdp8g": true,
-            "46sr0r": true,
-            "7ul4z3": true,
-            "9x0t0g": true,
-            "9yqouo": true,
-            "d1fi02": true,
-            "g0oihw": true,
-            "t9kph0": true,
-            "zos2pn": true,
+            "cf-1b0jccb": true,
+            "cf-1c6l5ki": true,
+            "cf-1f59ksd": true,
+            "cf-1fm7xdg": true,
+            "cf-1k2myrb": true,
+            "cf-1uiy02g": true,
+            "cf-1ypdp8g": true,
+            "cf-46sr0r": true,
+            "cf-7ul4z3": true,
+            "cf-9x0t0g": true,
+            "cf-9yqouo": true,
+            "cf-d1fi02": true,
+            "cf-g0oihw": true,
+            "cf-t9kph0": true,
+            "cf-zos2pn": true,
           },
           "clear": [Function],
           "fontFaces": "",
@@ -445,125 +445,125 @@ exports[`should render the dataset in columns 1`] = `
           ],
           "mediaQueryOrder": Array [],
           "mediaRules": Object {
-            "(max-width: 47.2em)": ".46sr0r {
+            "(max-width: 47.2em)": ".cf-46sr0r {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .9x0t0g {
+        .cf-9x0t0g {
           display: block;
           width: 100%;
           box-sizing: border-box;
           border-top-width: 0px
         }
         
-        .7ul4z3 {
+        .cf-7ul4z3 {
           display: block;
           width: 100%;
           box-sizing: border-box;
           border-top-width: 0px
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1c6l5ki {
+        .cf-1c6l5ki {
           display: block;
           width: 100%;
           box-sizing: border-box;
           border-top-width: 0px
         }
         
-        .1f59ksd {
+        .cf-1f59ksd {
           display: block;
           width: 100%;
           box-sizing: border-box;
           border-top-width: 0px
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1fm7xdg {
+        .cf-1fm7xdg {
           display: block;
           width: 100%;
           box-sizing: border-box;
           border-top-width: 0px
         }
         
-        .1ypdp8g {
+        .cf-1ypdp8g {
           display: block;
           width: 100%;
           box-sizing: border-box;
           border-top-width: 0px
         }
         
-        .t9kph0 {
+        .cf-t9kph0 {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .g0oihw {
+        .cf-g0oihw {
           display: block;
           width: 100%;
           box-sizing: border-box;
           border-top-width: 0px
         }
         
-        .9yqouo {
+        .cf-9yqouo {
           display: block;
           width: 100%;
           box-sizing: border-box;
           border-top-width: 0px
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           display: block;
           width: 100%;
           box-sizing: border-box
         }",
-            "screen and (max-width: 47.2em)": ".46sr0r {
+            "screen and (max-width: 47.2em)": ".cf-46sr0r {
           display: block
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: none
         }
         
-        .1b0jccb:after {
+        .cf-1b0jccb:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .9x0t0g {
+        .cf-9x0t0g {
           display: block;
           border: none;
           float: left;
@@ -571,7 +571,7 @@ exports[`should render the dataset in columns 1`] = `
           padding: 0px
         }
         
-        .7ul4z3 {
+        .cf-7ul4z3 {
           display: block;
           border: none;
           float: left;
@@ -579,11 +579,11 @@ exports[`should render the dataset in columns 1`] = `
           padding: 0px
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block
         }
         
-        .1c6l5ki {
+        .cf-1c6l5ki {
           display: block;
           border: none;
           float: left;
@@ -591,7 +591,7 @@ exports[`should render the dataset in columns 1`] = `
           padding: 0px
         }
         
-        .1f59ksd {
+        .cf-1f59ksd {
           display: block;
           border: none;
           float: left;
@@ -599,20 +599,20 @@ exports[`should render the dataset in columns 1`] = `
           padding: 0px
         }
         
-        .1k2myrb:after {
+        .cf-1k2myrb:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           display: block;
           padding: 0.73333333333rem;
           border-top: 1px solid #dedede;
           background-color: #ccc
         }
         
-        .1fm7xdg {
+        .cf-1fm7xdg {
           display: block;
           border: none;
           float: left;
@@ -620,7 +620,7 @@ exports[`should render the dataset in columns 1`] = `
           padding: 0px
         }
         
-        .1ypdp8g {
+        .cf-1ypdp8g {
           display: block;
           border: none;
           float: left;
@@ -628,24 +628,24 @@ exports[`should render the dataset in columns 1`] = `
           padding: 0px
         }
         
-        .t9kph0:after {
+        .cf-t9kph0:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .t9kph0:hover> td {
+        .cf-t9kph0:hover> td {
           background-color: transparent
         }
         
-        .t9kph0 {
+        .cf-t9kph0 {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .g0oihw {
+        .cf-g0oihw {
           display: block;
           border: none;
           float: left;
@@ -653,7 +653,7 @@ exports[`should render the dataset in columns 1`] = `
           padding: 0px
         }
         
-        .9yqouo {
+        .cf-9yqouo {
           display: block;
           border: none;
           float: left;
@@ -661,17 +661,17 @@ exports[`should render the dataset in columns 1`] = `
           padding: 0px
         }
         
-        .1uiy02g:after {
+        .cf-1uiy02g:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1uiy02g:hover> td {
+        .cf-1uiy02g:hover> td {
           background-color: transparent
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           display: block;
           padding: 0.73333333333rem;
           border-top: 1px solid #dedede;
@@ -693,7 +693,7 @@ exports[`should render the dataset in columns 1`] = `
           "renderRule": [Function],
           "renderStatic": [Function],
           "renderToString": [Function],
-          "rules": ".46sr0r {
+          "rules": ".cf-46sr0r {
           background: #fff;
           border-collapse: collapse;
           border-spacing: 0px;
@@ -701,19 +701,19 @@ exports[`should render the dataset in columns 1`] = `
           width: 100%
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           background: #dedede
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           border-color: #dedede
         }
         
-        .9x0t0g:first-letter {
+        .cf-9x0t0g:first-letter {
           text-transform: capitalize
         }
         
-        .9x0t0g {
+        .cf-9x0t0g {
           border-top: 1px solid #dedede;
           line-height: 1.5;
           padding: 0.73333333333rem;
@@ -726,11 +726,11 @@ exports[`should render the dataset in columns 1`] = `
           font-weight: 600
         }
         
-        .7ul4z3:first-letter {
+        .cf-7ul4z3:first-letter {
           text-transform: capitalize
         }
         
-        .7ul4z3 {
+        .cf-7ul4z3 {
           border-top: 1px solid #dedede;
           line-height: 1.5;
           padding: 0.73333333333rem;
@@ -743,7 +743,7 @@ exports[`should render the dataset in columns 1`] = `
           font-weight: 600
         }
         
-        .1c6l5ki {
+        .cf-1c6l5ki {
           border-top: 1px solid #dedede;
           line-height: 1.5;
           padding: 0.73333333333rem;
@@ -754,7 +754,7 @@ exports[`should render the dataset in columns 1`] = `
           border-left: 1px solid #dedede
         }
         
-        .1f59ksd {
+        .cf-1f59ksd {
           border-top: 1px solid #dedede;
           line-height: 1.5;
           padding: 0.73333333333rem;
@@ -765,15 +765,15 @@ exports[`should render the dataset in columns 1`] = `
           border-left: 1px solid #dedede
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           border-color: #dedede
         }
         
-        .1fm7xdg:first-letter {
+        .cf-1fm7xdg:first-letter {
           text-transform: capitalize
         }
         
-        .1fm7xdg {
+        .cf-1fm7xdg {
           border-top: 0px;
           line-height: 1.5;
           padding: 0.73333333333rem;
@@ -787,11 +787,11 @@ exports[`should render the dataset in columns 1`] = `
           border-top-left-radius: 2px
         }
         
-        .1ypdp8g:first-letter {
+        .cf-1ypdp8g:first-letter {
           text-transform: capitalize
         }
         
-        .1ypdp8g {
+        .cf-1ypdp8g {
           border-top: 0px;
           line-height: 1.5;
           padding: 0.73333333333rem;
@@ -805,11 +805,11 @@ exports[`should render the dataset in columns 1`] = `
           border-top-right-radius: 2px
         }
         
-        .t9kph0 {
+        .cf-t9kph0 {
           border-color: #dedede
         }
         
-        .g0oihw {
+        .cf-g0oihw {
           border-top: 0px;
           line-height: 1.5;
           padding: 0.73333333333rem;
@@ -821,7 +821,7 @@ exports[`should render the dataset in columns 1`] = `
           border-left: 1px solid #dedede
         }
         
-        .9yqouo {
+        .cf-9yqouo {
           border-top: 0px;
           line-height: 1.5;
           padding: 0.73333333333rem;
@@ -833,31 +833,31 @@ exports[`should render the dataset in columns 1`] = `
           border-left: 1px solid #dedede
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           border-color: #dedede
         }",
-          "selectorPrefix": "",
+          "selectorPrefix": "cf-",
           "statics": "",
           "styleNodes": Object {
             "RULE": <style
               data-fela-type="RULE"
               type="text/css"
         >
-              .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede } .9x0t0g:first-letter { text-transform: capitalize } .9x0t0g { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600 } .7ul4z3:first-letter { text-transform: capitalize } .7ul4z3 { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600 } .1c6l5ki { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede } .1f59ksd { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede } .1k2myrb { border-color: #dedede } .1fm7xdg:first-letter { text-transform: capitalize } .1fm7xdg { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600; border-top-left-radius: 2px } .1ypdp8g:first-letter { text-transform: capitalize } .1ypdp8g { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600; border-top-right-radius: 2px } .t9kph0 { border-color: #dedede } .g0oihw { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-top-left-radius: 2px; border-left: 1px solid #dedede } .9yqouo { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-top-right-radius: 2px; border-left: 1px solid #dedede } .1uiy02g { border-color: #dedede }
+              .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-d1fi02 { background: #dedede } .cf-1b0jccb { border-color: #dedede } .cf-9x0t0g:first-letter { text-transform: capitalize } .cf-9x0t0g { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600 } .cf-7ul4z3:first-letter { text-transform: capitalize } .cf-7ul4z3 { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600 } .cf-1c6l5ki { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede } .cf-1f59ksd { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede } .cf-1k2myrb { border-color: #dedede } .cf-1fm7xdg:first-letter { text-transform: capitalize } .cf-1fm7xdg { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600; border-top-left-radius: 2px } .cf-1ypdp8g:first-letter { text-transform: capitalize } .cf-1ypdp8g { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600; border-top-right-radius: 2px } .cf-t9kph0 { border-color: #dedede } .cf-g0oihw { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-top-left-radius: 2px; border-left: 1px solid #dedede } .cf-9yqouo { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-top-right-radius: 2px; border-left: 1px solid #dedede } .cf-1uiy02g { border-color: #dedede }
         </style>,
             "RULE(max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="(max-width: 47.2em)"
         >
-              .46sr0r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .9x0t0g { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .7ul4z3 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .zos2pn { display: block; width: 100%; box-sizing: border-box } .1c6l5ki { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .1f59ksd { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .1k2myrb { display: block; width: 100%; box-sizing: border-box } .1fm7xdg { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .1ypdp8g { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .t9kph0 { display: block; width: 100%; box-sizing: border-box } .g0oihw { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .9yqouo { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .1uiy02g { display: block; width: 100%; box-sizing: border-box }
+              .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-d1fi02 { display: block; width: 100%; box-sizing: border-box } .cf-1b0jccb { display: block; width: 100%; box-sizing: border-box } .cf-9x0t0g { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-7ul4z3 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-zos2pn { display: block; width: 100%; box-sizing: border-box } .cf-1c6l5ki { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-1f59ksd { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-1k2myrb { display: block; width: 100%; box-sizing: border-box } .cf-1fm7xdg { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-1ypdp8g { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-t9kph0 { display: block; width: 100%; box-sizing: border-box } .cf-g0oihw { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-9yqouo { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-1uiy02g { display: block; width: 100%; box-sizing: border-box }
         </style>,
             "RULEscreen and (max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="screen and (max-width: 47.2em)"
         >
-              .46sr0r { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .9x0t0g { display: block; border: none; float: left; clear: left; padding: 0px } .7ul4z3 { display: block; border: none; float: left; clear: left; padding: 0px } .zos2pn { display: block } .1c6l5ki { display: block; border: none; float: left; clear: left; padding: 0px } .1f59ksd { display: block; border: none; float: left; clear: left; padding: 0px } .1k2myrb:after { content: ""; display: table; clear: both } .1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .1fm7xdg { display: block; border: none; float: left; clear: left; padding: 0px } .1ypdp8g { display: block; border: none; float: left; clear: left; padding: 0px } .t9kph0:after { content: ""; display: table; clear: both } .t9kph0:hover> td { background-color: transparent } .t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .g0oihw { display: block; border: none; float: left; clear: left; padding: 0px } .9yqouo { display: block; border: none; float: left; clear: left; padding: 0px } .1uiy02g:after { content: ""; display: table; clear: both } .1uiy02g:hover> td { background-color: transparent } .1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc }
+              .cf-46sr0r { display: block } .cf-d1fi02 { display: none } .cf-1b0jccb:after { content: ""; display: table; clear: both } .cf-1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-9x0t0g { display: block; border: none; float: left; clear: left; padding: 0px } .cf-7ul4z3 { display: block; border: none; float: left; clear: left; padding: 0px } .cf-zos2pn { display: block } .cf-1c6l5ki { display: block; border: none; float: left; clear: left; padding: 0px } .cf-1f59ksd { display: block; border: none; float: left; clear: left; padding: 0px } .cf-1k2myrb:after { content: ""; display: table; clear: both } .cf-1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .cf-1fm7xdg { display: block; border: none; float: left; clear: left; padding: 0px } .cf-1ypdp8g { display: block; border: none; float: left; clear: left; padding: 0px } .cf-t9kph0:after { content: ""; display: table; clear: both } .cf-t9kph0:hover> td { background-color: transparent } .cf-t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-g0oihw { display: block; border: none; float: left; clear: left; padding: 0px } .cf-9yqouo { display: block; border: none; float: left; clear: left; padding: 0px } .cf-1uiy02g:after { content: ""; display: table; clear: both } .cf-1uiy02g:hover> td { background-color: transparent } .cf-1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc }
         </style>,
           },
           "subscribe": [Function],
@@ -1050,14 +1050,14 @@ exports[`should render the dataset in columns 1`] = `
                 <Table
                   bare={false}
                   bordered={true}
-                  className="46sr0r"
+                  className="cf-46sr0r"
                   condensed={false}
                   hover={false}
                   is="table"
                   striped={false}
                 >
                   <table
-                    className="46sr0r"
+                    className="cf-46sr0r"
                   >
                     <ThemedComponent
                       bare={false}
@@ -1076,14 +1076,14 @@ exports[`should render the dataset in columns 1`] = `
                         <TableHead
                           bare={false}
                           bordered={true}
-                          className="d1fi02"
+                          className="cf-d1fi02"
                           condensed={false}
                           hover={false}
                           is="thead"
                           striped={false}
                         >
                           <thead
-                            className="d1fi02"
+                            className="cf-d1fi02"
                           >
                             <ThemedComponent
                               bare={false}
@@ -1106,7 +1106,7 @@ exports[`should render the dataset in columns 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="1b0jccb"
+                                  className="cf-1b0jccb"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -1116,7 +1116,7 @@ exports[`should render the dataset in columns 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="1b0jccb"
+                                    className="cf-1b0jccb"
                                   >
                                     <ThemedComponent
                                       bare={false}
@@ -1144,7 +1144,7 @@ exports[`should render the dataset in columns 1`] = `
                                           bare={false}
                                           bordered={true}
                                           cellIndex={0}
-                                          className="1fm7xdg"
+                                          className="cf-1fm7xdg"
                                           condensed={false}
                                           hover={false}
                                           is="th"
@@ -1154,7 +1154,7 @@ exports[`should render the dataset in columns 1`] = `
                                           theadIndex={0}
                                         >
                                           <th
-                                            className="1fm7xdg"
+                                            className="cf-1fm7xdg"
                                           >
                                             Name
                                           </th>
@@ -1187,7 +1187,7 @@ exports[`should render the dataset in columns 1`] = `
                                           bare={false}
                                           bordered={true}
                                           cellIndex={-1}
-                                          className="1ypdp8g"
+                                          className="cf-1ypdp8g"
                                           condensed={false}
                                           hover={false}
                                           is="th"
@@ -1197,7 +1197,7 @@ exports[`should render the dataset in columns 1`] = `
                                           theadIndex={0}
                                         >
                                           <th
-                                            className="1ypdp8g"
+                                            className="cf-1ypdp8g"
                                           >
                                             Value
                                           </th>
@@ -1229,14 +1229,14 @@ exports[`should render the dataset in columns 1`] = `
                         <TableBody
                           bare={false}
                           bordered={true}
-                          className="zos2pn"
+                          className="cf-zos2pn"
                           condensed={false}
                           hover={false}
                           is="tbody"
                           striped={false}
                         >
                           <tbody
-                            className="zos2pn"
+                            className="cf-zos2pn"
                           >
                             <ThemedComponent
                               bare={false}
@@ -1259,7 +1259,7 @@ exports[`should render the dataset in columns 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="t9kph0"
+                                  className="cf-t9kph0"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -1269,7 +1269,7 @@ exports[`should render the dataset in columns 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="t9kph0"
+                                    className="cf-t9kph0"
                                   >
                                     <ThemedComponent
                                       bare={false}
@@ -1298,7 +1298,7 @@ exports[`should render the dataset in columns 1`] = `
                                           bare={false}
                                           bordered={true}
                                           cellIndex={0}
-                                          className="g0oihw"
+                                          className="cf-g0oihw"
                                           condensed={false}
                                           hover={false}
                                           is="td"
@@ -1308,7 +1308,7 @@ exports[`should render the dataset in columns 1`] = `
                                           tbodyIndex={0}
                                         >
                                           <td
-                                            className="g0oihw"
+                                            className="cf-g0oihw"
                                           >
                                             Foo
                                           </td>
@@ -1342,7 +1342,7 @@ exports[`should render the dataset in columns 1`] = `
                                           bare={false}
                                           bordered={true}
                                           cellIndex={-1}
-                                          className="9yqouo"
+                                          className="cf-9yqouo"
                                           condensed={false}
                                           hover={false}
                                           is="td"
@@ -1352,7 +1352,7 @@ exports[`should render the dataset in columns 1`] = `
                                           tbodyIndex={0}
                                         >
                                           <td
-                                            className="9yqouo"
+                                            className="cf-9yqouo"
                                           >
                                             foo
                                           </td>
@@ -1384,7 +1384,7 @@ exports[`should render the dataset in columns 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="1uiy02g"
+                                  className="cf-1uiy02g"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -1394,7 +1394,7 @@ exports[`should render the dataset in columns 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="1uiy02g"
+                                    className="cf-1uiy02g"
                                   >
                                     <ThemedComponent
                                       bare={false}
@@ -1423,7 +1423,7 @@ exports[`should render the dataset in columns 1`] = `
                                           bare={false}
                                           bordered={true}
                                           cellIndex={0}
-                                          className="1c6l5ki"
+                                          className="cf-1c6l5ki"
                                           condensed={false}
                                           hover={false}
                                           is="td"
@@ -1433,7 +1433,7 @@ exports[`should render the dataset in columns 1`] = `
                                           tbodyIndex={0}
                                         >
                                           <td
-                                            className="1c6l5ki"
+                                            className="cf-1c6l5ki"
                                           >
                                             Bar
                                           </td>
@@ -1467,7 +1467,7 @@ exports[`should render the dataset in columns 1`] = `
                                           bare={false}
                                           bordered={true}
                                           cellIndex={-1}
-                                          className="1f59ksd"
+                                          className="cf-1f59ksd"
                                           condensed={false}
                                           hover={false}
                                           is="td"
@@ -1477,7 +1477,7 @@ exports[`should render the dataset in columns 1`] = `
                                           tbodyIndex={0}
                                         >
                                           <td
-                                            className="1f59ksd"
+                                            className="cf-1f59ksd"
                                           >
                                             bar
                                           </td>
@@ -1526,14 +1526,14 @@ exports[`should support flashes 1`] = `
           "_renderStyleToCache": [Function],
           "_renderStyleToClassNames": [Function],
           "cache": Object {
-            "14uu5dt": true,
-            "1b0jccb": true,
-            "1k2myrb": true,
-            "1uiy02g": true,
-            "46sr0r": true,
-            "d1fi02": true,
-            "t9kph0": true,
-            "zos2pn": true,
+            "cf-14uu5dt": true,
+            "cf-1b0jccb": true,
+            "cf-1k2myrb": true,
+            "cf-1uiy02g": true,
+            "cf-46sr0r": true,
+            "cf-d1fi02": true,
+            "cf-t9kph0": true,
+            "cf-zos2pn": true,
           },
           "clear": [Function],
           "fontFaces": "",
@@ -1549,136 +1549,136 @@ exports[`should support flashes 1`] = `
           ],
           "mediaQueryOrder": Array [],
           "mediaRules": Object {
-            "(max-width: 47.2em)": ".46sr0r {
+            "(max-width: 47.2em)": ".cf-46sr0r {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .t9kph0 {
+        .cf-t9kph0 {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .14uu5dt {
+        .cf-14uu5dt {
           display: block;
           width: 100%;
           box-sizing: border-box
         }",
-            "screen and (max-width: 47.2em)": ".46sr0r {
+            "screen and (max-width: 47.2em)": ".cf-46sr0r {
           display: block
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: none
         }
         
-        .1b0jccb:after {
+        .cf-1b0jccb:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block
         }
         
-        .1k2myrb:after {
+        .cf-1k2myrb:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           display: block;
           padding: 0.73333333333rem;
           border-top: 1px solid #dedede;
           background-color: #ccc
         }
         
-        .t9kph0:after {
+        .cf-t9kph0:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .t9kph0:hover> td {
+        .cf-t9kph0:hover> td {
           background-color: transparent
         }
         
-        .t9kph0 {
+        .cf-t9kph0 {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .1uiy02g:after {
+        .cf-1uiy02g:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1uiy02g:hover> td {
+        .cf-1uiy02g:hover> td {
           background-color: transparent
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           display: block;
           padding: 0.73333333333rem;
           border-top: 1px solid #dedede;
           background-color: #ccc
         }
         
-        .14uu5dt:after {
+        .cf-14uu5dt:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .14uu5dt:hover> td {
+        .cf-14uu5dt:hover> td {
           background-color: transparent
         }
         
-        .14uu5dt {
+        .cf-14uu5dt {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
@@ -1700,7 +1700,7 @@ exports[`should support flashes 1`] = `
           "renderRule": [Function],
           "renderStatic": [Function],
           "renderToString": [Function],
-          "rules": ".46sr0r {
+          "rules": ".cf-46sr0r {
           background: #fff;
           border-collapse: collapse;
           border-spacing: 0px;
@@ -1708,52 +1708,52 @@ exports[`should support flashes 1`] = `
           width: 100%
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           background: #dedede
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           border-color: #dedede
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           border-color: #dedede
         }
         
-        .t9kph0 {
+        .cf-t9kph0 {
           border-color: #dedede
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           border-color: #dedede
         }
         
-        .14uu5dt {
+        .cf-14uu5dt {
           border-color: #b0d466;
           background-color: #bada7a
         }",
-          "selectorPrefix": "",
+          "selectorPrefix": "cf-",
           "statics": "",
           "styleNodes": Object {
             "RULE": <style
               data-fela-type="RULE"
               type="text/css"
         >
-              .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede } .1k2myrb { border-color: #dedede } .t9kph0 { border-color: #dedede } .1uiy02g { border-color: #dedede } .14uu5dt { border-color: #b0d466; background-color: #bada7a }
+              .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-d1fi02 { background: #dedede } .cf-1b0jccb { border-color: #dedede } .cf-1k2myrb { border-color: #dedede } .cf-t9kph0 { border-color: #dedede } .cf-1uiy02g { border-color: #dedede } .cf-14uu5dt { border-color: #b0d466; background-color: #bada7a }
         </style>,
             "RULE(max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="(max-width: 47.2em)"
         >
-              .46sr0r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box } .1k2myrb { display: block; width: 100%; box-sizing: border-box } .t9kph0 { display: block; width: 100%; box-sizing: border-box } .1uiy02g { display: block; width: 100%; box-sizing: border-box } .14uu5dt { display: block; width: 100%; box-sizing: border-box }
+              .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-d1fi02 { display: block; width: 100%; box-sizing: border-box } .cf-1b0jccb { display: block; width: 100%; box-sizing: border-box } .cf-zos2pn { display: block; width: 100%; box-sizing: border-box } .cf-1k2myrb { display: block; width: 100%; box-sizing: border-box } .cf-t9kph0 { display: block; width: 100%; box-sizing: border-box } .cf-1uiy02g { display: block; width: 100%; box-sizing: border-box } .cf-14uu5dt { display: block; width: 100%; box-sizing: border-box }
         </style>,
             "RULEscreen and (max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="screen and (max-width: 47.2em)"
         >
-              .46sr0r { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .zos2pn { display: block } .1k2myrb:after { content: ""; display: table; clear: both } .1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .t9kph0:after { content: ""; display: table; clear: both } .t9kph0:hover> td { background-color: transparent } .t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .1uiy02g:after { content: ""; display: table; clear: both } .1uiy02g:hover> td { background-color: transparent } .1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .14uu5dt:after { content: ""; display: table; clear: both } .14uu5dt:hover> td { background-color: transparent } .14uu5dt { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
+              .cf-46sr0r { display: block } .cf-d1fi02 { display: none } .cf-1b0jccb:after { content: ""; display: table; clear: both } .cf-1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-zos2pn { display: block } .cf-1k2myrb:after { content: ""; display: table; clear: both } .cf-1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .cf-t9kph0:after { content: ""; display: table; clear: both } .cf-t9kph0:hover> td { background-color: transparent } .cf-t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-1uiy02g:after { content: ""; display: table; clear: both } .cf-1uiy02g:hover> td { background-color: transparent } .cf-1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .cf-14uu5dt:after { content: ""; display: table; clear: both } .cf-14uu5dt:hover> td { background-color: transparent } .cf-14uu5dt { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
         </style>,
           },
           "subscribe": [Function],
@@ -1916,14 +1916,14 @@ exports[`should support flashes 1`] = `
                 <Table
                   bare={false}
                   bordered={true}
-                  className="46sr0r"
+                  className="cf-46sr0r"
                   condensed={false}
                   hover={false}
                   is="table"
                   striped={false}
                 >
                   <table
-                    className="46sr0r"
+                    className="cf-46sr0r"
                   >
                     <ThemedComponent
                       bare={false}
@@ -1942,14 +1942,14 @@ exports[`should support flashes 1`] = `
                         <TableHead
                           bare={false}
                           bordered={true}
-                          className="d1fi02"
+                          className="cf-d1fi02"
                           condensed={false}
                           hover={false}
                           is="thead"
                           striped={false}
                         >
                           <thead
-                            className="d1fi02"
+                            className="cf-d1fi02"
                           >
                             <ThemedComponent
                               bare={false}
@@ -1972,7 +1972,7 @@ exports[`should support flashes 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="1b0jccb"
+                                  className="cf-1b0jccb"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -1982,7 +1982,7 @@ exports[`should support flashes 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="1b0jccb"
+                                    className="cf-1b0jccb"
                                   />
                                 </TableRow>
                               </FelaComponent>
@@ -2008,14 +2008,14 @@ exports[`should support flashes 1`] = `
                         <TableBody
                           bare={false}
                           bordered={true}
-                          className="zos2pn"
+                          className="cf-zos2pn"
                           condensed={false}
                           hover={false}
                           is="tbody"
                           striped={false}
                         >
                           <tbody
-                            className="zos2pn"
+                            className="cf-zos2pn"
                           >
                             <ThemedComponent
                               bare={false}
@@ -2040,7 +2040,7 @@ exports[`should support flashes 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="14uu5dt"
+                                  className="cf-14uu5dt"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -2050,7 +2050,7 @@ exports[`should support flashes 1`] = `
                                   type="success"
                                 >
                                   <tr
-                                    className="14uu5dt"
+                                    className="cf-14uu5dt"
                                   />
                                 </TableRow>
                               </FelaComponent>
@@ -2076,7 +2076,7 @@ exports[`should support flashes 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="1uiy02g"
+                                  className="cf-1uiy02g"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -2086,7 +2086,7 @@ exports[`should support flashes 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="1uiy02g"
+                                    className="cf-1uiy02g"
                                   />
                                 </TableRow>
                               </FelaComponent>
@@ -2129,14 +2129,14 @@ exports[`should support row type/accent 1`] = `
           "_renderStyleToCache": [Function],
           "_renderStyleToClassNames": [Function],
           "cache": Object {
-            "14uu5dt": true,
-            "1b0jccb": true,
-            "1k2myrb": true,
-            "1uiy02g": true,
-            "46sr0r": true,
-            "d1fi02": true,
-            "dreiha": true,
-            "zos2pn": true,
+            "cf-14uu5dt": true,
+            "cf-1b0jccb": true,
+            "cf-1k2myrb": true,
+            "cf-1uiy02g": true,
+            "cf-46sr0r": true,
+            "cf-d1fi02": true,
+            "cf-dreiha": true,
+            "cf-zos2pn": true,
           },
           "clear": [Function],
           "fontFaces": "",
@@ -2152,132 +2152,132 @@ exports[`should support row type/accent 1`] = `
           ],
           "mediaQueryOrder": Array [],
           "mediaRules": Object {
-            "(max-width: 47.2em)": ".46sr0r {
+            "(max-width: 47.2em)": ".cf-46sr0r {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .dreiha {
+        .cf-dreiha {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .14uu5dt {
+        .cf-14uu5dt {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           display: block;
           width: 100%;
           box-sizing: border-box
         }",
-            "screen and (max-width: 47.2em)": ".46sr0r {
+            "screen and (max-width: 47.2em)": ".cf-46sr0r {
           display: block
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: none
         }
         
-        .1b0jccb:after {
+        .cf-1b0jccb:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block
         }
         
-        .dreiha:after {
+        .cf-dreiha:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .dreiha {
+        .cf-dreiha {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .1k2myrb:after {
+        .cf-1k2myrb:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           display: block;
           padding: 0.73333333333rem;
           border-top: 1px solid #dedede;
           background-color: #ccc
         }
         
-        .14uu5dt:after {
+        .cf-14uu5dt:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .14uu5dt:hover> td {
+        .cf-14uu5dt:hover> td {
           background-color: transparent
         }
         
-        .14uu5dt {
+        .cf-14uu5dt {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .1uiy02g:after {
+        .cf-1uiy02g:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1uiy02g:hover> td {
+        .cf-1uiy02g:hover> td {
           background-color: transparent
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           display: block;
           padding: 0.73333333333rem;
           border-top: 1px solid #dedede;
@@ -2299,7 +2299,7 @@ exports[`should support row type/accent 1`] = `
           "renderRule": [Function],
           "renderStatic": [Function],
           "renderToString": [Function],
-          "rules": ".46sr0r {
+          "rules": ".cf-46sr0r {
           background: #fff;
           border-collapse: collapse;
           border-spacing: 0px;
@@ -2307,53 +2307,53 @@ exports[`should support row type/accent 1`] = `
           width: 100%
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           background: #dedede
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           border-color: #dedede
         }
         
-        .dreiha {
+        .cf-dreiha {
           border-color: #b0d466;
           background-color: #bada7a
         }
         
-        .1k2myrb {
+        .cf-1k2myrb {
           border-color: #dedede
         }
         
-        .14uu5dt {
+        .cf-14uu5dt {
           border-color: #b0d466;
           background-color: #bada7a
         }
         
-        .1uiy02g {
+        .cf-1uiy02g {
           border-color: #dedede
         }",
-          "selectorPrefix": "",
+          "selectorPrefix": "cf-",
           "statics": "",
           "styleNodes": Object {
             "RULE": <style
               data-fela-type="RULE"
               type="text/css"
         >
-              .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede } .dreiha { border-color: #b0d466; background-color: #bada7a } .1k2myrb { border-color: #dedede } .14uu5dt { border-color: #b0d466; background-color: #bada7a } .1uiy02g { border-color: #dedede }
+              .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-d1fi02 { background: #dedede } .cf-1b0jccb { border-color: #dedede } .cf-dreiha { border-color: #b0d466; background-color: #bada7a } .cf-1k2myrb { border-color: #dedede } .cf-14uu5dt { border-color: #b0d466; background-color: #bada7a } .cf-1uiy02g { border-color: #dedede }
         </style>,
             "RULE(max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="(max-width: 47.2em)"
         >
-              .46sr0r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box } .dreiha { display: block; width: 100%; box-sizing: border-box } .1k2myrb { display: block; width: 100%; box-sizing: border-box } .14uu5dt { display: block; width: 100%; box-sizing: border-box } .1uiy02g { display: block; width: 100%; box-sizing: border-box }
+              .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-d1fi02 { display: block; width: 100%; box-sizing: border-box } .cf-1b0jccb { display: block; width: 100%; box-sizing: border-box } .cf-zos2pn { display: block; width: 100%; box-sizing: border-box } .cf-dreiha { display: block; width: 100%; box-sizing: border-box } .cf-1k2myrb { display: block; width: 100%; box-sizing: border-box } .cf-14uu5dt { display: block; width: 100%; box-sizing: border-box } .cf-1uiy02g { display: block; width: 100%; box-sizing: border-box }
         </style>,
             "RULEscreen and (max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="screen and (max-width: 47.2em)"
         >
-              .46sr0r { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .zos2pn { display: block } .dreiha:after { content: ""; display: table; clear: both } .dreiha { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .1k2myrb:after { content: ""; display: table; clear: both } .1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .14uu5dt:after { content: ""; display: table; clear: both } .14uu5dt:hover> td { background-color: transparent } .14uu5dt { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .1uiy02g:after { content: ""; display: table; clear: both } .1uiy02g:hover> td { background-color: transparent } .1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc }
+              .cf-46sr0r { display: block } .cf-d1fi02 { display: none } .cf-1b0jccb:after { content: ""; display: table; clear: both } .cf-1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-zos2pn { display: block } .cf-dreiha:after { content: ""; display: table; clear: both } .cf-dreiha { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-1k2myrb:after { content: ""; display: table; clear: both } .cf-1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .cf-14uu5dt:after { content: ""; display: table; clear: both } .cf-14uu5dt:hover> td { background-color: transparent } .cf-14uu5dt { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-1uiy02g:after { content: ""; display: table; clear: both } .cf-1uiy02g:hover> td { background-color: transparent } .cf-1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc }
         </style>,
           },
           "subscribe": [Function],
@@ -2516,14 +2516,14 @@ exports[`should support row type/accent 1`] = `
                 <Table
                   bare={false}
                   bordered={true}
-                  className="46sr0r"
+                  className="cf-46sr0r"
                   condensed={false}
                   hover={false}
                   is="table"
                   striped={false}
                 >
                   <table
-                    className="46sr0r"
+                    className="cf-46sr0r"
                   >
                     <ThemedComponent
                       bare={false}
@@ -2542,14 +2542,14 @@ exports[`should support row type/accent 1`] = `
                         <TableHead
                           bare={false}
                           bordered={true}
-                          className="d1fi02"
+                          className="cf-d1fi02"
                           condensed={false}
                           hover={false}
                           is="thead"
                           striped={false}
                         >
                           <thead
-                            className="d1fi02"
+                            className="cf-d1fi02"
                           >
                             <ThemedComponent
                               bare={false}
@@ -2572,7 +2572,7 @@ exports[`should support row type/accent 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="1b0jccb"
+                                  className="cf-1b0jccb"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -2582,7 +2582,7 @@ exports[`should support row type/accent 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="1b0jccb"
+                                    className="cf-1b0jccb"
                                   />
                                 </TableRow>
                               </FelaComponent>
@@ -2608,14 +2608,14 @@ exports[`should support row type/accent 1`] = `
                         <TableBody
                           bare={false}
                           bordered={true}
-                          className="zos2pn"
+                          className="cf-zos2pn"
                           condensed={false}
                           hover={false}
                           is="tbody"
                           striped={false}
                         >
                           <tbody
-                            className="zos2pn"
+                            className="cf-zos2pn"
                           >
                             <ThemedComponent
                               bare={false}
@@ -2640,7 +2640,7 @@ exports[`should support row type/accent 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="14uu5dt"
+                                  className="cf-14uu5dt"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -2650,7 +2650,7 @@ exports[`should support row type/accent 1`] = `
                                   type="success"
                                 >
                                   <tr
-                                    className="14uu5dt"
+                                    className="cf-14uu5dt"
                                   />
                                 </TableRow>
                               </FelaComponent>
@@ -2676,7 +2676,7 @@ exports[`should support row type/accent 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="1uiy02g"
+                                  className="cf-1uiy02g"
                                   condensed={false}
                                   hover={false}
                                   is="tr"
@@ -2686,7 +2686,7 @@ exports[`should support row type/accent 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="1uiy02g"
+                                    className="cf-1uiy02g"
                                   />
                                 </TableRow>
                               </FelaComponent>
@@ -2729,10 +2729,10 @@ exports[`should support table props 1`] = `
           "_renderStyleToCache": [Function],
           "_renderStyleToClassNames": [Function],
           "cache": Object {
-            "127ooxc": true,
-            "1b0jccb": true,
-            "d1fi02": true,
-            "zos2pn": true,
+            "cf-127ooxc": true,
+            "cf-1b0jccb": true,
+            "cf-d1fi02": true,
+            "cf-zos2pn": true,
           },
           "clear": [Function],
           "fontFaces": "",
@@ -2748,51 +2748,51 @@ exports[`should support table props 1`] = `
           ],
           "mediaQueryOrder": Array [],
           "mediaRules": Object {
-            "(max-width: 47.2em)": ".127ooxc {
+            "(max-width: 47.2em)": ".cf-127ooxc {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           width: 100%;
           box-sizing: border-box
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block;
           width: 100%;
           box-sizing: border-box
         }",
-            "screen and (max-width: 47.2em)": ".127ooxc {
+            "screen and (max-width: 47.2em)": ".cf-127ooxc {
           display: block
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
           display: none
         }
         
-        .1b0jccb:after {
+        .cf-1b0jccb:after {
           content: \\"\\";
           display: table;
           clear: both
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
           display: block;
           padding: 0.73333333333rem;
           border-top: none;
           background-color: #ccc
         }
         
-        .zos2pn {
+        .cf-zos2pn {
           display: block
         }",
           },
@@ -2811,7 +2811,7 @@ exports[`should support table props 1`] = `
           "renderRule": [Function],
           "renderStatic": [Function],
           "renderToString": [Function],
-          "rules": ".127ooxc {
+          "rules": ".cf-127ooxc {
           background: #fff;
           border-collapse: separate;
           border-spacing: 0px;
@@ -2823,35 +2823,35 @@ exports[`should support table props 1`] = `
         border-left:0px
         }
         
-        .d1fi02 {
+        .cf-d1fi02 {
         background: #dedede
         }
         
-        .1b0jccb {
+        .cf-1b0jccb {
         border-color: #dedede
         }",
-          "selectorPrefix": "",
+          "selectorPrefix": "cf-",
           "statics": "",
           "styleNodes": Object {
             "RULE": <style
               data-fela-type="RULE"
               type="text/css"
         >
-              .127ooxc { background: #fff; border-collapse: separate; border-spacing: 0px; max-width: 100%; width: 100%; border: 1px solid \${theme.tableBorderColor }; border-left:0px } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede }
+              .cf-127ooxc { background: #fff; border-collapse: separate; border-spacing: 0px; max-width: 100%; width: 100%; border: 1px solid \${theme.tableBorderColor }; border-left:0px } .cf-d1fi02 { background: #dedede } .cf-1b0jccb { border-color: #dedede }
         </style>,
             "RULE(max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="(max-width: 47.2em)"
         >
-              .127ooxc { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box }
+              .cf-127ooxc { display: block; width: 100%; box-sizing: border-box } .cf-d1fi02 { display: block; width: 100%; box-sizing: border-box } .cf-1b0jccb { display: block; width: 100%; box-sizing: border-box } .cf-zos2pn { display: block; width: 100%; box-sizing: border-box }
         </style>,
             "RULEscreen and (max-width: 47.2em)": <style
               data-fela-type="RULE"
               type="text/css"
               media="screen and (max-width: 47.2em)"
         >
-              .127ooxc { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .zos2pn { display: block }
+              .cf-127ooxc { display: block } .cf-d1fi02 { display: none } .cf-1b0jccb:after { content: ""; display: table; clear: both } .cf-1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-zos2pn { display: block }
         </style>,
           },
           "subscribe": [Function],
@@ -3006,14 +3006,14 @@ exports[`should support table props 1`] = `
                 <Table
                   bare={false}
                   bordered={true}
-                  className="127ooxc"
+                  className="cf-127ooxc"
                   condensed={true}
                   hover={true}
                   is="table"
                   striped={true}
                 >
                   <table
-                    className="127ooxc"
+                    className="cf-127ooxc"
                   >
                     <ThemedComponent
                       bare={false}
@@ -3032,14 +3032,14 @@ exports[`should support table props 1`] = `
                         <TableHead
                           bare={false}
                           bordered={true}
-                          className="d1fi02"
+                          className="cf-d1fi02"
                           condensed={true}
                           hover={true}
                           is="thead"
                           striped={true}
                         >
                           <thead
-                            className="d1fi02"
+                            className="cf-d1fi02"
                           >
                             <ThemedComponent
                               bare={false}
@@ -3062,7 +3062,7 @@ exports[`should support table props 1`] = `
                                 <TableRow
                                   bare={false}
                                   bordered={true}
-                                  className="1b0jccb"
+                                  className="cf-1b0jccb"
                                   condensed={true}
                                   hover={true}
                                   is="tr"
@@ -3072,7 +3072,7 @@ exports[`should support table props 1`] = `
                                   type="default"
                                 >
                                   <tr
-                                    className="1b0jccb"
+                                    className="cf-1b0jccb"
                                   />
                                 </TableRow>
                               </FelaComponent>
@@ -3098,14 +3098,14 @@ exports[`should support table props 1`] = `
                         <TableBody
                           bare={false}
                           bordered={true}
-                          className="zos2pn"
+                          className="cf-zos2pn"
                           condensed={true}
                           hover={true}
                           is="tbody"
                           striped={true}
                         >
                           <tbody
-                            className="zos2pn"
+                            className="cf-zos2pn"
                           />
                         </TableBody>
                       </FelaComponent>

--- a/packages/cf-builder-table/test/__snapshots__/TableBuilder.js.snap
+++ b/packages/cf-builder-table/test/__snapshots__/TableBuilder.js.snap
@@ -273,154 +273,117 @@ exports[`should render a table 1`] = `
             tableName="test-table"
           >
             <ThemedComponent>
-              <TableStyles>
-                <TableStyles
-                  _felaRule={[Function]}
-                  passThrough={Array []}
+              <FelaComponent>
+                <Table
+                  bare={false}
+                  bordered={true}
+                  className="46sr0r"
+                  condensed={false}
+                  hover={false}
+                  is="table"
+                  striped={false}
                 >
-                  <Table
-                    bare={false}
-                    bordered={true}
+                  <table
                     className="46sr0r"
-                    condensed={false}
-                    hover={false}
-                    is="table"
-                    striped={false}
                   >
-                    <table
-                      className="46sr0r"
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      striped={false}
                     >
-                      <ThemedComponent
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={false}
                         hover={false}
                         striped={false}
                       >
-                        <TableHeadStyles
+                        <TableHead
                           bare={false}
                           bordered={true}
+                          className="d1fi02"
                           condensed={false}
                           hover={false}
+                          is="thead"
                           striped={false}
                         >
-                          <TableHeadStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={false}
-                            hover={false}
-                            passThrough={Array []}
-                            striped={false}
+                          <thead
+                            className="d1fi02"
                           >
-                            <TableHead
+                            <ThemedComponent
                               bare={false}
                               bordered={true}
-                              className="d1fi02"
                               condensed={false}
                               hover={false}
-                              is="thead"
+                              rowIndex={-0}
                               striped={false}
+                              theadIndex={0}
                             >
-                              <thead
-                                className="d1fi02"
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={-0}
+                                striped={false}
+                                theadIndex={0}
                               >
-                                <ThemedComponent
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="1b0jccb"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={-0}
                                   striped={false}
                                   theadIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={-0}
-                                    striped={false}
-                                    theadIndex={0}
-                                  >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
-                                      bare={false}
-                                      bordered={true}
-                                      condensed={false}
-                                      hover={false}
-                                      passThrough={Array []}
-                                      rowIndex={-0}
-                                      striped={false}
-                                      theadIndex={0}
-                                    >
-                                      <TableRow
-                                        bare={false}
-                                        bordered={true}
-                                        className="1b0jccb"
-                                        condensed={false}
-                                        hover={false}
-                                        is="tr"
-                                        rowIndex={-0}
-                                        striped={false}
-                                        theadIndex={0}
-                                        type="default"
-                                      >
-                                        <tr
-                                          className="1b0jccb"
-                                        />
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                              </thead>
-                            </TableHead>
-                          </TableHeadStyles>
-                        </TableHeadStyles>
-                      </ThemedComponent>
-                      <ThemedComponent
+                                  <tr
+                                    className="1b0jccb"
+                                  />
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                          </thead>
+                        </TableHead>
+                      </FelaComponent>
+                    </ThemedComponent>
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      striped={false}
+                    >
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={false}
                         hover={false}
                         striped={false}
                       >
-                        <TableBodyStyles
+                        <TableBody
                           bare={false}
                           bordered={true}
+                          className="zos2pn"
                           condensed={false}
                           hover={false}
+                          is="tbody"
                           striped={false}
                         >
-                          <TableBodyStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={false}
-                            hover={false}
-                            passThrough={Array []}
-                            striped={false}
-                          >
-                            <TableBody
-                              bare={false}
-                              bordered={true}
-                              className="zos2pn"
-                              condensed={false}
-                              hover={false}
-                              is="tbody"
-                              striped={false}
-                            >
-                              <tbody
-                                className="zos2pn"
-                              />
-                            </TableBody>
-                          </TableBodyStyles>
-                        </TableBodyStyles>
-                      </ThemedComponent>
-                    </table>
-                  </Table>
-                </TableStyles>
-              </TableStyles>
+                          <tbody
+                            className="zos2pn"
+                          />
+                        </TableBody>
+                      </FelaComponent>
+                    </ThemedComponent>
+                  </table>
+                </Table>
+              </FelaComponent>
             </ThemedComponent>
           </TableBuilder>
         </Connect(TableBuilder)>
@@ -1083,628 +1046,455 @@ exports[`should render the dataset in columns 1`] = `
             tableName="test-table"
           >
             <ThemedComponent>
-              <TableStyles>
-                <TableStyles
-                  _felaRule={[Function]}
-                  passThrough={Array []}
+              <FelaComponent>
+                <Table
+                  bare={false}
+                  bordered={true}
+                  className="46sr0r"
+                  condensed={false}
+                  hover={false}
+                  is="table"
+                  striped={false}
                 >
-                  <Table
-                    bare={false}
-                    bordered={true}
+                  <table
                     className="46sr0r"
-                    condensed={false}
-                    hover={false}
-                    is="table"
-                    striped={false}
                   >
-                    <table
-                      className="46sr0r"
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      striped={false}
                     >
-                      <ThemedComponent
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={false}
                         hover={false}
                         striped={false}
                       >
-                        <TableHeadStyles
+                        <TableHead
                           bare={false}
                           bordered={true}
+                          className="d1fi02"
                           condensed={false}
                           hover={false}
+                          is="thead"
                           striped={false}
                         >
-                          <TableHeadStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={false}
-                            hover={false}
-                            passThrough={Array []}
-                            striped={false}
+                          <thead
+                            className="d1fi02"
                           >
-                            <TableHead
+                            <ThemedComponent
                               bare={false}
                               bordered={true}
-                              className="d1fi02"
                               condensed={false}
                               hover={false}
-                              is="thead"
+                              rowIndex={-0}
                               striped={false}
+                              theadIndex={0}
                             >
-                              <thead
-                                className="d1fi02"
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={-0}
+                                striped={false}
+                                theadIndex={0}
                               >
-                                <ThemedComponent
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="1b0jccb"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={-0}
                                   striped={false}
                                   theadIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={-0}
-                                    striped={false}
-                                    theadIndex={0}
+                                  <tr
+                                    className="1b0jccb"
                                   >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
+                                    <ThemedComponent
                                       bare={false}
                                       bordered={true}
+                                      cellIndex={0}
                                       condensed={false}
                                       hover={false}
-                                      passThrough={Array []}
                                       rowIndex={-0}
+                                      rowType="default"
                                       striped={false}
                                       theadIndex={0}
                                     >
-                                      <TableRow
+                                      <FelaComponent
                                         bare={false}
                                         bordered={true}
-                                        className="1b0jccb"
+                                        cellIndex={0}
                                         condensed={false}
                                         hover={false}
-                                        is="tr"
                                         rowIndex={-0}
+                                        rowType="default"
                                         striped={false}
                                         theadIndex={0}
-                                        type="default"
                                       >
-                                        <tr
-                                          className="1b0jccb"
+                                        <TableHeadCell
+                                          bare={false}
+                                          bordered={true}
+                                          cellIndex={0}
+                                          className="1fm7xdg"
+                                          condensed={false}
+                                          hover={false}
+                                          is="th"
+                                          rowIndex={-0}
+                                          rowType="default"
+                                          striped={false}
+                                          theadIndex={0}
                                         >
-                                          <ThemedComponent
-                                            bare={false}
-                                            bordered={true}
-                                            cellIndex={0}
-                                            condensed={false}
-                                            hover={false}
-                                            rowIndex={-0}
-                                            rowType="default"
-                                            striped={false}
-                                            theadIndex={0}
+                                          <th
+                                            className="1fm7xdg"
                                           >
-                                            <TableHeadCellStyles
-                                              bare={false}
-                                              bordered={true}
-                                              cellIndex={0}
-                                              condensed={false}
-                                              hover={false}
-                                              rowIndex={-0}
-                                              rowType="default"
-                                              striped={false}
-                                              theadIndex={0}
-                                            >
-                                              <TableCellStyles
-                                                _felaRule={[Function]}
-                                                bare={false}
-                                                bordered={true}
-                                                cellIndex={0}
-                                                condensed={false}
-                                                hover={false}
-                                                passThrough={Array []}
-                                                rowIndex={-0}
-                                                rowType="default"
-                                                striped={false}
-                                                theadIndex={0}
-                                              >
-                                                <TableCellStyles
-                                                  _felaRule={[Function]}
-                                                  bare={false}
-                                                  bordered={true}
-                                                  cellIndex={0}
-                                                  condensed={false}
-                                                  hover={false}
-                                                  passThrough={Array []}
-                                                  rowIndex={-0}
-                                                  rowType="default"
-                                                  striped={false}
-                                                  theadIndex={0}
-                                                >
-                                                  <TableHeadCell
-                                                    bare={false}
-                                                    bordered={true}
-                                                    cellIndex={0}
-                                                    className="1fm7xdg"
-                                                    condensed={false}
-                                                    hover={false}
-                                                    is="th"
-                                                    rowIndex={-0}
-                                                    rowType="default"
-                                                    striped={false}
-                                                    theadIndex={0}
-                                                  >
-                                                    <th
-                                                      className="1fm7xdg"
-                                                    >
-                                                      Name
-                                                    </th>
-                                                  </TableHeadCell>
-                                                </TableCellStyles>
-                                              </TableCellStyles>
-                                            </TableHeadCellStyles>
-                                          </ThemedComponent>
-                                          <ThemedComponent
-                                            bare={false}
-                                            bordered={true}
-                                            cellIndex={-1}
-                                            condensed={false}
-                                            hover={false}
-                                            rowIndex={-0}
-                                            rowType="default"
-                                            striped={false}
-                                            theadIndex={0}
+                                            Name
+                                          </th>
+                                        </TableHeadCell>
+                                      </FelaComponent>
+                                    </ThemedComponent>
+                                    <ThemedComponent
+                                      bare={false}
+                                      bordered={true}
+                                      cellIndex={-1}
+                                      condensed={false}
+                                      hover={false}
+                                      rowIndex={-0}
+                                      rowType="default"
+                                      striped={false}
+                                      theadIndex={0}
+                                    >
+                                      <FelaComponent
+                                        bare={false}
+                                        bordered={true}
+                                        cellIndex={-1}
+                                        condensed={false}
+                                        hover={false}
+                                        rowIndex={-0}
+                                        rowType="default"
+                                        striped={false}
+                                        theadIndex={0}
+                                      >
+                                        <TableHeadCell
+                                          bare={false}
+                                          bordered={true}
+                                          cellIndex={-1}
+                                          className="1ypdp8g"
+                                          condensed={false}
+                                          hover={false}
+                                          is="th"
+                                          rowIndex={-0}
+                                          rowType="default"
+                                          striped={false}
+                                          theadIndex={0}
+                                        >
+                                          <th
+                                            className="1ypdp8g"
                                           >
-                                            <TableHeadCellStyles
-                                              bare={false}
-                                              bordered={true}
-                                              cellIndex={-1}
-                                              condensed={false}
-                                              hover={false}
-                                              rowIndex={-0}
-                                              rowType="default"
-                                              striped={false}
-                                              theadIndex={0}
-                                            >
-                                              <TableCellStyles
-                                                _felaRule={[Function]}
-                                                bare={false}
-                                                bordered={true}
-                                                cellIndex={-1}
-                                                condensed={false}
-                                                hover={false}
-                                                passThrough={Array []}
-                                                rowIndex={-0}
-                                                rowType="default"
-                                                striped={false}
-                                                theadIndex={0}
-                                              >
-                                                <TableCellStyles
-                                                  _felaRule={[Function]}
-                                                  bare={false}
-                                                  bordered={true}
-                                                  cellIndex={-1}
-                                                  condensed={false}
-                                                  hover={false}
-                                                  passThrough={Array []}
-                                                  rowIndex={-0}
-                                                  rowType="default"
-                                                  striped={false}
-                                                  theadIndex={0}
-                                                >
-                                                  <TableHeadCell
-                                                    bare={false}
-                                                    bordered={true}
-                                                    cellIndex={-1}
-                                                    className="1ypdp8g"
-                                                    condensed={false}
-                                                    hover={false}
-                                                    is="th"
-                                                    rowIndex={-0}
-                                                    rowType="default"
-                                                    striped={false}
-                                                    theadIndex={0}
-                                                  >
-                                                    <th
-                                                      className="1ypdp8g"
-                                                    >
-                                                      Value
-                                                    </th>
-                                                  </TableHeadCell>
-                                                </TableCellStyles>
-                                              </TableCellStyles>
-                                            </TableHeadCellStyles>
-                                          </ThemedComponent>
-                                        </tr>
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                              </thead>
-                            </TableHead>
-                          </TableHeadStyles>
-                        </TableHeadStyles>
-                      </ThemedComponent>
-                      <ThemedComponent
+                                            Value
+                                          </th>
+                                        </TableHeadCell>
+                                      </FelaComponent>
+                                    </ThemedComponent>
+                                  </tr>
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                          </thead>
+                        </TableHead>
+                      </FelaComponent>
+                    </ThemedComponent>
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      striped={false}
+                    >
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={false}
                         hover={false}
                         striped={false}
                       >
-                        <TableBodyStyles
+                        <TableBody
                           bare={false}
                           bordered={true}
+                          className="zos2pn"
                           condensed={false}
                           hover={false}
+                          is="tbody"
                           striped={false}
                         >
-                          <TableBodyStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={false}
-                            hover={false}
-                            passThrough={Array []}
-                            striped={false}
+                          <tbody
+                            className="zos2pn"
                           >
-                            <TableBody
+                            <ThemedComponent
                               bare={false}
                               bordered={true}
-                              className="zos2pn"
                               condensed={false}
                               hover={false}
-                              is="tbody"
+                              rowIndex={0}
                               striped={false}
+                              tbodyIndex={0}
                             >
-                              <tbody
-                                className="zos2pn"
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={0}
+                                striped={false}
+                                tbodyIndex={0}
                               >
-                                <ThemedComponent
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="t9kph0"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={0}
                                   striped={false}
                                   tbodyIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={0}
-                                    striped={false}
-                                    tbodyIndex={0}
+                                  <tr
+                                    className="t9kph0"
                                   >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
+                                    <ThemedComponent
                                       bare={false}
                                       bordered={true}
+                                      cellIndex={0}
                                       condensed={false}
                                       hover={false}
-                                      passThrough={Array []}
                                       rowIndex={0}
+                                      rowType="default"
                                       striped={false}
                                       tbodyIndex={0}
                                     >
-                                      <TableRow
+                                      <FelaComponent
                                         bare={false}
                                         bordered={true}
-                                        className="t9kph0"
+                                        cellIndex={0}
                                         condensed={false}
                                         hover={false}
-                                        is="tr"
                                         rowIndex={0}
+                                        rowType="default"
                                         striped={false}
                                         tbodyIndex={0}
-                                        type="default"
                                       >
-                                        <tr
-                                          className="t9kph0"
+                                        <TableCell
+                                          align="left"
+                                          bare={false}
+                                          bordered={true}
+                                          cellIndex={0}
+                                          className="g0oihw"
+                                          condensed={false}
+                                          hover={false}
+                                          is="td"
+                                          rowIndex={0}
+                                          rowType="default"
+                                          striped={false}
+                                          tbodyIndex={0}
                                         >
-                                          <ThemedComponent
-                                            bare={false}
-                                            bordered={true}
-                                            cellIndex={0}
-                                            condensed={false}
-                                            hover={false}
-                                            rowIndex={0}
-                                            rowType="default"
-                                            striped={false}
-                                            tbodyIndex={0}
+                                          <td
+                                            className="g0oihw"
                                           >
-                                            <TableCellStyles
-                                              bare={false}
-                                              bordered={true}
-                                              cellIndex={0}
-                                              condensed={false}
-                                              hover={false}
-                                              rowIndex={0}
-                                              rowType="default"
-                                              striped={false}
-                                              tbodyIndex={0}
-                                            >
-                                              <TableCellStyles
-                                                _felaRule={[Function]}
-                                                bare={false}
-                                                bordered={true}
-                                                cellIndex={0}
-                                                condensed={false}
-                                                hover={false}
-                                                passThrough={Array []}
-                                                rowIndex={0}
-                                                rowType="default"
-                                                striped={false}
-                                                tbodyIndex={0}
-                                              >
-                                                <TableCell
-                                                  align="left"
-                                                  bare={false}
-                                                  bordered={true}
-                                                  cellIndex={0}
-                                                  className="g0oihw"
-                                                  condensed={false}
-                                                  hover={false}
-                                                  is="td"
-                                                  rowIndex={0}
-                                                  rowType="default"
-                                                  striped={false}
-                                                  tbodyIndex={0}
-                                                >
-                                                  <td
-                                                    className="g0oihw"
-                                                  >
-                                                    Foo
-                                                  </td>
-                                                </TableCell>
-                                              </TableCellStyles>
-                                            </TableCellStyles>
-                                          </ThemedComponent>
-                                          <ThemedComponent
-                                            bare={false}
-                                            bordered={true}
-                                            cellIndex={-1}
-                                            condensed={false}
-                                            hover={false}
-                                            rowIndex={0}
-                                            rowType="default"
-                                            striped={false}
-                                            tbodyIndex={0}
+                                            Foo
+                                          </td>
+                                        </TableCell>
+                                      </FelaComponent>
+                                    </ThemedComponent>
+                                    <ThemedComponent
+                                      bare={false}
+                                      bordered={true}
+                                      cellIndex={-1}
+                                      condensed={false}
+                                      hover={false}
+                                      rowIndex={0}
+                                      rowType="default"
+                                      striped={false}
+                                      tbodyIndex={0}
+                                    >
+                                      <FelaComponent
+                                        bare={false}
+                                        bordered={true}
+                                        cellIndex={-1}
+                                        condensed={false}
+                                        hover={false}
+                                        rowIndex={0}
+                                        rowType="default"
+                                        striped={false}
+                                        tbodyIndex={0}
+                                      >
+                                        <TableCell
+                                          align="left"
+                                          bare={false}
+                                          bordered={true}
+                                          cellIndex={-1}
+                                          className="9yqouo"
+                                          condensed={false}
+                                          hover={false}
+                                          is="td"
+                                          rowIndex={0}
+                                          rowType="default"
+                                          striped={false}
+                                          tbodyIndex={0}
+                                        >
+                                          <td
+                                            className="9yqouo"
                                           >
-                                            <TableCellStyles
-                                              bare={false}
-                                              bordered={true}
-                                              cellIndex={-1}
-                                              condensed={false}
-                                              hover={false}
-                                              rowIndex={0}
-                                              rowType="default"
-                                              striped={false}
-                                              tbodyIndex={0}
-                                            >
-                                              <TableCellStyles
-                                                _felaRule={[Function]}
-                                                bare={false}
-                                                bordered={true}
-                                                cellIndex={-1}
-                                                condensed={false}
-                                                hover={false}
-                                                passThrough={Array []}
-                                                rowIndex={0}
-                                                rowType="default"
-                                                striped={false}
-                                                tbodyIndex={0}
-                                              >
-                                                <TableCell
-                                                  align="left"
-                                                  bare={false}
-                                                  bordered={true}
-                                                  cellIndex={-1}
-                                                  className="9yqouo"
-                                                  condensed={false}
-                                                  hover={false}
-                                                  is="td"
-                                                  rowIndex={0}
-                                                  rowType="default"
-                                                  striped={false}
-                                                  tbodyIndex={0}
-                                                >
-                                                  <td
-                                                    className="9yqouo"
-                                                  >
-                                                    foo
-                                                  </td>
-                                                </TableCell>
-                                              </TableCellStyles>
-                                            </TableCellStyles>
-                                          </ThemedComponent>
-                                        </tr>
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                                <ThemedComponent
+                                            foo
+                                          </td>
+                                        </TableCell>
+                                      </FelaComponent>
+                                    </ThemedComponent>
+                                  </tr>
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                            <ThemedComponent
+                              bare={false}
+                              bordered={true}
+                              condensed={false}
+                              hover={false}
+                              rowIndex={-1}
+                              striped={false}
+                              tbodyIndex={0}
+                            >
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={-1}
+                                striped={false}
+                                tbodyIndex={0}
+                              >
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="1uiy02g"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={-1}
                                   striped={false}
                                   tbodyIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={-1}
-                                    striped={false}
-                                    tbodyIndex={0}
+                                  <tr
+                                    className="1uiy02g"
                                   >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
+                                    <ThemedComponent
                                       bare={false}
                                       bordered={true}
+                                      cellIndex={0}
                                       condensed={false}
                                       hover={false}
-                                      passThrough={Array []}
                                       rowIndex={-1}
+                                      rowType="default"
                                       striped={false}
                                       tbodyIndex={0}
                                     >
-                                      <TableRow
+                                      <FelaComponent
                                         bare={false}
                                         bordered={true}
-                                        className="1uiy02g"
+                                        cellIndex={0}
                                         condensed={false}
                                         hover={false}
-                                        is="tr"
                                         rowIndex={-1}
+                                        rowType="default"
                                         striped={false}
                                         tbodyIndex={0}
-                                        type="default"
                                       >
-                                        <tr
-                                          className="1uiy02g"
+                                        <TableCell
+                                          align="left"
+                                          bare={false}
+                                          bordered={true}
+                                          cellIndex={0}
+                                          className="1c6l5ki"
+                                          condensed={false}
+                                          hover={false}
+                                          is="td"
+                                          rowIndex={-1}
+                                          rowType="default"
+                                          striped={false}
+                                          tbodyIndex={0}
                                         >
-                                          <ThemedComponent
-                                            bare={false}
-                                            bordered={true}
-                                            cellIndex={0}
-                                            condensed={false}
-                                            hover={false}
-                                            rowIndex={-1}
-                                            rowType="default"
-                                            striped={false}
-                                            tbodyIndex={0}
+                                          <td
+                                            className="1c6l5ki"
                                           >
-                                            <TableCellStyles
-                                              bare={false}
-                                              bordered={true}
-                                              cellIndex={0}
-                                              condensed={false}
-                                              hover={false}
-                                              rowIndex={-1}
-                                              rowType="default"
-                                              striped={false}
-                                              tbodyIndex={0}
-                                            >
-                                              <TableCellStyles
-                                                _felaRule={[Function]}
-                                                bare={false}
-                                                bordered={true}
-                                                cellIndex={0}
-                                                condensed={false}
-                                                hover={false}
-                                                passThrough={Array []}
-                                                rowIndex={-1}
-                                                rowType="default"
-                                                striped={false}
-                                                tbodyIndex={0}
-                                              >
-                                                <TableCell
-                                                  align="left"
-                                                  bare={false}
-                                                  bordered={true}
-                                                  cellIndex={0}
-                                                  className="1c6l5ki"
-                                                  condensed={false}
-                                                  hover={false}
-                                                  is="td"
-                                                  rowIndex={-1}
-                                                  rowType="default"
-                                                  striped={false}
-                                                  tbodyIndex={0}
-                                                >
-                                                  <td
-                                                    className="1c6l5ki"
-                                                  >
-                                                    Bar
-                                                  </td>
-                                                </TableCell>
-                                              </TableCellStyles>
-                                            </TableCellStyles>
-                                          </ThemedComponent>
-                                          <ThemedComponent
-                                            bare={false}
-                                            bordered={true}
-                                            cellIndex={-1}
-                                            condensed={false}
-                                            hover={false}
-                                            rowIndex={-1}
-                                            rowType="default"
-                                            striped={false}
-                                            tbodyIndex={0}
+                                            Bar
+                                          </td>
+                                        </TableCell>
+                                      </FelaComponent>
+                                    </ThemedComponent>
+                                    <ThemedComponent
+                                      bare={false}
+                                      bordered={true}
+                                      cellIndex={-1}
+                                      condensed={false}
+                                      hover={false}
+                                      rowIndex={-1}
+                                      rowType="default"
+                                      striped={false}
+                                      tbodyIndex={0}
+                                    >
+                                      <FelaComponent
+                                        bare={false}
+                                        bordered={true}
+                                        cellIndex={-1}
+                                        condensed={false}
+                                        hover={false}
+                                        rowIndex={-1}
+                                        rowType="default"
+                                        striped={false}
+                                        tbodyIndex={0}
+                                      >
+                                        <TableCell
+                                          align="left"
+                                          bare={false}
+                                          bordered={true}
+                                          cellIndex={-1}
+                                          className="1f59ksd"
+                                          condensed={false}
+                                          hover={false}
+                                          is="td"
+                                          rowIndex={-1}
+                                          rowType="default"
+                                          striped={false}
+                                          tbodyIndex={0}
+                                        >
+                                          <td
+                                            className="1f59ksd"
                                           >
-                                            <TableCellStyles
-                                              bare={false}
-                                              bordered={true}
-                                              cellIndex={-1}
-                                              condensed={false}
-                                              hover={false}
-                                              rowIndex={-1}
-                                              rowType="default"
-                                              striped={false}
-                                              tbodyIndex={0}
-                                            >
-                                              <TableCellStyles
-                                                _felaRule={[Function]}
-                                                bare={false}
-                                                bordered={true}
-                                                cellIndex={-1}
-                                                condensed={false}
-                                                hover={false}
-                                                passThrough={Array []}
-                                                rowIndex={-1}
-                                                rowType="default"
-                                                striped={false}
-                                                tbodyIndex={0}
-                                              >
-                                                <TableCell
-                                                  align="left"
-                                                  bare={false}
-                                                  bordered={true}
-                                                  cellIndex={-1}
-                                                  className="1f59ksd"
-                                                  condensed={false}
-                                                  hover={false}
-                                                  is="td"
-                                                  rowIndex={-1}
-                                                  rowType="default"
-                                                  striped={false}
-                                                  tbodyIndex={0}
-                                                >
-                                                  <td
-                                                    className="1f59ksd"
-                                                  >
-                                                    bar
-                                                  </td>
-                                                </TableCell>
-                                              </TableCellStyles>
-                                            </TableCellStyles>
-                                          </ThemedComponent>
-                                        </tr>
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                              </tbody>
-                            </TableBody>
-                          </TableBodyStyles>
-                        </TableBodyStyles>
-                      </ThemedComponent>
-                    </table>
-                  </Table>
-                </TableStyles>
-              </TableStyles>
+                                            bar
+                                          </td>
+                                        </TableCell>
+                                      </FelaComponent>
+                                    </ThemedComponent>
+                                  </tr>
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                          </tbody>
+                        </TableBody>
+                      </FelaComponent>
+                    </ThemedComponent>
+                  </table>
+                </Table>
+              </FelaComponent>
             </ThemedComponent>
           </TableBuilder>
         </Connect(TableBuilder)>
@@ -2122,254 +1912,192 @@ exports[`should support flashes 1`] = `
             tableName="test-table"
           >
             <ThemedComponent>
-              <TableStyles>
-                <TableStyles
-                  _felaRule={[Function]}
-                  passThrough={Array []}
+              <FelaComponent>
+                <Table
+                  bare={false}
+                  bordered={true}
+                  className="46sr0r"
+                  condensed={false}
+                  hover={false}
+                  is="table"
+                  striped={false}
                 >
-                  <Table
-                    bare={false}
-                    bordered={true}
+                  <table
                     className="46sr0r"
-                    condensed={false}
-                    hover={false}
-                    is="table"
-                    striped={false}
                   >
-                    <table
-                      className="46sr0r"
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      striped={false}
                     >
-                      <ThemedComponent
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={false}
                         hover={false}
                         striped={false}
                       >
-                        <TableHeadStyles
+                        <TableHead
                           bare={false}
                           bordered={true}
+                          className="d1fi02"
                           condensed={false}
                           hover={false}
+                          is="thead"
                           striped={false}
                         >
-                          <TableHeadStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={false}
-                            hover={false}
-                            passThrough={Array []}
-                            striped={false}
+                          <thead
+                            className="d1fi02"
                           >
-                            <TableHead
+                            <ThemedComponent
                               bare={false}
                               bordered={true}
-                              className="d1fi02"
                               condensed={false}
                               hover={false}
-                              is="thead"
+                              rowIndex={-0}
                               striped={false}
+                              theadIndex={0}
                             >
-                              <thead
-                                className="d1fi02"
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={-0}
+                                striped={false}
+                                theadIndex={0}
                               >
-                                <ThemedComponent
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="1b0jccb"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={-0}
                                   striped={false}
                                   theadIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={-0}
-                                    striped={false}
-                                    theadIndex={0}
-                                  >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
-                                      bare={false}
-                                      bordered={true}
-                                      condensed={false}
-                                      hover={false}
-                                      passThrough={Array []}
-                                      rowIndex={-0}
-                                      striped={false}
-                                      theadIndex={0}
-                                    >
-                                      <TableRow
-                                        bare={false}
-                                        bordered={true}
-                                        className="1b0jccb"
-                                        condensed={false}
-                                        hover={false}
-                                        is="tr"
-                                        rowIndex={-0}
-                                        striped={false}
-                                        theadIndex={0}
-                                        type="default"
-                                      >
-                                        <tr
-                                          className="1b0jccb"
-                                        />
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                              </thead>
-                            </TableHead>
-                          </TableHeadStyles>
-                        </TableHeadStyles>
-                      </ThemedComponent>
-                      <ThemedComponent
+                                  <tr
+                                    className="1b0jccb"
+                                  />
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                          </thead>
+                        </TableHead>
+                      </FelaComponent>
+                    </ThemedComponent>
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      striped={false}
+                    >
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={false}
                         hover={false}
                         striped={false}
                       >
-                        <TableBodyStyles
+                        <TableBody
                           bare={false}
                           bordered={true}
+                          className="zos2pn"
                           condensed={false}
                           hover={false}
+                          is="tbody"
                           striped={false}
                         >
-                          <TableBodyStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={false}
-                            hover={false}
-                            passThrough={Array []}
-                            striped={false}
+                          <tbody
+                            className="zos2pn"
                           >
-                            <TableBody
+                            <ThemedComponent
                               bare={false}
                               bordered={true}
-                              className="zos2pn"
                               condensed={false}
                               hover={false}
-                              is="tbody"
+                              rowIndex={0}
                               striped={false}
+                              tbodyIndex={0}
+                              type="success"
                             >
-                              <tbody
-                                className="zos2pn"
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={0}
+                                striped={false}
+                                tbodyIndex={0}
+                                type="success"
                               >
-                                <ThemedComponent
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="14uu5dt"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={0}
                                   striped={false}
                                   tbodyIndex={0}
                                   type="success"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={0}
-                                    striped={false}
-                                    tbodyIndex={0}
-                                    type="success"
-                                  >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
-                                      bare={false}
-                                      bordered={true}
-                                      condensed={false}
-                                      hover={false}
-                                      passThrough={Array []}
-                                      rowIndex={0}
-                                      striped={false}
-                                      tbodyIndex={0}
-                                      type="success"
-                                    >
-                                      <TableRow
-                                        bare={false}
-                                        bordered={true}
-                                        className="14uu5dt"
-                                        condensed={false}
-                                        hover={false}
-                                        is="tr"
-                                        rowIndex={0}
-                                        striped={false}
-                                        tbodyIndex={0}
-                                        type="success"
-                                      >
-                                        <tr
-                                          className="14uu5dt"
-                                        />
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                                <ThemedComponent
+                                  <tr
+                                    className="14uu5dt"
+                                  />
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                            <ThemedComponent
+                              bare={false}
+                              bordered={true}
+                              condensed={false}
+                              hover={false}
+                              rowIndex={-1}
+                              striped={false}
+                              tbodyIndex={0}
+                            >
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={-1}
+                                striped={false}
+                                tbodyIndex={0}
+                              >
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="1uiy02g"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={-1}
                                   striped={false}
                                   tbodyIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={-1}
-                                    striped={false}
-                                    tbodyIndex={0}
-                                  >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
-                                      bare={false}
-                                      bordered={true}
-                                      condensed={false}
-                                      hover={false}
-                                      passThrough={Array []}
-                                      rowIndex={-1}
-                                      striped={false}
-                                      tbodyIndex={0}
-                                    >
-                                      <TableRow
-                                        bare={false}
-                                        bordered={true}
-                                        className="1uiy02g"
-                                        condensed={false}
-                                        hover={false}
-                                        is="tr"
-                                        rowIndex={-1}
-                                        striped={false}
-                                        tbodyIndex={0}
-                                        type="default"
-                                      >
-                                        <tr
-                                          className="1uiy02g"
-                                        />
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                              </tbody>
-                            </TableBody>
-                          </TableBodyStyles>
-                        </TableBodyStyles>
-                      </ThemedComponent>
-                    </table>
-                  </Table>
-                </TableStyles>
-              </TableStyles>
+                                  <tr
+                                    className="1uiy02g"
+                                  />
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                          </tbody>
+                        </TableBody>
+                      </FelaComponent>
+                    </ThemedComponent>
+                  </table>
+                </Table>
+              </FelaComponent>
             </ThemedComponent>
           </TableBuilder>
         </Connect(TableBuilder)>
@@ -2784,254 +2512,192 @@ exports[`should support row type/accent 1`] = `
             tableName="test-table"
           >
             <ThemedComponent>
-              <TableStyles>
-                <TableStyles
-                  _felaRule={[Function]}
-                  passThrough={Array []}
+              <FelaComponent>
+                <Table
+                  bare={false}
+                  bordered={true}
+                  className="46sr0r"
+                  condensed={false}
+                  hover={false}
+                  is="table"
+                  striped={false}
                 >
-                  <Table
-                    bare={false}
-                    bordered={true}
+                  <table
                     className="46sr0r"
-                    condensed={false}
-                    hover={false}
-                    is="table"
-                    striped={false}
                   >
-                    <table
-                      className="46sr0r"
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      striped={false}
                     >
-                      <ThemedComponent
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={false}
                         hover={false}
                         striped={false}
                       >
-                        <TableHeadStyles
+                        <TableHead
                           bare={false}
                           bordered={true}
+                          className="d1fi02"
                           condensed={false}
                           hover={false}
+                          is="thead"
                           striped={false}
                         >
-                          <TableHeadStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={false}
-                            hover={false}
-                            passThrough={Array []}
-                            striped={false}
+                          <thead
+                            className="d1fi02"
                           >
-                            <TableHead
+                            <ThemedComponent
                               bare={false}
                               bordered={true}
-                              className="d1fi02"
                               condensed={false}
                               hover={false}
-                              is="thead"
+                              rowIndex={-0}
                               striped={false}
+                              theadIndex={0}
                             >
-                              <thead
-                                className="d1fi02"
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={-0}
+                                striped={false}
+                                theadIndex={0}
                               >
-                                <ThemedComponent
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="1b0jccb"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={-0}
                                   striped={false}
                                   theadIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={-0}
-                                    striped={false}
-                                    theadIndex={0}
-                                  >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
-                                      bare={false}
-                                      bordered={true}
-                                      condensed={false}
-                                      hover={false}
-                                      passThrough={Array []}
-                                      rowIndex={-0}
-                                      striped={false}
-                                      theadIndex={0}
-                                    >
-                                      <TableRow
-                                        bare={false}
-                                        bordered={true}
-                                        className="1b0jccb"
-                                        condensed={false}
-                                        hover={false}
-                                        is="tr"
-                                        rowIndex={-0}
-                                        striped={false}
-                                        theadIndex={0}
-                                        type="default"
-                                      >
-                                        <tr
-                                          className="1b0jccb"
-                                        />
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                              </thead>
-                            </TableHead>
-                          </TableHeadStyles>
-                        </TableHeadStyles>
-                      </ThemedComponent>
-                      <ThemedComponent
+                                  <tr
+                                    className="1b0jccb"
+                                  />
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                          </thead>
+                        </TableHead>
+                      </FelaComponent>
+                    </ThemedComponent>
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      striped={false}
+                    >
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={false}
                         hover={false}
                         striped={false}
                       >
-                        <TableBodyStyles
+                        <TableBody
                           bare={false}
                           bordered={true}
+                          className="zos2pn"
                           condensed={false}
                           hover={false}
+                          is="tbody"
                           striped={false}
                         >
-                          <TableBodyStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={false}
-                            hover={false}
-                            passThrough={Array []}
-                            striped={false}
+                          <tbody
+                            className="zos2pn"
                           >
-                            <TableBody
+                            <ThemedComponent
                               bare={false}
                               bordered={true}
-                              className="zos2pn"
                               condensed={false}
                               hover={false}
-                              is="tbody"
+                              rowIndex={0}
                               striped={false}
+                              tbodyIndex={0}
+                              type="success"
                             >
-                              <tbody
-                                className="zos2pn"
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={0}
+                                striped={false}
+                                tbodyIndex={0}
+                                type="success"
                               >
-                                <ThemedComponent
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="14uu5dt"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={0}
                                   striped={false}
                                   tbodyIndex={0}
                                   type="success"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={0}
-                                    striped={false}
-                                    tbodyIndex={0}
-                                    type="success"
-                                  >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
-                                      bare={false}
-                                      bordered={true}
-                                      condensed={false}
-                                      hover={false}
-                                      passThrough={Array []}
-                                      rowIndex={0}
-                                      striped={false}
-                                      tbodyIndex={0}
-                                      type="success"
-                                    >
-                                      <TableRow
-                                        bare={false}
-                                        bordered={true}
-                                        className="14uu5dt"
-                                        condensed={false}
-                                        hover={false}
-                                        is="tr"
-                                        rowIndex={0}
-                                        striped={false}
-                                        tbodyIndex={0}
-                                        type="success"
-                                      >
-                                        <tr
-                                          className="14uu5dt"
-                                        />
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                                <ThemedComponent
+                                  <tr
+                                    className="14uu5dt"
+                                  />
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                            <ThemedComponent
+                              bare={false}
+                              bordered={true}
+                              condensed={false}
+                              hover={false}
+                              rowIndex={-1}
+                              striped={false}
+                              tbodyIndex={0}
+                            >
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={false}
+                                hover={false}
+                                rowIndex={-1}
+                                striped={false}
+                                tbodyIndex={0}
+                              >
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="1uiy02g"
                                   condensed={false}
                                   hover={false}
+                                  is="tr"
                                   rowIndex={-1}
                                   striped={false}
                                   tbodyIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={false}
-                                    hover={false}
-                                    rowIndex={-1}
-                                    striped={false}
-                                    tbodyIndex={0}
-                                  >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
-                                      bare={false}
-                                      bordered={true}
-                                      condensed={false}
-                                      hover={false}
-                                      passThrough={Array []}
-                                      rowIndex={-1}
-                                      striped={false}
-                                      tbodyIndex={0}
-                                    >
-                                      <TableRow
-                                        bare={false}
-                                        bordered={true}
-                                        className="1uiy02g"
-                                        condensed={false}
-                                        hover={false}
-                                        is="tr"
-                                        rowIndex={-1}
-                                        striped={false}
-                                        tbodyIndex={0}
-                                        type="default"
-                                      >
-                                        <tr
-                                          className="1uiy02g"
-                                        />
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                              </tbody>
-                            </TableBody>
-                          </TableBodyStyles>
-                        </TableBodyStyles>
-                      </ThemedComponent>
-                    </table>
-                  </Table>
-                </TableStyles>
-              </TableStyles>
+                                  <tr
+                                    className="1uiy02g"
+                                  />
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                          </tbody>
+                        </TableBody>
+                      </FelaComponent>
+                    </ThemedComponent>
+                  </table>
+                </Table>
+              </FelaComponent>
             </ThemedComponent>
           </TableBuilder>
         </Connect(TableBuilder)>
@@ -3331,163 +2997,122 @@ exports[`should support table props 1`] = `
               hover={true}
               striped={true}
             >
-              <TableStyles
+              <FelaComponent
                 bordered={true}
                 condensed={true}
                 hover={true}
                 striped={true}
               >
-                <TableStyles
-                  _felaRule={[Function]}
+                <Table
+                  bare={false}
                   bordered={true}
+                  className="127ooxc"
                   condensed={true}
                   hover={true}
-                  passThrough={Array []}
+                  is="table"
                   striped={true}
                 >
-                  <Table
-                    bare={false}
-                    bordered={true}
+                  <table
                     className="127ooxc"
-                    condensed={true}
-                    hover={true}
-                    is="table"
-                    striped={true}
                   >
-                    <table
-                      className="127ooxc"
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={true}
+                      hover={true}
+                      striped={true}
                     >
-                      <ThemedComponent
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={true}
                         hover={true}
                         striped={true}
                       >
-                        <TableHeadStyles
+                        <TableHead
                           bare={false}
                           bordered={true}
+                          className="d1fi02"
                           condensed={true}
                           hover={true}
+                          is="thead"
                           striped={true}
                         >
-                          <TableHeadStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={true}
-                            hover={true}
-                            passThrough={Array []}
-                            striped={true}
+                          <thead
+                            className="d1fi02"
                           >
-                            <TableHead
+                            <ThemedComponent
                               bare={false}
                               bordered={true}
-                              className="d1fi02"
                               condensed={true}
                               hover={true}
-                              is="thead"
+                              rowIndex={-0}
                               striped={true}
+                              theadIndex={0}
                             >
-                              <thead
-                                className="d1fi02"
+                              <FelaComponent
+                                bare={false}
+                                bordered={true}
+                                condensed={true}
+                                hover={true}
+                                rowIndex={-0}
+                                striped={true}
+                                theadIndex={0}
                               >
-                                <ThemedComponent
+                                <TableRow
                                   bare={false}
                                   bordered={true}
+                                  className="1b0jccb"
                                   condensed={true}
                                   hover={true}
+                                  is="tr"
                                   rowIndex={-0}
                                   striped={true}
                                   theadIndex={0}
+                                  type="default"
                                 >
-                                  <TableRowStyles
-                                    bare={false}
-                                    bordered={true}
-                                    condensed={true}
-                                    hover={true}
-                                    rowIndex={-0}
-                                    striped={true}
-                                    theadIndex={0}
-                                  >
-                                    <TableRowStyles
-                                      _felaRule={[Function]}
-                                      bare={false}
-                                      bordered={true}
-                                      condensed={true}
-                                      hover={true}
-                                      passThrough={Array []}
-                                      rowIndex={-0}
-                                      striped={true}
-                                      theadIndex={0}
-                                    >
-                                      <TableRow
-                                        bare={false}
-                                        bordered={true}
-                                        className="1b0jccb"
-                                        condensed={true}
-                                        hover={true}
-                                        is="tr"
-                                        rowIndex={-0}
-                                        striped={true}
-                                        theadIndex={0}
-                                        type="default"
-                                      >
-                                        <tr
-                                          className="1b0jccb"
-                                        />
-                                      </TableRow>
-                                    </TableRowStyles>
-                                  </TableRowStyles>
-                                </ThemedComponent>
-                              </thead>
-                            </TableHead>
-                          </TableHeadStyles>
-                        </TableHeadStyles>
-                      </ThemedComponent>
-                      <ThemedComponent
+                                  <tr
+                                    className="1b0jccb"
+                                  />
+                                </TableRow>
+                              </FelaComponent>
+                            </ThemedComponent>
+                          </thead>
+                        </TableHead>
+                      </FelaComponent>
+                    </ThemedComponent>
+                    <ThemedComponent
+                      bare={false}
+                      bordered={true}
+                      condensed={true}
+                      hover={true}
+                      striped={true}
+                    >
+                      <FelaComponent
                         bare={false}
                         bordered={true}
                         condensed={true}
                         hover={true}
                         striped={true}
                       >
-                        <TableBodyStyles
+                        <TableBody
                           bare={false}
                           bordered={true}
+                          className="zos2pn"
                           condensed={true}
                           hover={true}
+                          is="tbody"
                           striped={true}
                         >
-                          <TableBodyStyles
-                            _felaRule={[Function]}
-                            bare={false}
-                            bordered={true}
-                            condensed={true}
-                            hover={true}
-                            passThrough={Array []}
-                            striped={true}
-                          >
-                            <TableBody
-                              bare={false}
-                              bordered={true}
-                              className="zos2pn"
-                              condensed={true}
-                              hover={true}
-                              is="tbody"
-                              striped={true}
-                            >
-                              <tbody
-                                className="zos2pn"
-                              />
-                            </TableBody>
-                          </TableBodyStyles>
-                        </TableBodyStyles>
-                      </ThemedComponent>
-                    </table>
-                  </Table>
-                </TableStyles>
-              </TableStyles>
+                          <tbody
+                            className="zos2pn"
+                          />
+                        </TableBody>
+                      </FelaComponent>
+                    </ThemedComponent>
+                  </table>
+                </Table>
+              </FelaComponent>
             </ThemedComponent>
           </TableBuilder>
         </Connect(TableBuilder)>

--- a/packages/cf-builder-table/test/__snapshots__/TableBuilder.js.snap
+++ b/packages/cf-builder-table/test/__snapshots__/TableBuilder.js.snap
@@ -1,116 +1,3498 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should render a table 1`] = `
-<table
-  className="cf-table cf-table--bordered"
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
 >
-  <thead
-    className="cf-table__head"
+  <StyleProvider
+    dev={true}
   >
-    <tr
-      className="cf-table__row cf-table__row--default"
-    />
-  </thead>
-  <tbody
-    className="cf-table__body"
-  />
-</table>
+    <Provider
+      renderer={
+        Object {
+          "_emitChange": [Function],
+          "_renderStyleToCache": [Function],
+          "_renderStyleToClassNames": [Function],
+          "cache": Object {
+            "1b0jccb": true,
+            "46sr0r": true,
+            "d1fi02": true,
+            "zos2pn": true,
+          },
+          "clear": [Function],
+          "fontFaces": "",
+          "keyframePrefixes": Array [
+            "-webkit-",
+            "-moz-",
+            "",
+          ],
+          "keyframes": "",
+          "listeners": Array [
+            [Function],
+            [Function],
+          ],
+          "mediaQueryOrder": Array [],
+          "mediaRules": Object {
+            "(max-width: 47.2em)": ".46sr0r {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .d1fi02 {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1b0jccb {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .zos2pn {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }",
+            "screen and (max-width: 47.2em)": ".46sr0r {
+          display: block
+        }
+        
+        .d1fi02 {
+          display: none
+        }
+        
+        .1b0jccb:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1b0jccb {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .zos2pn {
+          display: block
+        }",
+          },
+          "plugins": Array [
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "prettySelectors": false,
+          "renderFont": [Function],
+          "renderKeyframe": [Function],
+          "renderRule": [Function],
+          "renderStatic": [Function],
+          "renderToString": [Function],
+          "rules": ".46sr0r {
+          background: #fff;
+          border-collapse: collapse;
+          border-spacing: 0px;
+          max-width: 100%;
+          width: 100%
+        }
+        
+        .d1fi02 {
+          background: #dedede
+        }
+        
+        .1b0jccb {
+          border-color: #dedede
+        }",
+          "selectorPrefix": "",
+          "statics": "",
+          "styleNodes": Object {
+            "RULE": <style
+              data-fela-type="RULE"
+              type="text/css"
+        >
+              .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede }
+        </style>,
+            "RULE(max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="(max-width: 47.2em)"
+        >
+              .46sr0r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box }
+        </style>,
+            "RULEscreen and (max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="screen and (max-width: 47.2em)"
+        >
+              .46sr0r { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .zos2pn { display: block }
+        </style>,
+          },
+          "subscribe": [Function],
+          "uniqueKeyframeIdentifier": 0,
+          "uniqueRuleIdentifier": 0,
+        }
+      }
+    >
+      <ThemeProvider
+        overwrite={false}
+        theme={
+          Object {
+            "arrowSize": "5px",
+            "bodyAccentColor": "#333",
+            "bodyBackground": "#ebebeb",
+            "bodyOffsetColor": "#787878",
+            "borderRadius": "2px",
+            "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+            "breakpoints": Object {
+              "desktop": "64em",
+              "desktopLarge": "97.6em",
+              "mobile": "13.6em",
+              "mobileWide": "30.4em",
+              "tablet": "47.2em",
+            },
+            "color": Object {
+              "apple": "#BD2527",
+              "carrot": "#f56500",
+              "cement": "#7D7D7D",
+              "charcoal": "#333333",
+              "dawn": "#F16975",
+              "dew": "#85CBA8",
+              "dusk": "#4D4D4F",
+              "grass": "#9BCA3E",
+              "hail": "#BCBEC0",
+              "lightning": "#FFDB6F",
+              "marine": "#2F7BBF",
+              "moonshine": "#F7F7F7",
+              "night": "#404041",
+              "rain": "#408BC9",
+              "sky": "#76C4E2",
+              "smoke": "#e0e0e0",
+              "storm": "#808285",
+              "sunrise": "#F69259",
+              "sunset": "#BA77B1",
+              "tangerine": "#FF7900",
+              "twilight": "#8176B5",
+            },
+            "colorBlack": "#000",
+            "colorBlue": "#2f7bbf",
+            "colorBlueDark": "#2869a2",
+            "colorBlueLight": "#62a1d8",
+            "colorError": "#ff3100",
+            "colorFacebookBlue": "#3b5998",
+            "colorGray": "#7c7c7c",
+            "colorGrayBorder": "#666",
+            "colorGrayDark": "#333",
+            "colorGrayLight": "#dedede",
+            "colorGrayLightOnboarding": "#F7F7F7",
+            "colorGreen": "#9bca3e",
+            "colorGreenDark": "#87b331",
+            "colorGreenLight": "#bada7a",
+            "colorImportantInformation": "rgba(64,139,201,0.2)",
+            "colorInfo": "#00a9eb",
+            "colorMainBackground": "#e6e6e6",
+            "colorMuted": "#7c7c7c",
+            "colorOffsetDark": 0.07,
+            "colorOffsetLight": 0.15,
+            "colorOrange": "#ff7900",
+            "colorOrangeDark": "#db6800",
+            "colorOrangeLight": "#ffa14d",
+            "colorOverlay": "rgba(0, 0, 0, .7)",
+            "colorPink": "#d91698",
+            "colorPinkDark": "#b91381",
+            "colorPinkLight": "#ed4eb8",
+            "colorPurple": "#9545e5",
+            "colorPurpleDark": "#b91381",
+            "colorPurpleLight": "#ed4eb8",
+            "colorRed": "#bd2527",
+            "colorRedDark": "#9f1f21",
+            "colorRedLight": "#dd5153",
+            "colorSmoke": "#f2f2f2",
+            "colorSuccess": "#68970f",
+            "colorTwitterBlue": "#00aced",
+            "colorWarning": "#fca520",
+            "colorWhite": "#fff",
+            "colorYellow": "#ffd24d",
+            "colorYellowDark": "#ffc929",
+            "colorYellowLight": "#ffe59a",
+            "disabledBackground": "#ededed",
+            "em": "1em",
+            "fontColor": "#333",
+            "fontColorHeadingCaption": "#888",
+            "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+            "fontSize": "15px",
+            "fontWeight": 400,
+            "fontWeightLight": 300,
+            "gradient": Object {
+              "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+              "five": "linear-gradient(left, #8176B5, #F16975)",
+              "four": "linear-gradient(left, #8176B5, #BA77B1)",
+              "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+              "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+              "six": "linear-gradient(left, #F16975, #F69259)",
+              "three": "linear-gradient(left, #8176B5, #76C4E2)",
+              "two": "linear-gradient(left, #8176B5, #85CBA8)",
+            },
+            "inputFontSize": "13px",
+            "inputLineHeight": 1.4,
+            "lineHeight": 1.5,
+            "rem": "1rem",
+            "weightBold": 700,
+            "weightLight": 300,
+            "weightNormal": 400,
+            "weightSemiBold": 600,
+            "zIndexMax": 1000,
+          }
+        }
+      >
+        <Connect(TableBuilder)
+          columns={Array []}
+          rows={Array []}
+          tableName="test-table"
+        >
+          <TableBuilder
+            columns={Array []}
+            dispatch={[Function]}
+            flashes={Object {}}
+            rows={Array []}
+            tableName="test-table"
+          >
+            <ThemedComponent>
+              <TableStyles>
+                <TableStyles
+                  _felaRule={[Function]}
+                  passThrough={Array []}
+                >
+                  <Table
+                    bare={false}
+                    bordered={true}
+                    className="46sr0r"
+                    condensed={false}
+                    hover={false}
+                    is="table"
+                    striped={false}
+                  >
+                    <table
+                      className="46sr0r"
+                    >
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        striped={false}
+                      >
+                        <TableHeadStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={false}
+                          hover={false}
+                          striped={false}
+                        >
+                          <TableHeadStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={false}
+                            hover={false}
+                            passThrough={Array []}
+                            striped={false}
+                          >
+                            <TableHead
+                              bare={false}
+                              bordered={true}
+                              className="d1fi02"
+                              condensed={false}
+                              hover={false}
+                              is="thead"
+                              striped={false}
+                            >
+                              <thead
+                                className="d1fi02"
+                              >
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={-0}
+                                  striped={false}
+                                  theadIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={-0}
+                                    striped={false}
+                                    theadIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={-0}
+                                      striped={false}
+                                      theadIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="1b0jccb"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={-0}
+                                        striped={false}
+                                        theadIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="1b0jccb"
+                                        />
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                              </thead>
+                            </TableHead>
+                          </TableHeadStyles>
+                        </TableHeadStyles>
+                      </ThemedComponent>
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        striped={false}
+                      >
+                        <TableBodyStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={false}
+                          hover={false}
+                          striped={false}
+                        >
+                          <TableBodyStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={false}
+                            hover={false}
+                            passThrough={Array []}
+                            striped={false}
+                          >
+                            <TableBody
+                              bare={false}
+                              bordered={true}
+                              className="zos2pn"
+                              condensed={false}
+                              hover={false}
+                              is="tbody"
+                              striped={false}
+                            >
+                              <tbody
+                                className="zos2pn"
+                              />
+                            </TableBody>
+                          </TableBodyStyles>
+                        </TableBodyStyles>
+                      </ThemedComponent>
+                    </table>
+                  </Table>
+                </TableStyles>
+              </TableStyles>
+            </ThemedComponent>
+          </TableBuilder>
+        </Connect(TableBuilder)>
+      </ThemeProvider>
+    </Provider>
+  </StyleProvider>
+</Provider>
 `;
 
 exports[`should render the dataset in columns 1`] = `
-<table
-  className="cf-table cf-table--bordered"
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
 >
-  <thead
-    className="cf-table__head"
+  <StyleProvider
+    dev={true}
   >
-    <tr
-      className="cf-table__row cf-table__row--default"
+    <Provider
+      renderer={
+        Object {
+          "_emitChange": [Function],
+          "_renderStyleToCache": [Function],
+          "_renderStyleToClassNames": [Function],
+          "cache": Object {
+            "1b0jccb": true,
+            "1c6l5ki": true,
+            "1f59ksd": true,
+            "1fm7xdg": true,
+            "1k2myrb": true,
+            "1uiy02g": true,
+            "1ypdp8g": true,
+            "46sr0r": true,
+            "7ul4z3": true,
+            "9x0t0g": true,
+            "9yqouo": true,
+            "d1fi02": true,
+            "g0oihw": true,
+            "t9kph0": true,
+            "zos2pn": true,
+          },
+          "clear": [Function],
+          "fontFaces": "",
+          "keyframePrefixes": Array [
+            "-webkit-",
+            "-moz-",
+            "",
+          ],
+          "keyframes": "",
+          "listeners": Array [
+            [Function],
+            [Function],
+          ],
+          "mediaQueryOrder": Array [],
+          "mediaRules": Object {
+            "(max-width: 47.2em)": ".46sr0r {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .d1fi02 {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1b0jccb {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .9x0t0g {
+          display: block;
+          width: 100%;
+          box-sizing: border-box;
+          border-top-width: 0px
+        }
+        
+        .7ul4z3 {
+          display: block;
+          width: 100%;
+          box-sizing: border-box;
+          border-top-width: 0px
+        }
+        
+        .zos2pn {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1c6l5ki {
+          display: block;
+          width: 100%;
+          box-sizing: border-box;
+          border-top-width: 0px
+        }
+        
+        .1f59ksd {
+          display: block;
+          width: 100%;
+          box-sizing: border-box;
+          border-top-width: 0px
+        }
+        
+        .1k2myrb {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1fm7xdg {
+          display: block;
+          width: 100%;
+          box-sizing: border-box;
+          border-top-width: 0px
+        }
+        
+        .1ypdp8g {
+          display: block;
+          width: 100%;
+          box-sizing: border-box;
+          border-top-width: 0px
+        }
+        
+        .t9kph0 {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .g0oihw {
+          display: block;
+          width: 100%;
+          box-sizing: border-box;
+          border-top-width: 0px
+        }
+        
+        .9yqouo {
+          display: block;
+          width: 100%;
+          box-sizing: border-box;
+          border-top-width: 0px
+        }
+        
+        .1uiy02g {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }",
+            "screen and (max-width: 47.2em)": ".46sr0r {
+          display: block
+        }
+        
+        .d1fi02 {
+          display: none
+        }
+        
+        .1b0jccb:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1b0jccb {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .9x0t0g {
+          display: block;
+          border: none;
+          float: left;
+          clear: left;
+          padding: 0px
+        }
+        
+        .7ul4z3 {
+          display: block;
+          border: none;
+          float: left;
+          clear: left;
+          padding: 0px
+        }
+        
+        .zos2pn {
+          display: block
+        }
+        
+        .1c6l5ki {
+          display: block;
+          border: none;
+          float: left;
+          clear: left;
+          padding: 0px
+        }
+        
+        .1f59ksd {
+          display: block;
+          border: none;
+          float: left;
+          clear: left;
+          padding: 0px
+        }
+        
+        .1k2myrb:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1k2myrb {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: 1px solid #dedede;
+          background-color: #ccc
+        }
+        
+        .1fm7xdg {
+          display: block;
+          border: none;
+          float: left;
+          clear: left;
+          padding: 0px
+        }
+        
+        .1ypdp8g {
+          display: block;
+          border: none;
+          float: left;
+          clear: left;
+          padding: 0px
+        }
+        
+        .t9kph0:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .t9kph0:hover> td {
+          background-color: transparent
+        }
+        
+        .t9kph0 {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .g0oihw {
+          display: block;
+          border: none;
+          float: left;
+          clear: left;
+          padding: 0px
+        }
+        
+        .9yqouo {
+          display: block;
+          border: none;
+          float: left;
+          clear: left;
+          padding: 0px
+        }
+        
+        .1uiy02g:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1uiy02g:hover> td {
+          background-color: transparent
+        }
+        
+        .1uiy02g {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: 1px solid #dedede;
+          background-color: #ccc
+        }",
+          },
+          "plugins": Array [
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "prettySelectors": false,
+          "renderFont": [Function],
+          "renderKeyframe": [Function],
+          "renderRule": [Function],
+          "renderStatic": [Function],
+          "renderToString": [Function],
+          "rules": ".46sr0r {
+          background: #fff;
+          border-collapse: collapse;
+          border-spacing: 0px;
+          max-width: 100%;
+          width: 100%
+        }
+        
+        .d1fi02 {
+          background: #dedede
+        }
+        
+        .1b0jccb {
+          border-color: #dedede
+        }
+        
+        .9x0t0g:first-letter {
+          text-transform: capitalize
+        }
+        
+        .9x0t0g {
+          border-top: 1px solid #dedede;
+          line-height: 1.5;
+          padding: 0.73333333333rem;
+          vertical-align: middle;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          border-left: 1px solid #dedede;
+          text-align: left;
+          font-weight: 600
+        }
+        
+        .7ul4z3:first-letter {
+          text-transform: capitalize
+        }
+        
+        .7ul4z3 {
+          border-top: 1px solid #dedede;
+          line-height: 1.5;
+          padding: 0.73333333333rem;
+          vertical-align: middle;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          border-left: 1px solid #dedede;
+          text-align: left;
+          font-weight: 600
+        }
+        
+        .1c6l5ki {
+          border-top: 1px solid #dedede;
+          line-height: 1.5;
+          padding: 0.73333333333rem;
+          vertical-align: middle;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          border-left: 1px solid #dedede
+        }
+        
+        .1f59ksd {
+          border-top: 1px solid #dedede;
+          line-height: 1.5;
+          padding: 0.73333333333rem;
+          vertical-align: middle;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          border-left: 1px solid #dedede
+        }
+        
+        .1k2myrb {
+          border-color: #dedede
+        }
+        
+        .1fm7xdg:first-letter {
+          text-transform: capitalize
+        }
+        
+        .1fm7xdg {
+          border-top: 0px;
+          line-height: 1.5;
+          padding: 0.73333333333rem;
+          vertical-align: bottom;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          border-left: 1px solid #dedede;
+          text-align: left;
+          font-weight: 600;
+          border-top-left-radius: 2px
+        }
+        
+        .1ypdp8g:first-letter {
+          text-transform: capitalize
+        }
+        
+        .1ypdp8g {
+          border-top: 0px;
+          line-height: 1.5;
+          padding: 0.73333333333rem;
+          vertical-align: bottom;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          border-left: 1px solid #dedede;
+          text-align: left;
+          font-weight: 600;
+          border-top-right-radius: 2px
+        }
+        
+        .t9kph0 {
+          border-color: #dedede
+        }
+        
+        .g0oihw {
+          border-top: 0px;
+          line-height: 1.5;
+          padding: 0.73333333333rem;
+          vertical-align: middle;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          border-top-left-radius: 2px;
+          border-left: 1px solid #dedede
+        }
+        
+        .9yqouo {
+          border-top: 0px;
+          line-height: 1.5;
+          padding: 0.73333333333rem;
+          vertical-align: middle;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          border-top-right-radius: 2px;
+          border-left: 1px solid #dedede
+        }
+        
+        .1uiy02g {
+          border-color: #dedede
+        }",
+          "selectorPrefix": "",
+          "statics": "",
+          "styleNodes": Object {
+            "RULE": <style
+              data-fela-type="RULE"
+              type="text/css"
+        >
+              .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede } .9x0t0g:first-letter { text-transform: capitalize } .9x0t0g { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600 } .7ul4z3:first-letter { text-transform: capitalize } .7ul4z3 { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600 } .1c6l5ki { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede } .1f59ksd { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede } .1k2myrb { border-color: #dedede } .1fm7xdg:first-letter { text-transform: capitalize } .1fm7xdg { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600; border-top-left-radius: 2px } .1ypdp8g:first-letter { text-transform: capitalize } .1ypdp8g { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: bottom; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 1px solid #dedede; text-align: left; font-weight: 600; border-top-right-radius: 2px } .t9kph0 { border-color: #dedede } .g0oihw { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-top-left-radius: 2px; border-left: 1px solid #dedede } .9yqouo { border-top: 0px; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-top-right-radius: 2px; border-left: 1px solid #dedede } .1uiy02g { border-color: #dedede }
+        </style>,
+            "RULE(max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="(max-width: 47.2em)"
+        >
+              .46sr0r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .9x0t0g { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .7ul4z3 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .zos2pn { display: block; width: 100%; box-sizing: border-box } .1c6l5ki { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .1f59ksd { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .1k2myrb { display: block; width: 100%; box-sizing: border-box } .1fm7xdg { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .1ypdp8g { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .t9kph0 { display: block; width: 100%; box-sizing: border-box } .g0oihw { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .9yqouo { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .1uiy02g { display: block; width: 100%; box-sizing: border-box }
+        </style>,
+            "RULEscreen and (max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="screen and (max-width: 47.2em)"
+        >
+              .46sr0r { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .9x0t0g { display: block; border: none; float: left; clear: left; padding: 0px } .7ul4z3 { display: block; border: none; float: left; clear: left; padding: 0px } .zos2pn { display: block } .1c6l5ki { display: block; border: none; float: left; clear: left; padding: 0px } .1f59ksd { display: block; border: none; float: left; clear: left; padding: 0px } .1k2myrb:after { content: ""; display: table; clear: both } .1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .1fm7xdg { display: block; border: none; float: left; clear: left; padding: 0px } .1ypdp8g { display: block; border: none; float: left; clear: left; padding: 0px } .t9kph0:after { content: ""; display: table; clear: both } .t9kph0:hover> td { background-color: transparent } .t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .g0oihw { display: block; border: none; float: left; clear: left; padding: 0px } .9yqouo { display: block; border: none; float: left; clear: left; padding: 0px } .1uiy02g:after { content: ""; display: table; clear: both } .1uiy02g:hover> td { background-color: transparent } .1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc }
+        </style>,
+          },
+          "subscribe": [Function],
+          "uniqueKeyframeIdentifier": 0,
+          "uniqueRuleIdentifier": 0,
+        }
+      }
     >
-      <th
-        className="cf-table__cell cf-table__cell--head"
+      <ThemeProvider
+        overwrite={false}
+        theme={
+          Object {
+            "arrowSize": "5px",
+            "bodyAccentColor": "#333",
+            "bodyBackground": "#ebebeb",
+            "bodyOffsetColor": "#787878",
+            "borderRadius": "2px",
+            "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+            "breakpoints": Object {
+              "desktop": "64em",
+              "desktopLarge": "97.6em",
+              "mobile": "13.6em",
+              "mobileWide": "30.4em",
+              "tablet": "47.2em",
+            },
+            "color": Object {
+              "apple": "#BD2527",
+              "carrot": "#f56500",
+              "cement": "#7D7D7D",
+              "charcoal": "#333333",
+              "dawn": "#F16975",
+              "dew": "#85CBA8",
+              "dusk": "#4D4D4F",
+              "grass": "#9BCA3E",
+              "hail": "#BCBEC0",
+              "lightning": "#FFDB6F",
+              "marine": "#2F7BBF",
+              "moonshine": "#F7F7F7",
+              "night": "#404041",
+              "rain": "#408BC9",
+              "sky": "#76C4E2",
+              "smoke": "#e0e0e0",
+              "storm": "#808285",
+              "sunrise": "#F69259",
+              "sunset": "#BA77B1",
+              "tangerine": "#FF7900",
+              "twilight": "#8176B5",
+            },
+            "colorBlack": "#000",
+            "colorBlue": "#2f7bbf",
+            "colorBlueDark": "#2869a2",
+            "colorBlueLight": "#62a1d8",
+            "colorError": "#ff3100",
+            "colorFacebookBlue": "#3b5998",
+            "colorGray": "#7c7c7c",
+            "colorGrayBorder": "#666",
+            "colorGrayDark": "#333",
+            "colorGrayLight": "#dedede",
+            "colorGrayLightOnboarding": "#F7F7F7",
+            "colorGreen": "#9bca3e",
+            "colorGreenDark": "#87b331",
+            "colorGreenLight": "#bada7a",
+            "colorImportantInformation": "rgba(64,139,201,0.2)",
+            "colorInfo": "#00a9eb",
+            "colorMainBackground": "#e6e6e6",
+            "colorMuted": "#7c7c7c",
+            "colorOffsetDark": 0.07,
+            "colorOffsetLight": 0.15,
+            "colorOrange": "#ff7900",
+            "colorOrangeDark": "#db6800",
+            "colorOrangeLight": "#ffa14d",
+            "colorOverlay": "rgba(0, 0, 0, .7)",
+            "colorPink": "#d91698",
+            "colorPinkDark": "#b91381",
+            "colorPinkLight": "#ed4eb8",
+            "colorPurple": "#9545e5",
+            "colorPurpleDark": "#b91381",
+            "colorPurpleLight": "#ed4eb8",
+            "colorRed": "#bd2527",
+            "colorRedDark": "#9f1f21",
+            "colorRedLight": "#dd5153",
+            "colorSmoke": "#f2f2f2",
+            "colorSuccess": "#68970f",
+            "colorTwitterBlue": "#00aced",
+            "colorWarning": "#fca520",
+            "colorWhite": "#fff",
+            "colorYellow": "#ffd24d",
+            "colorYellowDark": "#ffc929",
+            "colorYellowLight": "#ffe59a",
+            "disabledBackground": "#ededed",
+            "em": "1em",
+            "fontColor": "#333",
+            "fontColorHeadingCaption": "#888",
+            "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+            "fontSize": "15px",
+            "fontWeight": 400,
+            "fontWeightLight": 300,
+            "gradient": Object {
+              "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+              "five": "linear-gradient(left, #8176B5, #F16975)",
+              "four": "linear-gradient(left, #8176B5, #BA77B1)",
+              "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+              "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+              "six": "linear-gradient(left, #F16975, #F69259)",
+              "three": "linear-gradient(left, #8176B5, #76C4E2)",
+              "two": "linear-gradient(left, #8176B5, #85CBA8)",
+            },
+            "inputFontSize": "13px",
+            "inputLineHeight": 1.4,
+            "lineHeight": 1.5,
+            "rem": "1rem",
+            "weightBold": 700,
+            "weightLight": 300,
+            "weightNormal": 400,
+            "weightSemiBold": 600,
+            "zIndexMax": 1000,
+          }
+        }
       >
-        Name
-      </th>
-      <th
-        className="cf-table__cell cf-table__cell--head"
-      >
-        Value
-      </th>
-    </tr>
-  </thead>
-  <tbody
-    className="cf-table__body"
+        <Connect(TableBuilder)
+          columns={
+            Array [
+              Object {
+                "cell": [Function],
+                "label": "Name",
+              },
+              Object {
+                "cell": [Function],
+                "label": "Value",
+              },
+            ]
+          }
+          rows={
+            Array [
+              Object {
+                "cells": Object {
+                  "name": "Foo",
+                  "value": "foo",
+                },
+                "id": "1",
+              },
+              Object {
+                "cells": Object {
+                  "name": "Bar",
+                  "value": "bar",
+                },
+                "id": "2",
+              },
+            ]
+          }
+          tableName="test-table"
+        >
+          <TableBuilder
+            columns={
+              Array [
+                Object {
+                  "cell": [Function],
+                  "label": "Name",
+                },
+                Object {
+                  "cell": [Function],
+                  "label": "Value",
+                },
+              ]
+            }
+            dispatch={[Function]}
+            flashes={Object {}}
+            rows={
+              Array [
+                Object {
+                  "cells": Object {
+                    "name": "Foo",
+                    "value": "foo",
+                  },
+                  "id": "1",
+                },
+                Object {
+                  "cells": Object {
+                    "name": "Bar",
+                    "value": "bar",
+                  },
+                  "id": "2",
+                },
+              ]
+            }
+            tableName="test-table"
+          >
+            <ThemedComponent>
+              <TableStyles>
+                <TableStyles
+                  _felaRule={[Function]}
+                  passThrough={Array []}
+                >
+                  <Table
+                    bare={false}
+                    bordered={true}
+                    className="46sr0r"
+                    condensed={false}
+                    hover={false}
+                    is="table"
+                    striped={false}
+                  >
+                    <table
+                      className="46sr0r"
+                    >
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        striped={false}
+                      >
+                        <TableHeadStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={false}
+                          hover={false}
+                          striped={false}
+                        >
+                          <TableHeadStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={false}
+                            hover={false}
+                            passThrough={Array []}
+                            striped={false}
+                          >
+                            <TableHead
+                              bare={false}
+                              bordered={true}
+                              className="d1fi02"
+                              condensed={false}
+                              hover={false}
+                              is="thead"
+                              striped={false}
+                            >
+                              <thead
+                                className="d1fi02"
+                              >
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={-0}
+                                  striped={false}
+                                  theadIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={-0}
+                                    striped={false}
+                                    theadIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={-0}
+                                      striped={false}
+                                      theadIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="1b0jccb"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={-0}
+                                        striped={false}
+                                        theadIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="1b0jccb"
+                                        >
+                                          <ThemedComponent
+                                            bare={false}
+                                            bordered={true}
+                                            cellIndex={0}
+                                            condensed={false}
+                                            hover={false}
+                                            rowIndex={-0}
+                                            rowType="default"
+                                            striped={false}
+                                            theadIndex={0}
+                                          >
+                                            <TableHeadCellStyles
+                                              bare={false}
+                                              bordered={true}
+                                              cellIndex={0}
+                                              condensed={false}
+                                              hover={false}
+                                              rowIndex={-0}
+                                              rowType="default"
+                                              striped={false}
+                                              theadIndex={0}
+                                            >
+                                              <TableCellStyles
+                                                _felaRule={[Function]}
+                                                bare={false}
+                                                bordered={true}
+                                                cellIndex={0}
+                                                condensed={false}
+                                                hover={false}
+                                                passThrough={Array []}
+                                                rowIndex={-0}
+                                                rowType="default"
+                                                striped={false}
+                                                theadIndex={0}
+                                              >
+                                                <TableCellStyles
+                                                  _felaRule={[Function]}
+                                                  bare={false}
+                                                  bordered={true}
+                                                  cellIndex={0}
+                                                  condensed={false}
+                                                  hover={false}
+                                                  passThrough={Array []}
+                                                  rowIndex={-0}
+                                                  rowType="default"
+                                                  striped={false}
+                                                  theadIndex={0}
+                                                >
+                                                  <TableHeadCell
+                                                    bare={false}
+                                                    bordered={true}
+                                                    cellIndex={0}
+                                                    className="1fm7xdg"
+                                                    condensed={false}
+                                                    hover={false}
+                                                    is="th"
+                                                    rowIndex={-0}
+                                                    rowType="default"
+                                                    striped={false}
+                                                    theadIndex={0}
+                                                  >
+                                                    <th
+                                                      className="1fm7xdg"
+                                                    >
+                                                      Name
+                                                    </th>
+                                                  </TableHeadCell>
+                                                </TableCellStyles>
+                                              </TableCellStyles>
+                                            </TableHeadCellStyles>
+                                          </ThemedComponent>
+                                          <ThemedComponent
+                                            bare={false}
+                                            bordered={true}
+                                            cellIndex={-1}
+                                            condensed={false}
+                                            hover={false}
+                                            rowIndex={-0}
+                                            rowType="default"
+                                            striped={false}
+                                            theadIndex={0}
+                                          >
+                                            <TableHeadCellStyles
+                                              bare={false}
+                                              bordered={true}
+                                              cellIndex={-1}
+                                              condensed={false}
+                                              hover={false}
+                                              rowIndex={-0}
+                                              rowType="default"
+                                              striped={false}
+                                              theadIndex={0}
+                                            >
+                                              <TableCellStyles
+                                                _felaRule={[Function]}
+                                                bare={false}
+                                                bordered={true}
+                                                cellIndex={-1}
+                                                condensed={false}
+                                                hover={false}
+                                                passThrough={Array []}
+                                                rowIndex={-0}
+                                                rowType="default"
+                                                striped={false}
+                                                theadIndex={0}
+                                              >
+                                                <TableCellStyles
+                                                  _felaRule={[Function]}
+                                                  bare={false}
+                                                  bordered={true}
+                                                  cellIndex={-1}
+                                                  condensed={false}
+                                                  hover={false}
+                                                  passThrough={Array []}
+                                                  rowIndex={-0}
+                                                  rowType="default"
+                                                  striped={false}
+                                                  theadIndex={0}
+                                                >
+                                                  <TableHeadCell
+                                                    bare={false}
+                                                    bordered={true}
+                                                    cellIndex={-1}
+                                                    className="1ypdp8g"
+                                                    condensed={false}
+                                                    hover={false}
+                                                    is="th"
+                                                    rowIndex={-0}
+                                                    rowType="default"
+                                                    striped={false}
+                                                    theadIndex={0}
+                                                  >
+                                                    <th
+                                                      className="1ypdp8g"
+                                                    >
+                                                      Value
+                                                    </th>
+                                                  </TableHeadCell>
+                                                </TableCellStyles>
+                                              </TableCellStyles>
+                                            </TableHeadCellStyles>
+                                          </ThemedComponent>
+                                        </tr>
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                              </thead>
+                            </TableHead>
+                          </TableHeadStyles>
+                        </TableHeadStyles>
+                      </ThemedComponent>
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        striped={false}
+                      >
+                        <TableBodyStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={false}
+                          hover={false}
+                          striped={false}
+                        >
+                          <TableBodyStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={false}
+                            hover={false}
+                            passThrough={Array []}
+                            striped={false}
+                          >
+                            <TableBody
+                              bare={false}
+                              bordered={true}
+                              className="zos2pn"
+                              condensed={false}
+                              hover={false}
+                              is="tbody"
+                              striped={false}
+                            >
+                              <tbody
+                                className="zos2pn"
+                              >
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={0}
+                                  striped={false}
+                                  tbodyIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={0}
+                                    striped={false}
+                                    tbodyIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={0}
+                                      striped={false}
+                                      tbodyIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="t9kph0"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={0}
+                                        striped={false}
+                                        tbodyIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="t9kph0"
+                                        >
+                                          <ThemedComponent
+                                            bare={false}
+                                            bordered={true}
+                                            cellIndex={0}
+                                            condensed={false}
+                                            hover={false}
+                                            rowIndex={0}
+                                            rowType="default"
+                                            striped={false}
+                                            tbodyIndex={0}
+                                          >
+                                            <TableCellStyles
+                                              bare={false}
+                                              bordered={true}
+                                              cellIndex={0}
+                                              condensed={false}
+                                              hover={false}
+                                              rowIndex={0}
+                                              rowType="default"
+                                              striped={false}
+                                              tbodyIndex={0}
+                                            >
+                                              <TableCellStyles
+                                                _felaRule={[Function]}
+                                                bare={false}
+                                                bordered={true}
+                                                cellIndex={0}
+                                                condensed={false}
+                                                hover={false}
+                                                passThrough={Array []}
+                                                rowIndex={0}
+                                                rowType="default"
+                                                striped={false}
+                                                tbodyIndex={0}
+                                              >
+                                                <TableCell
+                                                  align="left"
+                                                  bare={false}
+                                                  bordered={true}
+                                                  cellIndex={0}
+                                                  className="g0oihw"
+                                                  condensed={false}
+                                                  hover={false}
+                                                  is="td"
+                                                  rowIndex={0}
+                                                  rowType="default"
+                                                  striped={false}
+                                                  tbodyIndex={0}
+                                                >
+                                                  <td
+                                                    className="g0oihw"
+                                                  >
+                                                    Foo
+                                                  </td>
+                                                </TableCell>
+                                              </TableCellStyles>
+                                            </TableCellStyles>
+                                          </ThemedComponent>
+                                          <ThemedComponent
+                                            bare={false}
+                                            bordered={true}
+                                            cellIndex={-1}
+                                            condensed={false}
+                                            hover={false}
+                                            rowIndex={0}
+                                            rowType="default"
+                                            striped={false}
+                                            tbodyIndex={0}
+                                          >
+                                            <TableCellStyles
+                                              bare={false}
+                                              bordered={true}
+                                              cellIndex={-1}
+                                              condensed={false}
+                                              hover={false}
+                                              rowIndex={0}
+                                              rowType="default"
+                                              striped={false}
+                                              tbodyIndex={0}
+                                            >
+                                              <TableCellStyles
+                                                _felaRule={[Function]}
+                                                bare={false}
+                                                bordered={true}
+                                                cellIndex={-1}
+                                                condensed={false}
+                                                hover={false}
+                                                passThrough={Array []}
+                                                rowIndex={0}
+                                                rowType="default"
+                                                striped={false}
+                                                tbodyIndex={0}
+                                              >
+                                                <TableCell
+                                                  align="left"
+                                                  bare={false}
+                                                  bordered={true}
+                                                  cellIndex={-1}
+                                                  className="9yqouo"
+                                                  condensed={false}
+                                                  hover={false}
+                                                  is="td"
+                                                  rowIndex={0}
+                                                  rowType="default"
+                                                  striped={false}
+                                                  tbodyIndex={0}
+                                                >
+                                                  <td
+                                                    className="9yqouo"
+                                                  >
+                                                    foo
+                                                  </td>
+                                                </TableCell>
+                                              </TableCellStyles>
+                                            </TableCellStyles>
+                                          </ThemedComponent>
+                                        </tr>
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={-1}
+                                  striped={false}
+                                  tbodyIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={-1}
+                                    striped={false}
+                                    tbodyIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={-1}
+                                      striped={false}
+                                      tbodyIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="1uiy02g"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={-1}
+                                        striped={false}
+                                        tbodyIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="1uiy02g"
+                                        >
+                                          <ThemedComponent
+                                            bare={false}
+                                            bordered={true}
+                                            cellIndex={0}
+                                            condensed={false}
+                                            hover={false}
+                                            rowIndex={-1}
+                                            rowType="default"
+                                            striped={false}
+                                            tbodyIndex={0}
+                                          >
+                                            <TableCellStyles
+                                              bare={false}
+                                              bordered={true}
+                                              cellIndex={0}
+                                              condensed={false}
+                                              hover={false}
+                                              rowIndex={-1}
+                                              rowType="default"
+                                              striped={false}
+                                              tbodyIndex={0}
+                                            >
+                                              <TableCellStyles
+                                                _felaRule={[Function]}
+                                                bare={false}
+                                                bordered={true}
+                                                cellIndex={0}
+                                                condensed={false}
+                                                hover={false}
+                                                passThrough={Array []}
+                                                rowIndex={-1}
+                                                rowType="default"
+                                                striped={false}
+                                                tbodyIndex={0}
+                                              >
+                                                <TableCell
+                                                  align="left"
+                                                  bare={false}
+                                                  bordered={true}
+                                                  cellIndex={0}
+                                                  className="1c6l5ki"
+                                                  condensed={false}
+                                                  hover={false}
+                                                  is="td"
+                                                  rowIndex={-1}
+                                                  rowType="default"
+                                                  striped={false}
+                                                  tbodyIndex={0}
+                                                >
+                                                  <td
+                                                    className="1c6l5ki"
+                                                  >
+                                                    Bar
+                                                  </td>
+                                                </TableCell>
+                                              </TableCellStyles>
+                                            </TableCellStyles>
+                                          </ThemedComponent>
+                                          <ThemedComponent
+                                            bare={false}
+                                            bordered={true}
+                                            cellIndex={-1}
+                                            condensed={false}
+                                            hover={false}
+                                            rowIndex={-1}
+                                            rowType="default"
+                                            striped={false}
+                                            tbodyIndex={0}
+                                          >
+                                            <TableCellStyles
+                                              bare={false}
+                                              bordered={true}
+                                              cellIndex={-1}
+                                              condensed={false}
+                                              hover={false}
+                                              rowIndex={-1}
+                                              rowType="default"
+                                              striped={false}
+                                              tbodyIndex={0}
+                                            >
+                                              <TableCellStyles
+                                                _felaRule={[Function]}
+                                                bare={false}
+                                                bordered={true}
+                                                cellIndex={-1}
+                                                condensed={false}
+                                                hover={false}
+                                                passThrough={Array []}
+                                                rowIndex={-1}
+                                                rowType="default"
+                                                striped={false}
+                                                tbodyIndex={0}
+                                              >
+                                                <TableCell
+                                                  align="left"
+                                                  bare={false}
+                                                  bordered={true}
+                                                  cellIndex={-1}
+                                                  className="1f59ksd"
+                                                  condensed={false}
+                                                  hover={false}
+                                                  is="td"
+                                                  rowIndex={-1}
+                                                  rowType="default"
+                                                  striped={false}
+                                                  tbodyIndex={0}
+                                                >
+                                                  <td
+                                                    className="1f59ksd"
+                                                  >
+                                                    bar
+                                                  </td>
+                                                </TableCell>
+                                              </TableCellStyles>
+                                            </TableCellStyles>
+                                          </ThemedComponent>
+                                        </tr>
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                              </tbody>
+                            </TableBody>
+                          </TableBodyStyles>
+                        </TableBodyStyles>
+                      </ThemedComponent>
+                    </table>
+                  </Table>
+                </TableStyles>
+              </TableStyles>
+            </ThemedComponent>
+          </TableBuilder>
+        </Connect(TableBuilder)>
+      </ThemeProvider>
+    </Provider>
+  </StyleProvider>
+</Provider>
+`;
+
+exports[`should support flashes 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <StyleProvider
+    dev={true}
   >
-    <tr
-      className="cf-table__row cf-table__row--default"
+    <Provider
+      renderer={
+        Object {
+          "_emitChange": [Function],
+          "_renderStyleToCache": [Function],
+          "_renderStyleToClassNames": [Function],
+          "cache": Object {
+            "14uu5dt": true,
+            "1b0jccb": true,
+            "1k2myrb": true,
+            "1uiy02g": true,
+            "46sr0r": true,
+            "d1fi02": true,
+            "t9kph0": true,
+            "zos2pn": true,
+          },
+          "clear": [Function],
+          "fontFaces": "",
+          "keyframePrefixes": Array [
+            "-webkit-",
+            "-moz-",
+            "",
+          ],
+          "keyframes": "",
+          "listeners": Array [
+            [Function],
+            [Function],
+          ],
+          "mediaQueryOrder": Array [],
+          "mediaRules": Object {
+            "(max-width: 47.2em)": ".46sr0r {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .d1fi02 {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1b0jccb {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .zos2pn {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1k2myrb {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .t9kph0 {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1uiy02g {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .14uu5dt {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }",
+            "screen and (max-width: 47.2em)": ".46sr0r {
+          display: block
+        }
+        
+        .d1fi02 {
+          display: none
+        }
+        
+        .1b0jccb:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1b0jccb {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .zos2pn {
+          display: block
+        }
+        
+        .1k2myrb:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1k2myrb {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: 1px solid #dedede;
+          background-color: #ccc
+        }
+        
+        .t9kph0:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .t9kph0:hover> td {
+          background-color: transparent
+        }
+        
+        .t9kph0 {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .1uiy02g:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1uiy02g:hover> td {
+          background-color: transparent
+        }
+        
+        .1uiy02g {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: 1px solid #dedede;
+          background-color: #ccc
+        }
+        
+        .14uu5dt:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .14uu5dt:hover> td {
+          background-color: transparent
+        }
+        
+        .14uu5dt {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }",
+          },
+          "plugins": Array [
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "prettySelectors": false,
+          "renderFont": [Function],
+          "renderKeyframe": [Function],
+          "renderRule": [Function],
+          "renderStatic": [Function],
+          "renderToString": [Function],
+          "rules": ".46sr0r {
+          background: #fff;
+          border-collapse: collapse;
+          border-spacing: 0px;
+          max-width: 100%;
+          width: 100%
+        }
+        
+        .d1fi02 {
+          background: #dedede
+        }
+        
+        .1b0jccb {
+          border-color: #dedede
+        }
+        
+        .1k2myrb {
+          border-color: #dedede
+        }
+        
+        .t9kph0 {
+          border-color: #dedede
+        }
+        
+        .1uiy02g {
+          border-color: #dedede
+        }
+        
+        .14uu5dt {
+          border-color: #b0d466;
+          background-color: #bada7a
+        }",
+          "selectorPrefix": "",
+          "statics": "",
+          "styleNodes": Object {
+            "RULE": <style
+              data-fela-type="RULE"
+              type="text/css"
+        >
+              .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede } .1k2myrb { border-color: #dedede } .t9kph0 { border-color: #dedede } .1uiy02g { border-color: #dedede } .14uu5dt { border-color: #b0d466; background-color: #bada7a }
+        </style>,
+            "RULE(max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="(max-width: 47.2em)"
+        >
+              .46sr0r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box } .1k2myrb { display: block; width: 100%; box-sizing: border-box } .t9kph0 { display: block; width: 100%; box-sizing: border-box } .1uiy02g { display: block; width: 100%; box-sizing: border-box } .14uu5dt { display: block; width: 100%; box-sizing: border-box }
+        </style>,
+            "RULEscreen and (max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="screen and (max-width: 47.2em)"
+        >
+              .46sr0r { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .zos2pn { display: block } .1k2myrb:after { content: ""; display: table; clear: both } .1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .t9kph0:after { content: ""; display: table; clear: both } .t9kph0:hover> td { background-color: transparent } .t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .1uiy02g:after { content: ""; display: table; clear: both } .1uiy02g:hover> td { background-color: transparent } .1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .14uu5dt:after { content: ""; display: table; clear: both } .14uu5dt:hover> td { background-color: transparent } .14uu5dt { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
+        </style>,
+          },
+          "subscribe": [Function],
+          "uniqueKeyframeIdentifier": 0,
+          "uniqueRuleIdentifier": 0,
+        }
+      }
     >
-      <td
-        className="cf-table__cell"
+      <ThemeProvider
+        overwrite={false}
+        theme={
+          Object {
+            "arrowSize": "5px",
+            "bodyAccentColor": "#333",
+            "bodyBackground": "#ebebeb",
+            "bodyOffsetColor": "#787878",
+            "borderRadius": "2px",
+            "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+            "breakpoints": Object {
+              "desktop": "64em",
+              "desktopLarge": "97.6em",
+              "mobile": "13.6em",
+              "mobileWide": "30.4em",
+              "tablet": "47.2em",
+            },
+            "color": Object {
+              "apple": "#BD2527",
+              "carrot": "#f56500",
+              "cement": "#7D7D7D",
+              "charcoal": "#333333",
+              "dawn": "#F16975",
+              "dew": "#85CBA8",
+              "dusk": "#4D4D4F",
+              "grass": "#9BCA3E",
+              "hail": "#BCBEC0",
+              "lightning": "#FFDB6F",
+              "marine": "#2F7BBF",
+              "moonshine": "#F7F7F7",
+              "night": "#404041",
+              "rain": "#408BC9",
+              "sky": "#76C4E2",
+              "smoke": "#e0e0e0",
+              "storm": "#808285",
+              "sunrise": "#F69259",
+              "sunset": "#BA77B1",
+              "tangerine": "#FF7900",
+              "twilight": "#8176B5",
+            },
+            "colorBlack": "#000",
+            "colorBlue": "#2f7bbf",
+            "colorBlueDark": "#2869a2",
+            "colorBlueLight": "#62a1d8",
+            "colorError": "#ff3100",
+            "colorFacebookBlue": "#3b5998",
+            "colorGray": "#7c7c7c",
+            "colorGrayBorder": "#666",
+            "colorGrayDark": "#333",
+            "colorGrayLight": "#dedede",
+            "colorGrayLightOnboarding": "#F7F7F7",
+            "colorGreen": "#9bca3e",
+            "colorGreenDark": "#87b331",
+            "colorGreenLight": "#bada7a",
+            "colorImportantInformation": "rgba(64,139,201,0.2)",
+            "colorInfo": "#00a9eb",
+            "colorMainBackground": "#e6e6e6",
+            "colorMuted": "#7c7c7c",
+            "colorOffsetDark": 0.07,
+            "colorOffsetLight": 0.15,
+            "colorOrange": "#ff7900",
+            "colorOrangeDark": "#db6800",
+            "colorOrangeLight": "#ffa14d",
+            "colorOverlay": "rgba(0, 0, 0, .7)",
+            "colorPink": "#d91698",
+            "colorPinkDark": "#b91381",
+            "colorPinkLight": "#ed4eb8",
+            "colorPurple": "#9545e5",
+            "colorPurpleDark": "#b91381",
+            "colorPurpleLight": "#ed4eb8",
+            "colorRed": "#bd2527",
+            "colorRedDark": "#9f1f21",
+            "colorRedLight": "#dd5153",
+            "colorSmoke": "#f2f2f2",
+            "colorSuccess": "#68970f",
+            "colorTwitterBlue": "#00aced",
+            "colorWarning": "#fca520",
+            "colorWhite": "#fff",
+            "colorYellow": "#ffd24d",
+            "colorYellowDark": "#ffc929",
+            "colorYellowLight": "#ffe59a",
+            "disabledBackground": "#ededed",
+            "em": "1em",
+            "fontColor": "#333",
+            "fontColorHeadingCaption": "#888",
+            "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+            "fontSize": "15px",
+            "fontWeight": 400,
+            "fontWeightLight": 300,
+            "gradient": Object {
+              "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+              "five": "linear-gradient(left, #8176B5, #F16975)",
+              "four": "linear-gradient(left, #8176B5, #BA77B1)",
+              "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+              "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+              "six": "linear-gradient(left, #F16975, #F69259)",
+              "three": "linear-gradient(left, #8176B5, #76C4E2)",
+              "two": "linear-gradient(left, #8176B5, #85CBA8)",
+            },
+            "inputFontSize": "13px",
+            "inputLineHeight": 1.4,
+            "lineHeight": 1.5,
+            "rem": "1rem",
+            "weightBold": 700,
+            "weightLight": 300,
+            "weightNormal": 400,
+            "weightSemiBold": 600,
+            "zIndexMax": 1000,
+          }
+        }
       >
-        Foo
-      </td>
-      <td
-        className="cf-table__cell"
-      >
-        foo
-      </td>
-    </tr>
-    <tr
-      className="cf-table__row cf-table__row--default"
-    >
-      <td
-        className="cf-table__cell"
-      >
-        Bar
-      </td>
-      <td
-        className="cf-table__cell"
-      >
-        bar
-      </td>
-    </tr>
-  </tbody>
-</table>
+        <Connect(TableBuilder)
+          columns={Array []}
+          rows={
+            Array [
+              Object {
+                "cells": Object {},
+                "id": "1",
+              },
+              Object {
+                "cells": Object {},
+                "id": "2",
+              },
+            ]
+          }
+          tableName="test-table"
+        >
+          <TableBuilder
+            columns={Array []}
+            dispatch={[Function]}
+            flashes={
+              Object {
+                "1": "success",
+              }
+            }
+            rows={
+              Array [
+                Object {
+                  "cells": Object {},
+                  "id": "1",
+                },
+                Object {
+                  "cells": Object {},
+                  "id": "2",
+                },
+              ]
+            }
+            tableName="test-table"
+          >
+            <ThemedComponent>
+              <TableStyles>
+                <TableStyles
+                  _felaRule={[Function]}
+                  passThrough={Array []}
+                >
+                  <Table
+                    bare={false}
+                    bordered={true}
+                    className="46sr0r"
+                    condensed={false}
+                    hover={false}
+                    is="table"
+                    striped={false}
+                  >
+                    <table
+                      className="46sr0r"
+                    >
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        striped={false}
+                      >
+                        <TableHeadStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={false}
+                          hover={false}
+                          striped={false}
+                        >
+                          <TableHeadStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={false}
+                            hover={false}
+                            passThrough={Array []}
+                            striped={false}
+                          >
+                            <TableHead
+                              bare={false}
+                              bordered={true}
+                              className="d1fi02"
+                              condensed={false}
+                              hover={false}
+                              is="thead"
+                              striped={false}
+                            >
+                              <thead
+                                className="d1fi02"
+                              >
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={-0}
+                                  striped={false}
+                                  theadIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={-0}
+                                    striped={false}
+                                    theadIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={-0}
+                                      striped={false}
+                                      theadIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="1b0jccb"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={-0}
+                                        striped={false}
+                                        theadIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="1b0jccb"
+                                        />
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                              </thead>
+                            </TableHead>
+                          </TableHeadStyles>
+                        </TableHeadStyles>
+                      </ThemedComponent>
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        striped={false}
+                      >
+                        <TableBodyStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={false}
+                          hover={false}
+                          striped={false}
+                        >
+                          <TableBodyStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={false}
+                            hover={false}
+                            passThrough={Array []}
+                            striped={false}
+                          >
+                            <TableBody
+                              bare={false}
+                              bordered={true}
+                              className="zos2pn"
+                              condensed={false}
+                              hover={false}
+                              is="tbody"
+                              striped={false}
+                            >
+                              <tbody
+                                className="zos2pn"
+                              >
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={0}
+                                  striped={false}
+                                  tbodyIndex={0}
+                                  type="success"
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={0}
+                                    striped={false}
+                                    tbodyIndex={0}
+                                    type="success"
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={0}
+                                      striped={false}
+                                      tbodyIndex={0}
+                                      type="success"
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="14uu5dt"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={0}
+                                        striped={false}
+                                        tbodyIndex={0}
+                                        type="success"
+                                      >
+                                        <tr
+                                          className="14uu5dt"
+                                        />
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={-1}
+                                  striped={false}
+                                  tbodyIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={-1}
+                                    striped={false}
+                                    tbodyIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={-1}
+                                      striped={false}
+                                      tbodyIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="1uiy02g"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={-1}
+                                        striped={false}
+                                        tbodyIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="1uiy02g"
+                                        />
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                              </tbody>
+                            </TableBody>
+                          </TableBodyStyles>
+                        </TableBodyStyles>
+                      </ThemedComponent>
+                    </table>
+                  </Table>
+                </TableStyles>
+              </TableStyles>
+            </ThemedComponent>
+          </TableBuilder>
+        </Connect(TableBuilder)>
+      </ThemeProvider>
+    </Provider>
+  </StyleProvider>
+</Provider>
 `;
 
 exports[`should support row type/accent 1`] = `
-<table
-  className="cf-table cf-table--bordered"
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
 >
-  <thead
-    className="cf-table__head"
+  <StyleProvider
+    dev={true}
   >
-    <tr
-      className="cf-table__row cf-table__row--default"
-    />
-  </thead>
-  <tbody
-    className="cf-table__body"
-  >
-    <tr
-      className="cf-table__row cf-table__row--success"
-    />
-    <tr
-      className="cf-table__row cf-table__row--default cf-table__row--accent-red"
-    />
-  </tbody>
-</table>
+    <Provider
+      renderer={
+        Object {
+          "_emitChange": [Function],
+          "_renderStyleToCache": [Function],
+          "_renderStyleToClassNames": [Function],
+          "cache": Object {
+            "14uu5dt": true,
+            "1b0jccb": true,
+            "1k2myrb": true,
+            "1uiy02g": true,
+            "46sr0r": true,
+            "d1fi02": true,
+            "dreiha": true,
+            "zos2pn": true,
+          },
+          "clear": [Function],
+          "fontFaces": "",
+          "keyframePrefixes": Array [
+            "-webkit-",
+            "-moz-",
+            "",
+          ],
+          "keyframes": "",
+          "listeners": Array [
+            [Function],
+            [Function],
+          ],
+          "mediaQueryOrder": Array [],
+          "mediaRules": Object {
+            "(max-width: 47.2em)": ".46sr0r {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .d1fi02 {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1b0jccb {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .zos2pn {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .dreiha {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1k2myrb {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .14uu5dt {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1uiy02g {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }",
+            "screen and (max-width: 47.2em)": ".46sr0r {
+          display: block
+        }
+        
+        .d1fi02 {
+          display: none
+        }
+        
+        .1b0jccb:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1b0jccb {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .zos2pn {
+          display: block
+        }
+        
+        .dreiha:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .dreiha {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .1k2myrb:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1k2myrb {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: 1px solid #dedede;
+          background-color: #ccc
+        }
+        
+        .14uu5dt:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .14uu5dt:hover> td {
+          background-color: transparent
+        }
+        
+        .14uu5dt {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .1uiy02g:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1uiy02g:hover> td {
+          background-color: transparent
+        }
+        
+        .1uiy02g {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: 1px solid #dedede;
+          background-color: #ccc
+        }",
+          },
+          "plugins": Array [
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "prettySelectors": false,
+          "renderFont": [Function],
+          "renderKeyframe": [Function],
+          "renderRule": [Function],
+          "renderStatic": [Function],
+          "renderToString": [Function],
+          "rules": ".46sr0r {
+          background: #fff;
+          border-collapse: collapse;
+          border-spacing: 0px;
+          max-width: 100%;
+          width: 100%
+        }
+        
+        .d1fi02 {
+          background: #dedede
+        }
+        
+        .1b0jccb {
+          border-color: #dedede
+        }
+        
+        .dreiha {
+          border-color: #b0d466;
+          background-color: #bada7a
+        }
+        
+        .1k2myrb {
+          border-color: #dedede
+        }
+        
+        .14uu5dt {
+          border-color: #b0d466;
+          background-color: #bada7a
+        }
+        
+        .1uiy02g {
+          border-color: #dedede
+        }",
+          "selectorPrefix": "",
+          "statics": "",
+          "styleNodes": Object {
+            "RULE": <style
+              data-fela-type="RULE"
+              type="text/css"
+        >
+              .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede } .dreiha { border-color: #b0d466; background-color: #bada7a } .1k2myrb { border-color: #dedede } .14uu5dt { border-color: #b0d466; background-color: #bada7a } .1uiy02g { border-color: #dedede }
+        </style>,
+            "RULE(max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="(max-width: 47.2em)"
+        >
+              .46sr0r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box } .dreiha { display: block; width: 100%; box-sizing: border-box } .1k2myrb { display: block; width: 100%; box-sizing: border-box } .14uu5dt { display: block; width: 100%; box-sizing: border-box } .1uiy02g { display: block; width: 100%; box-sizing: border-box }
+        </style>,
+            "RULEscreen and (max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="screen and (max-width: 47.2em)"
+        >
+              .46sr0r { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .zos2pn { display: block } .dreiha:after { content: ""; display: table; clear: both } .dreiha { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .1k2myrb:after { content: ""; display: table; clear: both } .1k2myrb { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .14uu5dt:after { content: ""; display: table; clear: both } .14uu5dt:hover> td { background-color: transparent } .14uu5dt { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .1uiy02g:after { content: ""; display: table; clear: both } .1uiy02g:hover> td { background-color: transparent } .1uiy02g { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc }
+        </style>,
+          },
+          "subscribe": [Function],
+          "uniqueKeyframeIdentifier": 0,
+          "uniqueRuleIdentifier": 0,
+        }
+      }
+    >
+      <ThemeProvider
+        overwrite={false}
+        theme={
+          Object {
+            "arrowSize": "5px",
+            "bodyAccentColor": "#333",
+            "bodyBackground": "#ebebeb",
+            "bodyOffsetColor": "#787878",
+            "borderRadius": "2px",
+            "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+            "breakpoints": Object {
+              "desktop": "64em",
+              "desktopLarge": "97.6em",
+              "mobile": "13.6em",
+              "mobileWide": "30.4em",
+              "tablet": "47.2em",
+            },
+            "color": Object {
+              "apple": "#BD2527",
+              "carrot": "#f56500",
+              "cement": "#7D7D7D",
+              "charcoal": "#333333",
+              "dawn": "#F16975",
+              "dew": "#85CBA8",
+              "dusk": "#4D4D4F",
+              "grass": "#9BCA3E",
+              "hail": "#BCBEC0",
+              "lightning": "#FFDB6F",
+              "marine": "#2F7BBF",
+              "moonshine": "#F7F7F7",
+              "night": "#404041",
+              "rain": "#408BC9",
+              "sky": "#76C4E2",
+              "smoke": "#e0e0e0",
+              "storm": "#808285",
+              "sunrise": "#F69259",
+              "sunset": "#BA77B1",
+              "tangerine": "#FF7900",
+              "twilight": "#8176B5",
+            },
+            "colorBlack": "#000",
+            "colorBlue": "#2f7bbf",
+            "colorBlueDark": "#2869a2",
+            "colorBlueLight": "#62a1d8",
+            "colorError": "#ff3100",
+            "colorFacebookBlue": "#3b5998",
+            "colorGray": "#7c7c7c",
+            "colorGrayBorder": "#666",
+            "colorGrayDark": "#333",
+            "colorGrayLight": "#dedede",
+            "colorGrayLightOnboarding": "#F7F7F7",
+            "colorGreen": "#9bca3e",
+            "colorGreenDark": "#87b331",
+            "colorGreenLight": "#bada7a",
+            "colorImportantInformation": "rgba(64,139,201,0.2)",
+            "colorInfo": "#00a9eb",
+            "colorMainBackground": "#e6e6e6",
+            "colorMuted": "#7c7c7c",
+            "colorOffsetDark": 0.07,
+            "colorOffsetLight": 0.15,
+            "colorOrange": "#ff7900",
+            "colorOrangeDark": "#db6800",
+            "colorOrangeLight": "#ffa14d",
+            "colorOverlay": "rgba(0, 0, 0, .7)",
+            "colorPink": "#d91698",
+            "colorPinkDark": "#b91381",
+            "colorPinkLight": "#ed4eb8",
+            "colorPurple": "#9545e5",
+            "colorPurpleDark": "#b91381",
+            "colorPurpleLight": "#ed4eb8",
+            "colorRed": "#bd2527",
+            "colorRedDark": "#9f1f21",
+            "colorRedLight": "#dd5153",
+            "colorSmoke": "#f2f2f2",
+            "colorSuccess": "#68970f",
+            "colorTwitterBlue": "#00aced",
+            "colorWarning": "#fca520",
+            "colorWhite": "#fff",
+            "colorYellow": "#ffd24d",
+            "colorYellowDark": "#ffc929",
+            "colorYellowLight": "#ffe59a",
+            "disabledBackground": "#ededed",
+            "em": "1em",
+            "fontColor": "#333",
+            "fontColorHeadingCaption": "#888",
+            "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+            "fontSize": "15px",
+            "fontWeight": 400,
+            "fontWeightLight": 300,
+            "gradient": Object {
+              "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+              "five": "linear-gradient(left, #8176B5, #F16975)",
+              "four": "linear-gradient(left, #8176B5, #BA77B1)",
+              "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+              "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+              "six": "linear-gradient(left, #F16975, #F69259)",
+              "three": "linear-gradient(left, #8176B5, #76C4E2)",
+              "two": "linear-gradient(left, #8176B5, #85CBA8)",
+            },
+            "inputFontSize": "13px",
+            "inputLineHeight": 1.4,
+            "lineHeight": 1.5,
+            "rem": "1rem",
+            "weightBold": 700,
+            "weightLight": 300,
+            "weightNormal": 400,
+            "weightSemiBold": 600,
+            "zIndexMax": 1000,
+          }
+        }
+      >
+        <Connect(TableBuilder)
+          columns={Array []}
+          rows={
+            Array [
+              Object {
+                "cells": Object {},
+                "id": "1",
+                "type": "success",
+              },
+              Object {
+                "accent": "red",
+                "cells": Object {},
+                "id": "2",
+              },
+            ]
+          }
+          tableName="test-table"
+        >
+          <TableBuilder
+            columns={Array []}
+            dispatch={[Function]}
+            flashes={Object {}}
+            rows={
+              Array [
+                Object {
+                  "cells": Object {},
+                  "id": "1",
+                  "type": "success",
+                },
+                Object {
+                  "accent": "red",
+                  "cells": Object {},
+                  "id": "2",
+                },
+              ]
+            }
+            tableName="test-table"
+          >
+            <ThemedComponent>
+              <TableStyles>
+                <TableStyles
+                  _felaRule={[Function]}
+                  passThrough={Array []}
+                >
+                  <Table
+                    bare={false}
+                    bordered={true}
+                    className="46sr0r"
+                    condensed={false}
+                    hover={false}
+                    is="table"
+                    striped={false}
+                  >
+                    <table
+                      className="46sr0r"
+                    >
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        striped={false}
+                      >
+                        <TableHeadStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={false}
+                          hover={false}
+                          striped={false}
+                        >
+                          <TableHeadStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={false}
+                            hover={false}
+                            passThrough={Array []}
+                            striped={false}
+                          >
+                            <TableHead
+                              bare={false}
+                              bordered={true}
+                              className="d1fi02"
+                              condensed={false}
+                              hover={false}
+                              is="thead"
+                              striped={false}
+                            >
+                              <thead
+                                className="d1fi02"
+                              >
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={-0}
+                                  striped={false}
+                                  theadIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={-0}
+                                    striped={false}
+                                    theadIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={-0}
+                                      striped={false}
+                                      theadIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="1b0jccb"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={-0}
+                                        striped={false}
+                                        theadIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="1b0jccb"
+                                        />
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                              </thead>
+                            </TableHead>
+                          </TableHeadStyles>
+                        </TableHeadStyles>
+                      </ThemedComponent>
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        striped={false}
+                      >
+                        <TableBodyStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={false}
+                          hover={false}
+                          striped={false}
+                        >
+                          <TableBodyStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={false}
+                            hover={false}
+                            passThrough={Array []}
+                            striped={false}
+                          >
+                            <TableBody
+                              bare={false}
+                              bordered={true}
+                              className="zos2pn"
+                              condensed={false}
+                              hover={false}
+                              is="tbody"
+                              striped={false}
+                            >
+                              <tbody
+                                className="zos2pn"
+                              >
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={0}
+                                  striped={false}
+                                  tbodyIndex={0}
+                                  type="success"
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={0}
+                                    striped={false}
+                                    tbodyIndex={0}
+                                    type="success"
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={0}
+                                      striped={false}
+                                      tbodyIndex={0}
+                                      type="success"
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="14uu5dt"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={0}
+                                        striped={false}
+                                        tbodyIndex={0}
+                                        type="success"
+                                      >
+                                        <tr
+                                          className="14uu5dt"
+                                        />
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={false}
+                                  hover={false}
+                                  rowIndex={-1}
+                                  striped={false}
+                                  tbodyIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={false}
+                                    hover={false}
+                                    rowIndex={-1}
+                                    striped={false}
+                                    tbodyIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={false}
+                                      hover={false}
+                                      passThrough={Array []}
+                                      rowIndex={-1}
+                                      striped={false}
+                                      tbodyIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="1uiy02g"
+                                        condensed={false}
+                                        hover={false}
+                                        is="tr"
+                                        rowIndex={-1}
+                                        striped={false}
+                                        tbodyIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="1uiy02g"
+                                        />
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                              </tbody>
+                            </TableBody>
+                          </TableBodyStyles>
+                        </TableBodyStyles>
+                      </ThemedComponent>
+                    </table>
+                  </Table>
+                </TableStyles>
+              </TableStyles>
+            </ThemedComponent>
+          </TableBuilder>
+        </Connect(TableBuilder)>
+      </ThemeProvider>
+    </Provider>
+  </StyleProvider>
+</Provider>
 `;
 
 exports[`should support table props 1`] = `
-<table
-  className="cf-table cf-table--striped cf-table--hover cf-table--bordered cf-table--condensed"
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
 >
-  <thead
-    className="cf-table__head"
+  <StyleProvider
+    dev={true}
   >
-    <tr
-      className="cf-table__row cf-table__row--default"
-    />
-  </thead>
-  <tbody
-    className="cf-table__body"
-  />
-</table>
+    <Provider
+      renderer={
+        Object {
+          "_emitChange": [Function],
+          "_renderStyleToCache": [Function],
+          "_renderStyleToClassNames": [Function],
+          "cache": Object {
+            "127ooxc": true,
+            "1b0jccb": true,
+            "d1fi02": true,
+            "zos2pn": true,
+          },
+          "clear": [Function],
+          "fontFaces": "",
+          "keyframePrefixes": Array [
+            "-webkit-",
+            "-moz-",
+            "",
+          ],
+          "keyframes": "",
+          "listeners": Array [
+            [Function],
+            [Function],
+          ],
+          "mediaQueryOrder": Array [],
+          "mediaRules": Object {
+            "(max-width: 47.2em)": ".127ooxc {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .d1fi02 {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .1b0jccb {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }
+        
+        .zos2pn {
+          display: block;
+          width: 100%;
+          box-sizing: border-box
+        }",
+            "screen and (max-width: 47.2em)": ".127ooxc {
+          display: block
+        }
+        
+        .d1fi02 {
+          display: none
+        }
+        
+        .1b0jccb:after {
+          content: \\"\\";
+          display: table;
+          clear: both
+        }
+        
+        .1b0jccb {
+          display: block;
+          padding: 0.73333333333rem;
+          border-top: none;
+          background-color: #ccc
+        }
+        
+        .zos2pn {
+          display: block
+        }",
+          },
+          "plugins": Array [
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "prettySelectors": false,
+          "renderFont": [Function],
+          "renderKeyframe": [Function],
+          "renderRule": [Function],
+          "renderStatic": [Function],
+          "renderToString": [Function],
+          "rules": ".127ooxc {
+          background: #fff;
+          border-collapse: separate;
+          border-spacing: 0px;
+          max-width: 100%;
+          width: 100%;
+          border: 1px solid \${theme.tableBorderColor
+        };
+        
+        border-left:0px
+        }
+        
+        .d1fi02 {
+        background: #dedede
+        }
+        
+        .1b0jccb {
+        border-color: #dedede
+        }",
+          "selectorPrefix": "",
+          "statics": "",
+          "styleNodes": Object {
+            "RULE": <style
+              data-fela-type="RULE"
+              type="text/css"
+        >
+              .127ooxc { background: #fff; border-collapse: separate; border-spacing: 0px; max-width: 100%; width: 100%; border: 1px solid \${theme.tableBorderColor }; border-left:0px } .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede }
+        </style>,
+            "RULE(max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="(max-width: 47.2em)"
+        >
+              .127ooxc { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box }
+        </style>,
+            "RULEscreen and (max-width: 47.2em)": <style
+              data-fela-type="RULE"
+              type="text/css"
+              media="screen and (max-width: 47.2em)"
+        >
+              .127ooxc { display: block } .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .zos2pn { display: block }
+        </style>,
+          },
+          "subscribe": [Function],
+          "uniqueKeyframeIdentifier": 0,
+          "uniqueRuleIdentifier": 0,
+        }
+      }
+    >
+      <ThemeProvider
+        overwrite={false}
+        theme={
+          Object {
+            "arrowSize": "5px",
+            "bodyAccentColor": "#333",
+            "bodyBackground": "#ebebeb",
+            "bodyOffsetColor": "#787878",
+            "borderRadius": "2px",
+            "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+            "breakpoints": Object {
+              "desktop": "64em",
+              "desktopLarge": "97.6em",
+              "mobile": "13.6em",
+              "mobileWide": "30.4em",
+              "tablet": "47.2em",
+            },
+            "color": Object {
+              "apple": "#BD2527",
+              "carrot": "#f56500",
+              "cement": "#7D7D7D",
+              "charcoal": "#333333",
+              "dawn": "#F16975",
+              "dew": "#85CBA8",
+              "dusk": "#4D4D4F",
+              "grass": "#9BCA3E",
+              "hail": "#BCBEC0",
+              "lightning": "#FFDB6F",
+              "marine": "#2F7BBF",
+              "moonshine": "#F7F7F7",
+              "night": "#404041",
+              "rain": "#408BC9",
+              "sky": "#76C4E2",
+              "smoke": "#e0e0e0",
+              "storm": "#808285",
+              "sunrise": "#F69259",
+              "sunset": "#BA77B1",
+              "tangerine": "#FF7900",
+              "twilight": "#8176B5",
+            },
+            "colorBlack": "#000",
+            "colorBlue": "#2f7bbf",
+            "colorBlueDark": "#2869a2",
+            "colorBlueLight": "#62a1d8",
+            "colorError": "#ff3100",
+            "colorFacebookBlue": "#3b5998",
+            "colorGray": "#7c7c7c",
+            "colorGrayBorder": "#666",
+            "colorGrayDark": "#333",
+            "colorGrayLight": "#dedede",
+            "colorGrayLightOnboarding": "#F7F7F7",
+            "colorGreen": "#9bca3e",
+            "colorGreenDark": "#87b331",
+            "colorGreenLight": "#bada7a",
+            "colorImportantInformation": "rgba(64,139,201,0.2)",
+            "colorInfo": "#00a9eb",
+            "colorMainBackground": "#e6e6e6",
+            "colorMuted": "#7c7c7c",
+            "colorOffsetDark": 0.07,
+            "colorOffsetLight": 0.15,
+            "colorOrange": "#ff7900",
+            "colorOrangeDark": "#db6800",
+            "colorOrangeLight": "#ffa14d",
+            "colorOverlay": "rgba(0, 0, 0, .7)",
+            "colorPink": "#d91698",
+            "colorPinkDark": "#b91381",
+            "colorPinkLight": "#ed4eb8",
+            "colorPurple": "#9545e5",
+            "colorPurpleDark": "#b91381",
+            "colorPurpleLight": "#ed4eb8",
+            "colorRed": "#bd2527",
+            "colorRedDark": "#9f1f21",
+            "colorRedLight": "#dd5153",
+            "colorSmoke": "#f2f2f2",
+            "colorSuccess": "#68970f",
+            "colorTwitterBlue": "#00aced",
+            "colorWarning": "#fca520",
+            "colorWhite": "#fff",
+            "colorYellow": "#ffd24d",
+            "colorYellowDark": "#ffc929",
+            "colorYellowLight": "#ffe59a",
+            "disabledBackground": "#ededed",
+            "em": "1em",
+            "fontColor": "#333",
+            "fontColorHeadingCaption": "#888",
+            "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+            "fontSize": "15px",
+            "fontWeight": 400,
+            "fontWeightLight": 300,
+            "gradient": Object {
+              "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+              "five": "linear-gradient(left, #8176B5, #F16975)",
+              "four": "linear-gradient(left, #8176B5, #BA77B1)",
+              "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+              "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+              "six": "linear-gradient(left, #F16975, #F69259)",
+              "three": "linear-gradient(left, #8176B5, #76C4E2)",
+              "two": "linear-gradient(left, #8176B5, #85CBA8)",
+            },
+            "inputFontSize": "13px",
+            "inputLineHeight": 1.4,
+            "lineHeight": 1.5,
+            "rem": "1rem",
+            "weightBold": 700,
+            "weightLight": 300,
+            "weightNormal": 400,
+            "weightSemiBold": 600,
+            "zIndexMax": 1000,
+          }
+        }
+      >
+        <Connect(TableBuilder)
+          bordered={true}
+          columns={Array []}
+          condensed={true}
+          hover={true}
+          rows={Array []}
+          striped={true}
+          tableName="test-table"
+        >
+          <TableBuilder
+            bordered={true}
+            columns={Array []}
+            condensed={true}
+            dispatch={[Function]}
+            flashes={Object {}}
+            hover={true}
+            rows={Array []}
+            striped={true}
+            tableName="test-table"
+          >
+            <ThemedComponent
+              bordered={true}
+              condensed={true}
+              hover={true}
+              striped={true}
+            >
+              <TableStyles
+                bordered={true}
+                condensed={true}
+                hover={true}
+                striped={true}
+              >
+                <TableStyles
+                  _felaRule={[Function]}
+                  bordered={true}
+                  condensed={true}
+                  hover={true}
+                  passThrough={Array []}
+                  striped={true}
+                >
+                  <Table
+                    bare={false}
+                    bordered={true}
+                    className="127ooxc"
+                    condensed={true}
+                    hover={true}
+                    is="table"
+                    striped={true}
+                  >
+                    <table
+                      className="127ooxc"
+                    >
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={true}
+                        hover={true}
+                        striped={true}
+                      >
+                        <TableHeadStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={true}
+                          hover={true}
+                          striped={true}
+                        >
+                          <TableHeadStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={true}
+                            hover={true}
+                            passThrough={Array []}
+                            striped={true}
+                          >
+                            <TableHead
+                              bare={false}
+                              bordered={true}
+                              className="d1fi02"
+                              condensed={true}
+                              hover={true}
+                              is="thead"
+                              striped={true}
+                            >
+                              <thead
+                                className="d1fi02"
+                              >
+                                <ThemedComponent
+                                  bare={false}
+                                  bordered={true}
+                                  condensed={true}
+                                  hover={true}
+                                  rowIndex={-0}
+                                  striped={true}
+                                  theadIndex={0}
+                                >
+                                  <TableRowStyles
+                                    bare={false}
+                                    bordered={true}
+                                    condensed={true}
+                                    hover={true}
+                                    rowIndex={-0}
+                                    striped={true}
+                                    theadIndex={0}
+                                  >
+                                    <TableRowStyles
+                                      _felaRule={[Function]}
+                                      bare={false}
+                                      bordered={true}
+                                      condensed={true}
+                                      hover={true}
+                                      passThrough={Array []}
+                                      rowIndex={-0}
+                                      striped={true}
+                                      theadIndex={0}
+                                    >
+                                      <TableRow
+                                        bare={false}
+                                        bordered={true}
+                                        className="1b0jccb"
+                                        condensed={true}
+                                        hover={true}
+                                        is="tr"
+                                        rowIndex={-0}
+                                        striped={true}
+                                        theadIndex={0}
+                                        type="default"
+                                      >
+                                        <tr
+                                          className="1b0jccb"
+                                        />
+                                      </TableRow>
+                                    </TableRowStyles>
+                                  </TableRowStyles>
+                                </ThemedComponent>
+                              </thead>
+                            </TableHead>
+                          </TableHeadStyles>
+                        </TableHeadStyles>
+                      </ThemedComponent>
+                      <ThemedComponent
+                        bare={false}
+                        bordered={true}
+                        condensed={true}
+                        hover={true}
+                        striped={true}
+                      >
+                        <TableBodyStyles
+                          bare={false}
+                          bordered={true}
+                          condensed={true}
+                          hover={true}
+                          striped={true}
+                        >
+                          <TableBodyStyles
+                            _felaRule={[Function]}
+                            bare={false}
+                            bordered={true}
+                            condensed={true}
+                            hover={true}
+                            passThrough={Array []}
+                            striped={true}
+                          >
+                            <TableBody
+                              bare={false}
+                              bordered={true}
+                              className="zos2pn"
+                              condensed={true}
+                              hover={true}
+                              is="tbody"
+                              striped={true}
+                            >
+                              <tbody
+                                className="zos2pn"
+                              />
+                            </TableBody>
+                          </TableBodyStyles>
+                        </TableBodyStyles>
+                      </ThemedComponent>
+                    </table>
+                  </Table>
+                </TableStyles>
+              </TableStyles>
+            </ThemedComponent>
+          </TableBuilder>
+        </Connect(TableBuilder)>
+      </ThemeProvider>
+    </Provider>
+  </StyleProvider>
+</Provider>
 `;

--- a/packages/cf-component-table/package.json
+++ b/packages/cf-component-table/package.json
@@ -11,9 +11,13 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
+    "cf-style-container": "^1.3.1",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.0.0-0 || ^16.0.0-0"
+  },
+  "devDependencies": {
+    "cf-style-provider": "^2.0.0"
   }
 }

--- a/packages/cf-component-table/src/Table.js
+++ b/packages/cf-component-table/src/Table.js
@@ -1,41 +1,90 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import {
+  mapChildren,
+  filterNone,
+  applyTheme,
+  createComponent,
+  connectStyles
+} from 'cf-style-container';
+import TableTheme from './TableTheme.js';
+
+const TableStyles = ({ theme, bordered }) =>
+  filterNone({
+    background: theme.colorWhite,
+    borderCollapse: bordered ? 'separate' : 'collapse',
+    borderSpacing: 0,
+    maxWidth: '100%',
+    width: '100%',
+
+    // Table styles
+    border: bordered ? '1px solid ${theme.tableBorderColor}' : undefined,
+    borderLeft: bordered ? 0 : undefined,
+
+    [`@media (max-width: ${theme.breakpoints.tablet})`]: {
+      display: 'block',
+      width: '100%',
+      boxSizing: 'border-box'
+    },
+
+    [`@media screen and (max-width: ${theme.breakpoints.tablet})`]: {
+      display: 'block'
+    }
+  });
 
 class Table extends React.Component {
   render() {
-    let className = 'cf-table';
+    const {
+      is,
+      className,
+      striped,
+      hover,
+      bordered,
+      condensed,
+      bare,
+      children
+    } = this.props;
 
-    if (this.props.striped) className += ' cf-table--striped';
-    if (this.props.hover) className += ' cf-table--hover';
-    if (this.props.bordered) className += ' cf-table--bordered';
-    if (this.props.condensed) className += ' cf-table--condensed';
-    if (this.props.className.trim())
-      className += ' ' + this.props.className.trim();
-
-    return (
-      <table className={className}>
-        {this.props.children}
-      </table>
+    return React.createElement(
+      is,
+      { className },
+      mapChildren(children, child => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, {
+            condensed,
+            striped,
+            bordered,
+            hover,
+            bare
+          });
+        }
+        return child;
+      })
     );
   }
 }
 
 Table.propTypes = {
-  className: PropTypes.string,
+  is: PropTypes.oneOf(['table', 'div']),
+  className: PropTypes.string.isRequired,
   striped: PropTypes.bool,
   hover: PropTypes.bool,
   bordered: PropTypes.bool,
   condensed: PropTypes.bool,
+  bare: PropTypes.bool,
   children: PropTypes.node
 };
 
 Table.defaultProps = {
-  className: '',
+  is: 'table',
   striped: false,
   hover: false,
   bordered: true,
-  condensed: false
+  condensed: false,
+  bare: false
 };
 
-export default Table;
+export const createTable = (...styles) =>
+  applyTheme(connectStyles(TableStyles, ...styles)(Table), TableTheme);
+
+export default createTable();

--- a/packages/cf-component-table/src/TableBody.js
+++ b/packages/cf-component-table/src/TableBody.js
@@ -1,28 +1,107 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import {
+  mapChildren,
+  filterNone,
+  applyTheme,
+  createComponent,
+  connectStyles
+} from 'cf-style-container';
+import TableTheme from './TableTheme.js';
+
+const TableBodyStyles = ({ theme, tbodyIndex }) =>
+  filterNone({
+    borderTop: tbodyIndex > 0
+      ? '2px solid ${theme.tableBorderColor}'
+      : undefined,
+
+    [`@media (max-width: ${theme.breakpoints.tablet})`]: {
+      display: 'block',
+      width: '100%',
+      boxSizing: 'border-box'
+    },
+
+    [`@media screen and (max-width: ${theme.breakpoints.tablet})`]: {
+      display: 'block'
+    }
+  });
 
 class TableBody extends React.Component {
-  render() {
-    let className = 'cf-table__body';
-    if (this.props.className.trim())
-      className += ' ' + this.props.className.trim();
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
 
-    return (
-      <tbody className={className}>
-        {this.props.children}
-      </tbody>
+  componentDidMount() {
+    const table = this.node.parentNode;
+    const tbodies = table.querySelectorAll('tbody');
+    let tbodyIndex;
+    for (let i = 0; i < tbodies.length; i++) {
+      if (tbodies.item(i) === this.node) {
+        tbodyIndex = i;
+        break;
+      }
+    }
+
+    this.setState({ tbodyIndex });
+  }
+
+  render() {
+    const {
+      is,
+      className,
+      striped,
+      hover,
+      bordered,
+      condensed,
+      bare,
+      children
+    } = this.props;
+
+    return React.createElement(
+      is,
+      {
+        className,
+        ref: node => {
+          this.node = node;
+        }
+      },
+      mapChildren(children, (child, index, children) => {
+        const isLast = index === children.length - 1;
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, {
+            condensed,
+            striped,
+            bordered,
+            hover,
+            bare,
+            tbodyIndex: this.state.tbodyIndex,
+            rowIndex: isLast ? -index : index
+          });
+        }
+        return child;
+      })
     );
   }
 }
 
 TableBody.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node
+  is: PropTypes.oneOf(['tbody', 'div']),
+  className: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  // implicit style props
+  condensed: PropTypes.bool,
+  striped: PropTypes.bool,
+  bordered: PropTypes.bool,
+  hover: PropTypes.bool,
+  bare: PropTypes.bool
 };
 
 TableBody.defaultProps = {
-  className: ''
+  is: 'tbody'
 };
 
-export default TableBody;
+export const createTableBody = (...styles) =>
+  applyTheme(connectStyles(TableBodyStyles, ...styles)(TableBody), TableTheme);
+
+export default createTableBody();

--- a/packages/cf-component-table/src/TableCell.js
+++ b/packages/cf-component-table/src/TableCell.js
@@ -119,26 +119,7 @@ export const TableCellStyles = ({
 
 class TableCell extends React.Component {
   render() {
-    const {
-      is,
-      className,
-      children,
-      condensed,
-      striped,
-      bordered,
-      hover,
-      bare,
-      rowType,
-      theadIndex,
-      tbodyIndex,
-      tfootIndex,
-      rowIndex,
-      cellIndex,
-      align,
-      width,
-      rowSpan,
-      colSpan
-    } = this.props;
+    const { is, className, children, rowSpan, colSpan } = this.props;
 
     return React.createElement(
       is,
@@ -147,7 +128,7 @@ class TableCell extends React.Component {
         rowSpan: is === 'div' ? undefined : rowSpan,
         colSpan: is === 'div' ? undefined : colSpan
       },
-      this.props.children
+      children
     );
   }
 }

--- a/packages/cf-component-table/src/TableCell.js
+++ b/packages/cf-component-table/src/TableCell.js
@@ -1,37 +1,186 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import {
+  filterStyle,
+  capitalize,
+  filterNone,
+  applyTheme,
+  createComponent,
+  connectStyles
+} from 'cf-style-container';
+import TableTheme from './TableTheme';
+
+export const TableCellStyles = ({
+  is,
+  theme,
+  condensed,
+  striped,
+  bordered,
+  hover,
+  bare,
+  rowType,
+  theadIndex,
+  tbodyIndex,
+  tfootIndex,
+  rowIndex,
+  cellIndex,
+  align,
+  width
+}) =>
+  filterNone({
+    display: is === 'div' ? 'inline-block' : undefined,
+    flex: is === 'div' ? 'auto' : undefined,
+
+    // Baseline cell styles
+    borderTop: ((theadIndex === 0 || tbodyIndex === 0) && rowIndex === 0) ||
+      bare
+      ? 0
+      : `1px solid ${theme.tableBorderColor}`,
+    lineHeight: theme.lineHeight,
+    padding: condensed ? theme.tableCondensedPadding : theme.tablePadding,
+    verticalAlign: 'middle',
+    textAlign: align,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+
+    width: width,
+
+    // For first th/td in the first row in the first thead or tbody
+    borderTopLeftRadius: tbodyIndex === 0 && rowIndex === 0 && cellIndex === 0
+      ? theme.borderRadius
+      : undefined,
+    // The last index is passed down as its complement so you can detect whether
+    // it's the last child easily while preserving its magnitude
+
+    // For last th/td in the first row in the first thead or tbody
+    borderTopRightRadius: tbodyIndex === 0 && rowIndex === 0 && cellIndex < 0
+      ? theme.borderRadius
+      : undefined,
+
+    // For first th/td (can be either) in the last row in the last thead, tbody, and tfoot
+    borderBottomLeftRadius: (tbodyIndex < 0 || tfootIndex < 0) &&
+      rowIndex < 0 &&
+      cellIndex === 0
+      ? theme.borderRadius
+      : undefined,
+
+    // For last th/td (can be either) in the last row in the last thead, tbody, and tfoot
+    borderBottomRightRadius: (tbodyIndex < 0 || tfootIndex < 0) &&
+      rowIndex < 0 &&
+      cellIndex < 0
+      ? theme.borderRadius
+      : undefined,
+
+    // Clear border-radius for first and last td in the last row in the last
+    // tbody for table with tfoot
+    borderRadius: tfootIndex != null &&
+      tbodyIndex < 0 &&
+      rowIndex < 0 &&
+      (cellIndex === 0 || cellIndex < 0)
+      ? 0
+      : undefined,
+
+    // Responsive styles
+    [`@media (max-width: ${theme.breakpoints.tablet})`]: {
+      display: 'block',
+      width: '100%',
+      boxSizing: 'border-box',
+      borderTopWidth: 0,
+      borderTop: cellIndex === 0
+        ? `1px solid ${theme.tableBordercolor}`
+        : undefined
+    },
+
+    // Row Styles
+    borderColor: theme[`table${capitalize(rowType)}BorderColor`],
+    backgroundColor: striped && Math.abs(rowIndex) % 2 === 1
+      ? theme[`tableStriped${capitalize(rowType)}Color`]
+      : theme[`table${capitalize(rowType)}Color`],
+
+    ':hover': hover
+      ? { backgroundColor: theme[`tableHover${capitalize(rowType)}Color`] }
+      : undefined,
+    borderLeft: bordered ? `1px solid ${theme.tableBorderColor}` : undefined,
+
+    [`@media screen and (max-width: ${theme.breakpoints.tablet})`]: {
+      display: 'block',
+      border: 'none',
+      float: 'left',
+      clear: 'left',
+      padding: 0,
+
+      // Mobile stripe issue fix
+      backgroundColor: striped && Math.abs(rowIndex) % 2 === 1
+        ? 'transparent'
+        : undefined
+    }
+  });
 
 class TableCell extends React.Component {
   render() {
-    const { className, align, children, ...props } = this.props;
+    const {
+      is,
+      className,
+      children,
+      condensed,
+      striped,
+      bordered,
+      hover,
+      bare,
+      rowType,
+      theadIndex,
+      tbodyIndex,
+      tfootIndex,
+      rowIndex,
+      cellIndex,
+      align,
+      width,
+      rowSpan,
+      colSpan
+    } = this.props;
 
-    let _className = 'cf-table__cell';
-
-    if (align) {
-      _className += ` cf-table__cell--align-${align}`;
-    }
-
-    if (className && className.trim()) {
-      _className += ' ' + className.trim();
-    }
-
-    return (
-      <td className={_className} {...props}>
-        {this.props.children}
-      </td>
+    return React.createElement(
+      is,
+      {
+        className,
+        rowSpan: is === 'div' ? undefined : rowSpan,
+        colSpan: is === 'div' ? undefined : colSpan
+      },
+      this.props.children
     );
   }
 }
 
 TableCell.propTypes = {
-  className: PropTypes.string,
+  is: PropTypes.oneOf(['td', 'div']),
+  className: PropTypes.string.isRequired,
   align: PropTypes.oneOf(['left', 'center', 'right']),
-  children: PropTypes.node
+  rowSpan: PropTypes.number,
+  colSpan: PropTypes.number,
+  headers: PropTypes.arrayOf(PropTypes.string),
+  children: PropTypes.node,
+  // implicit style props
+  condensed: PropTypes.bool,
+  striped: PropTypes.bool,
+  bordered: PropTypes.bool,
+  hover: PropTypes.bool,
+  bare: PropTypes.bool,
+  rowType: PropTypes.string,
+  theadIndex: PropTypes.number,
+  tbodyIndex: PropTypes.number,
+  tfootIndex: PropTypes.number,
+  rowIndex: PropTypes.number,
+  cellIndex: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 
 TableCell.defaultProps = {
-  className: ''
+  is: 'td',
+  align: 'left'
 };
 
-export default TableCell;
+export const createTableCell = (...styles) =>
+  applyTheme(connectStyles(TableCellStyles, ...styles)(TableCell), TableTheme);
+
+export default createTableCell();

--- a/packages/cf-component-table/src/TableFoot.js
+++ b/packages/cf-component-table/src/TableFoot.js
@@ -1,28 +1,97 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import {
+  mapChildren,
+  applyTheme,
+  createComponent,
+  connectStyles
+} from 'cf-style-container';
+import TableTheme from './TableTheme.js';
+
+const TableFootStyles = ({ theme }) => ({
+  [`@media (max-width: ${theme.breakpoints.tablet})`]: {
+    display: 'block',
+    width: '100%',
+    boxSizing: 'border-box'
+  }
+});
 
 class TableFoot extends React.Component {
-  render() {
-    let className = 'cf-table__foot';
-    if (this.props.className.trim())
-      className += ' ' + this.props.className.trim();
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
 
-    return (
-      <tfoot className={className}>
-        {this.props.children}
-      </tfoot>
+  componentDidMount() {
+    const table = this.node.parentNode;
+    const tfoots = table.querySelectorAll('tfoot');
+    let tfootIndex;
+    for (let i = 0; i < tfoots.length; i++) {
+      if (tfoots.item(i) === this.node) {
+        tfootIndex = i;
+        break;
+      }
+    }
+
+    this.setState({ tfootIndex });
+  }
+
+  render() {
+    const {
+      is,
+      className,
+      striped,
+      hover,
+      bordered,
+      condensed,
+      bare,
+      children
+    } = this.props;
+
+    return React.createElement(
+      is,
+      {
+        className,
+        ref: node => {
+          this.node = node;
+        }
+      },
+      mapChildren(children, (child, index, children) => {
+        const isLast = index === children.length - 1;
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, {
+            condensed,
+            striped,
+            bordered,
+            hover,
+            bare,
+            tfootIndex: this.state.tfootIndex,
+            rowIndex: isLast ? -index : index
+          });
+        }
+        return child;
+      })
     );
   }
 }
 
 TableFoot.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node
+  is: PropTypes.oneOf(['tfoot', 'div']),
+  className: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  // implicit style props
+  condensed: PropTypes.bool,
+  striped: PropTypes.bool,
+  bordered: PropTypes.bool,
+  hover: PropTypes.bool,
+  bare: PropTypes.bool
 };
 
 TableFoot.defaultProps = {
-  className: ''
+  is: 'tfoot'
 };
 
-export default TableFoot;
+export const createTableFoot = (...styles) =>
+  applyTheme(connectStyles(TableFootStyles, ...styles)(TableFoot), TableTheme);
+
+export default createTableFoot();

--- a/packages/cf-component-table/src/TableHead.js
+++ b/packages/cf-component-table/src/TableHead.js
@@ -1,28 +1,101 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import {
+  mapChildren,
+  applyTheme,
+  createComponent,
+  connectStyles
+} from 'cf-style-container';
+import TableTheme from './TableTheme.js';
+
+const TableHeadStyles = ({ theme }) => ({
+  background: theme.tableHeadBackground,
+  [`@media (max-width: ${theme.breakpoints.tablet})`]: {
+    display: 'block',
+    width: '100%',
+    boxSizing: 'border-box'
+  },
+  [`@media screen and (max-width: ${theme.breakpoints.tablet})`]: {
+    display: 'none'
+  }
+});
 
 class TableHead extends React.Component {
-  render() {
-    let className = 'cf-table__head';
-    if (this.props.className.trim())
-      className += ' ' + this.props.className.trim();
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
 
-    return (
-      <thead className={className}>
-        {this.props.children}
-      </thead>
+  componentDidMount() {
+    const table = this.node.parentNode;
+    const theads = table.querySelectorAll('thead');
+    let theadIndex;
+    for (let i = 0; i < theads.length; i++) {
+      if (theads.item(i) === this.node) {
+        theadIndex = i;
+        break;
+      }
+    }
+
+    this.setState({ theadIndex });
+  }
+
+  render() {
+    const {
+      is,
+      className,
+      striped,
+      hover,
+      bordered,
+      condensed,
+      bare,
+      children
+    } = this.props;
+
+    return React.createElement(
+      is,
+      {
+        className,
+        ref: node => {
+          this.node = node;
+        }
+      },
+      mapChildren(children, (child, index, children) => {
+        const isLast = index === children.length - 1;
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, {
+            condensed,
+            striped,
+            bordered,
+            hover,
+            bare,
+            theadIndex: this.state.theadIndex,
+            rowIndex: isLast ? -index : index
+          });
+        }
+        return child;
+      })
     );
   }
 }
 
 TableHead.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node
+  is: PropTypes.oneOf(['thead', 'div']),
+  className: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  // implicit style props
+  condensed: PropTypes.bool,
+  striped: PropTypes.bool,
+  bordered: PropTypes.bool,
+  hover: PropTypes.bool,
+  bare: PropTypes.bool
 };
 
 TableHead.defaultProps = {
-  className: ''
+  is: 'thead'
 };
 
-export default TableHead;
+export const createTableHead = (...styles) =>
+  applyTheme(connectStyles(TableHeadStyles, ...styles)(TableHead), TableTheme);
+
+export default createTableHead();

--- a/packages/cf-component-table/src/TableHeadCell.js
+++ b/packages/cf-component-table/src/TableHeadCell.js
@@ -1,32 +1,103 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import {
+  filterStyle,
+  filterNone,
+  applyTheme,
+  createComponent,
+  connectStyles
+} from 'cf-style-container';
+import { TableCellStyles } from './TableCell';
+import TableTheme from './TableTheme.js';
+
+const TableHeadCellStyles = props => {
+  const { theme, theadIndex, rowIndex, cellIndex } = props;
+  const style = {
+    textAlign: 'left',
+    fontWeight: theme.tableHeadFontWeight,
+    ':first-letter': {
+      textTransform: 'capitalize'
+    },
+    verticalAlign: theadIndex != null ? 'bottom' : undefined,
+
+    // For first th/td in the first row in the first thead or tbody
+    borderTopLeftRadius: theadIndex === 0 && rowIndex === 0 && cellIndex === 0
+      ? theme.borderRadius
+      : undefined,
+    // The last index is passed down as its complement so you can detect whether
+    // it's the last child easily while preserving its magnitude
+
+    // For last th/td in the first row in the first thead or tbody
+    borderTopRightRadius: theadIndex === 0 && rowIndex === 0 && cellIndex < 0
+      ? theme.borderRadius
+      : undefined,
+
+    // For first th/td (can be either) in the last row in the last thead, tbody, and tfoot
+    borderBottomLeftRadius: theadIndex < 0 && rowIndex < 0 && cellIndex === 0
+      ? theme.borderRadius
+      : undefined,
+
+    // For last th/td (can be either) in the last row in the last thead, tbody, and tfoot
+    borderBottomRightRadius: theadIndex < 0 && rowIndex < 0 && cellIndex < 0
+      ? theme.borderRadius
+      : undefined
+  };
+
+  return filterNone(style);
+};
 
 class TableHeadCell extends React.Component {
   render() {
-    const { className, ...props } = this.props;
+    const {
+      is,
+      className,
+      children,
+      condensed,
+      striped,
+      bordered,
+      hover,
+      bare,
+      rowType,
+      theadIndex,
+      tbodyIndex,
+      tfootIndex,
+      rowIndex,
+      cellIndex,
+      width
+    } = this.props;
 
-    let _className = 'cf-table__cell cf-table__cell--head';
-
-    if (className && className.trim()) {
-      _className += ' ' + className.trim();
-    }
-
-    return (
-      <th className={_className} {...props}>
-        {this.props.children}
-      </th>
-    );
+    return React.createElement(is, { className }, this.props.children);
   }
 }
 
 TableHeadCell.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node
+  is: PropTypes.oneOf(['th', 'div']),
+  rowSpan: PropTypes.number,
+  colSpan: PropTypes.number,
+  condensed: PropTypes.bool,
+  striped: PropTypes.bool,
+  bordered: PropTypes.bool,
+  hover: PropTypes.bool,
+  bare: PropTypes.bool,
+  rowType: PropTypes.string,
+  theadIndex: PropTypes.number,
+  tbodyIndex: PropTypes.number,
+  tfootIndex: PropTypes.number,
+  rowIndex: PropTypes.number,
+  cellIndex: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 };
 
 TableHeadCell.defaultProps = {
-  className: ''
+  is: 'th'
 };
 
-export default TableHeadCell;
+export const createTableHeadCell = (...styles) =>
+  applyTheme(
+    connectStyles(TableCellStyles, TableHeadCellStyles, ...styles)(
+      TableHeadCell
+    ),
+    TableTheme
+  );
+
+export default createTableHeadCell();

--- a/packages/cf-component-table/src/TablePropTypes.js
+++ b/packages/cf-component-table/src/TablePropTypes.js
@@ -9,14 +9,4 @@ const rowType = PropTypes.oneOf([
   'error'
 ]);
 
-const rowAccent = PropTypes.oneOf([
-  false,
-  'gray',
-  'orange',
-  'pink',
-  'red',
-  'green',
-  'purple'
-]);
-
-export default { rowType, rowAccent };
+export default { rowType };

--- a/packages/cf-component-table/src/TableRow.js
+++ b/packages/cf-component-table/src/TableRow.js
@@ -1,40 +1,125 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { darken } from 'polished';
+import {
+  mapChildren,
+  capitalize,
+  applyTheme,
+  createComponent,
+  connectStyles
+} from 'cf-style-container';
 import TablePropTypes from './TablePropTypes';
+import TableTheme from './TableTheme.js';
+
+const TableRowStyles = ({ is, theme, tbodyIndex, rowIndex, type }) =>
+  Object.assign(
+    is === 'div'
+      ? {
+          display: 'flex',
+          flexWrap: 'nowrap',
+          justifyContent: 'space-around',
+          alignItems: 'center'
+        }
+      : {},
+    {
+      borderColor: theme[`table${capitalize(type)}BorderColor`],
+      backgroundColor: theme[`table${capitalize(type)}Color`],
+
+      [`@media (max-width: ${theme.breakpoints.tablet})`]: {
+        display: 'block',
+        width: '100%',
+        boxSizing: 'border-box'
+      },
+
+      [`@media screen and (max-width: ${theme.breakpoints.tablet})`]: {
+        display: 'block',
+        padding: theme.tablePadding,
+        borderTop: rowIndex === 0
+          ? 'none'
+          : `1px solid ${theme.tableBorderColor}`,
+        ':after': {
+          content: '""',
+          display: 'table',
+          clear: 'both'
+        },
+        backgroundColor: darken(0.2, theme.colorWhite),
+
+        ':hover': {
+          '> td': {
+            backgroundColor: tbodyIndex >= 0 ? 'transparent' : undefined
+          }
+        }
+      }
+    }
+  );
 
 class TableRow extends React.Component {
   render() {
-    const { className, type, accent, children, ...props } = this.props;
+    const {
+      is,
+      className,
+      type,
+      children,
+      condensed,
+      striped,
+      bordered,
+      hover,
+      bare,
+      theadIndex,
+      tbodyIndex,
+      tfootIndex,
+      rowIndex
+    } = this.props;
 
-    let _className = `cf-table__row cf-table__row--${type}`;
-
-    if (accent) {
-      _className += ` cf-table__row--accent-${accent}`;
-    }
-
-    if (className && className.trim()) {
-      _className += ' ' + className.trim();
-    }
-
-    return (
-      <tr className={_className} {...props}>
-        {children}
-      </tr>
+    return React.createElement(
+      is,
+      { className },
+      mapChildren(children, (child, index, children) => {
+        const isLast = index === children.length - 1;
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, {
+            condensed,
+            striped,
+            bordered,
+            hover,
+            bare,
+            rowType: type,
+            theadIndex,
+            tbodyIndex,
+            tfootIndex,
+            rowIndex,
+            cellIndex: isLast ? -index : index
+          });
+        }
+        return child;
+      })
     );
   }
 }
 
 TableRow.propTypes = {
-  className: PropTypes.string,
+  is: PropTypes.oneOf(['tr', 'div']),
+  className: PropTypes.string.isRequired,
   type: TablePropTypes.rowType,
-  accent: TablePropTypes.rowAccent,
-  children: PropTypes.node
+  children: PropTypes.node,
+  // implicit style props
+  condensed: PropTypes.bool,
+  striped: PropTypes.bool,
+  bordered: PropTypes.bool,
+  hover: PropTypes.bool,
+  bare: PropTypes.bool,
+  theadIndex: PropTypes.number,
+  tbodyIndex: PropTypes.number,
+  tfootIndex: PropTypes.number,
+  rowIndex: PropTypes.number
 };
 
 TableRow.defaultProps = {
-  className: '',
-  type: 'default',
-  accent: false
+  is: 'tr',
+  type: 'default'
 };
 
-export default TableRow;
+export const createTableRow = (...styles) =>
+  applyTheme(connectStyles(TableRowStyles, ...styles)(TableRow), TableTheme);
+
+export default createTableRow();

--- a/packages/cf-component-table/src/TableTheme.js
+++ b/packages/cf-component-table/src/TableTheme.js
@@ -1,0 +1,34 @@
+import { darken } from 'polished';
+
+export default baseTheme => {
+  const tableInfoColor = baseTheme.colorBlueLight;
+  const tableSuccessColor = baseTheme.colorGreenLight;
+  const tableErrorColor = baseTheme.colorRedLight;
+  const tableWarningColor = baseTheme.colorYellowLight;
+
+  return {
+    tableBorderColor: baseTheme.colorGrayLight,
+    tablePadding: '0.73333333333rem',
+    tableHeadBackground: baseTheme.colorGrayLight,
+    tableHeadFontWeight: baseTheme.weightSemiBold,
+    tableCondensedPadding: '0.366666666667rem 0.866666666665rem',
+    tableInfoColor,
+    tableSuccessColor,
+    tableErrorColor,
+    tableWarningColor,
+    tableInfoBorderColor: darken(0.05, tableInfoColor),
+    tableSuccessBorderColor: darken(0.05, tableSuccessColor),
+    tableErrorBorderColor: darken(0.05, tableErrorColor),
+    tableWarningBorderColor: darken(0.05, tableWarningColor),
+    tableStripedDefaultColor: darken(0.02, baseTheme.colorWhite),
+    tableStripedInfoColor: darken(0.02, tableInfoColor),
+    tableStripedSuccessColor: darken(0.02, tableSuccessColor),
+    tableStripedErrorColor: darken(0.02, tableErrorColor),
+    tableStripedWarningColor: darken(0.02, tableWarningColor),
+    tableHoverDefaultColor: darken(0.06, baseTheme.colorWhite),
+    tableHoverInfoColor: darken(0.02, tableInfoColor),
+    tableHoverSuccessColor: darken(0.02, tableSuccessColor),
+    tableHoverErrorColor: darken(0.02, tableErrorColor),
+    tableHoverWarningColor: darken(0.02, tableWarningColor)
+  };
+};

--- a/packages/cf-component-table/src/index.js
+++ b/packages/cf-component-table/src/index.js
@@ -6,7 +6,6 @@ import TableHead, { createTableHead } from './TableHead';
 import TableHeadCell, { createTableHeadCell } from './TableHeadCell';
 import TableRow, { createTableRow } from './TableRow';
 import TablePropTypes from './TablePropTypes';
-import TableTheme from './TableTheme';
 
 export {
   Table,

--- a/packages/cf-component-table/src/index.js
+++ b/packages/cf-component-table/src/index.js
@@ -1,11 +1,12 @@
-import Table from './Table';
-import TableBody from './TableBody';
-import TableCell from './TableCell';
-import TableFoot from './TableFoot';
-import TableHead from './TableHead';
-import TableHeadCell from './TableHeadCell';
+import Table, { createTable } from './Table';
+import TableBody, { createTableBody } from './TableBody';
+import TableCell, { createTableCell } from './TableCell';
+import TableFoot, { createTableFoot } from './TableFoot';
+import TableHead, { createTableHead } from './TableHead';
+import TableHeadCell, { createTableHeadCell } from './TableHeadCell';
+import TableRow, { createTableRow } from './TableRow';
 import TablePropTypes from './TablePropTypes';
-import TableRow from './TableRow';
+import TableTheme from './TableTheme';
 
 export {
   Table,
@@ -14,6 +15,13 @@ export {
   TableFoot,
   TableHead,
   TableHeadCell,
-  TablePropTypes,
-  TableRow
+  TableRow,
+  createTable,
+  createTableBody,
+  createTableCell,
+  createTableFoot,
+  createTableHead,
+  createTableHeadCell,
+  createTableRow,
+  TablePropTypes
 };

--- a/packages/cf-component-table/test/Table.js
+++ b/packages/cf-component-table/test/Table.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { felaSnapshot, felaTestContext } from 'cf-style-provider';
+import felaTestContext from '../../cf-style-provider/src/felaTestContext';
+import felaSnapshot from '../../cf-style-provider/src/felaSnapshot';
 import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 

--- a/packages/cf-component-table/test/Table.js
+++ b/packages/cf-component-table/test/Table.js
@@ -1,33 +1,108 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { Table } from '../../cf-component-table/src/index';
+import { felaSnapshot, felaTestContext } from 'cf-style-provider';
 
-test('should render', () => {
-  const component = renderer.create(<Table>Table</Table>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableFoot,
+  createTable
+} from '../../cf-component-table/src/index';
+import { mount } from 'enzyme';
 
-test('should render extra class names', () => {
-  const component = renderer.create(<Table className="extra">Table</Table>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+describe('Table', () => {
+  it('should render', () => {
+    const snapshot = felaSnapshot(<Table>Table</Table>);
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render striped', () => {
-  const component = renderer.create(<Table striped>Table</Table>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+  it('should render striped', () => {
+    const snapshot = felaSnapshot(<Table striped>Table</Table>);
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render hover', () => {
-  const component = renderer.create(<Table hover>Table</Table>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+  it('should render hover', () => {
+    const snapshot = felaSnapshot(<Table hover>Table</Table>);
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render not bordered', () => {
-  const component = renderer.create(<Table bordered={false}>Table</Table>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+  it('should render not bordered', () => {
+    const snapshot = felaSnapshot(<Table bordered={false}>Table</Table>);
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render condensed', () => {
-  const component = renderer.create(<Table condensed>Table</Table>);
-  expect(component.toJSON()).toMatchSnapshot();
+  it('should render condensed', () => {
+    const snapshot = felaSnapshot(<Table condensed>Table</Table>);
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should pass down CSS query props', () => {
+    const wrapper = mount(
+      felaTestContext(
+        <Table striped hover bordered condensed bare>
+          <TableHead />
+          <TableHead />
+          <TableBody />
+          <TableBody />
+          <TableFoot />
+          <TableFoot />
+        </Table>
+      )
+    );
+
+    const thead0 = wrapper.find(TableHead).at(0);
+    const thead1 = wrapper.find(TableHead).at(1);
+    const tbody0 = wrapper.find(TableBody).at(0);
+    const tbody1 = wrapper.find(TableBody).at(1);
+    const tfoot0 = wrapper.find(TableFoot).at(0);
+    const tfoot1 = wrapper.find(TableFoot).at(1);
+
+    expect(thead0.prop('condensed')).toBeTruthy();
+    expect(thead0.prop('striped')).toBeTruthy();
+    expect(thead0.prop('bordered')).toBeTruthy();
+    expect(thead0.prop('hover')).toBeTruthy();
+    expect(thead0.prop('bare')).toBeTruthy();
+
+    expect(thead1.prop('condensed')).toBeTruthy();
+    expect(thead1.prop('striped')).toBeTruthy();
+    expect(thead1.prop('bordered')).toBeTruthy();
+    expect(thead1.prop('hover')).toBeTruthy();
+    expect(thead1.prop('bare')).toBeTruthy();
+
+    expect(tbody0.prop('condensed')).toBeTruthy();
+    expect(tbody0.prop('striped')).toBeTruthy();
+    expect(tbody0.prop('bordered')).toBeTruthy();
+    expect(tbody0.prop('hover')).toBeTruthy();
+    expect(tbody0.prop('bare')).toBeTruthy();
+
+    expect(tbody1.prop('condensed')).toBeTruthy();
+    expect(tbody1.prop('striped')).toBeTruthy();
+    expect(tbody1.prop('bordered')).toBeTruthy();
+    expect(tbody1.prop('hover')).toBeTruthy();
+    expect(tbody1.prop('bare')).toBeTruthy();
+
+    expect(tfoot0.prop('condensed')).toBeTruthy();
+    expect(tfoot0.prop('striped')).toBeTruthy();
+    expect(tfoot0.prop('bordered')).toBeTruthy();
+    expect(tfoot0.prop('hover')).toBeTruthy();
+    expect(tfoot0.prop('bare')).toBeTruthy();
+
+    expect(tfoot1.prop('condensed')).toBeTruthy();
+    expect(tfoot1.prop('striped')).toBeTruthy();
+    expect(tfoot1.prop('bordered')).toBeTruthy();
+    expect(tfoot1.prop('hover')).toBeTruthy();
+    expect(tfoot1.prop('bare')).toBeTruthy();
+  });
+
+  it('should compose with styles overrides', () => {
+    const Table = createTable(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = felaSnapshot(<Table>Table</Table>);
+    expect(snapshot).toMatchSnapshot();
+  });
 });

--- a/packages/cf-component-table/test/Table.js
+++ b/packages/cf-component-table/test/Table.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { felaSnapshot, felaTestContext } from 'cf-style-provider';
+import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 
 import {
   Table,
   TableHead,
   TableBody,
   TableFoot,
+  TableRow,
+  TableCell,
   createTable
 } from '../../cf-component-table/src/index';
-import { mount } from 'enzyme';
 
 describe('Table', () => {
   it('should render', () => {
@@ -103,6 +106,62 @@ describe('Table', () => {
       }
     }));
     const snapshot = felaSnapshot(<Table>Table</Table>);
+    expect(snapshot).toMatchSnapshot();
+  });
+});
+
+describe('createTable', () => {
+  it('should compose with styles overrides', () => {
+    const Table = createTable(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <table>
+            <TableHead />
+            <TableBody />
+            <TableFoot />
+          </table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should be able to render a div', () => {
+    const Table = createTable(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <Table is="div">
+            <TableHead is="div">
+              <TableRow is="div">
+                <TableCell is="div" />
+              </TableRow>
+            </TableHead>
+            <TableBody is="div">
+              <TableRow is="div">
+                <TableCell is="div" />
+              </TableRow>
+            </TableBody>
+            <TableFoot is="div">
+              <TableRow is="div">
+                <TableCell is="div" />
+              </TableRow>
+            </TableFoot>
+          </Table>
+        )
+      )
+    );
     expect(snapshot).toMatchSnapshot();
   });
 });

--- a/packages/cf-component-table/test/TableBody.js
+++ b/packages/cf-component-table/test/TableBody.js
@@ -1,15 +1,63 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import { TableBody } from '../../cf-component-table/src/index';
+import {
+  Table,
+  TableBody,
+  TableRow,
+  createTableBody
+} from '../../cf-component-table/src/index';
+import { felaTestContext } from 'cf-style-provider';
+import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 
-test('should render', () => {
-  const component = renderer.create(<TableBody>TableBody</TableBody>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+describe('TableBody', () => {
+  it('should render', () => {
+    const wrapper = mount(
+      felaTestContext(
+        <table>
+          <TableBody>
+            <TableRow />
+          </TableBody>
+        </table>
+      )
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
 
-test('should render extra class names', () => {
-  const component = renderer.create(
-    <TableBody className="extra">TableBody</TableBody>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
+  it('should pass down CSS query props', () => {
+    const wrapper = mount(
+      felaTestContext(
+        <table>
+          <TableBody striped hover bordered condensed bare>
+            <TableRow />
+            <TableRow />
+          </TableBody>
+        </table>
+      )
+    );
+
+    const trs = wrapper.find(TableRow);
+
+    for (let i = 0; i < 2; i++) {
+      expect(trs.at(i).prop('condensed')).toBeTruthy();
+      expect(trs.at(i).prop('striped')).toBeTruthy();
+      expect(trs.at(i).prop('bordered')).toBeTruthy();
+      expect(trs.at(i).prop('hover')).toBeTruthy();
+      expect(trs.at(i).prop('bare')).toBeTruthy();
+      expect(trs.at(i).prop('tbodyIndex')).toBe(0);
+    }
+
+    expect(trs.at(0).prop('rowIndex')).toBe(0);
+    expect(trs.at(1).prop('rowIndex')).toBe(-1);
+  });
+
+  it('should compose with styles overrides', () => {
+    const TableBody = createTableBody(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const tree = mount(felaTestContext(<Table><TableBody /></Table>));
+    expect(toJSON(tree)).toMatchSnapshot();
+  });
 });

--- a/packages/cf-component-table/test/TableBody.js
+++ b/packages/cf-component-table/test/TableBody.js
@@ -6,7 +6,7 @@ import {
   TableCell,
   createTableBody
 } from '../../cf-component-table/src/index';
-import { felaTestContext } from 'cf-style-provider';
+import felaTestContext from '../../cf-style-provider/src/felaTestContext';
 import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 

--- a/packages/cf-component-table/test/TableBody.js
+++ b/packages/cf-component-table/test/TableBody.js
@@ -3,6 +3,7 @@ import {
   Table,
   TableBody,
   TableRow,
+  TableCell,
   createTableBody
 } from '../../cf-component-table/src/index';
 import { felaTestContext } from 'cf-style-provider';
@@ -59,5 +60,49 @@ describe('TableBody', () => {
     }));
     const tree = mount(felaTestContext(<Table><TableBody /></Table>));
     expect(toJSON(tree)).toMatchSnapshot();
+  });
+});
+
+describe('createTableBody', () => {
+  it('should compose with styles overrides', () => {
+    const TableBody = createTableBody(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <table>
+            <TableBody />
+          </table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should be able to render a div', () => {
+    const TableBody = createTableBody(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <Table is="div">
+            <TableBody is="div">
+              <TableRow is="div">
+                <TableCell is="div" />
+              </TableRow>
+            </TableBody>
+          </Table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
   });
 });

--- a/packages/cf-component-table/test/TableCell.js
+++ b/packages/cf-component-table/test/TableCell.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { TableCell, createTableCell } from '../../cf-component-table/src/index';
-import { felaSnapshot } from 'cf-style-provider';
+import { felaSnapshot, felaTestContext } from 'cf-style-provider';
+import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 
 describe('TableCell', () => {
   it('should render', () => {
@@ -16,6 +18,13 @@ describe('TableCell', () => {
     expect(snapshot).toMatchSnapshot();
   });
 
+  it('can render a div', () => {
+    const snapshot = felaSnapshot(<TableCell is="div">TableCell</TableCell>);
+    expect(snapshot).toMatchSnapshot();
+  });
+});
+
+describe('createTableCell', () => {
   it('should compose with styles overrides', () => {
     const TableCell = createTableCell(({ theme }) => ({
       verticalAlign: 'right',
@@ -23,7 +32,30 @@ describe('TableCell', () => {
         width: '1000px'
       }
     }));
-    const snapshot = felaSnapshot(<TableCell>TableCell</TableCell>);
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <table>
+            <tbody>
+              <tr>
+                <TableCell />
+              </tr>
+            </tbody>
+          </table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should be able to render a div', () => {
+    const TableCell = createTableCell(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(mount(felaTestContext(<TableCell is="div" />)));
     expect(snapshot).toMatchSnapshot();
   });
 });

--- a/packages/cf-component-table/test/TableCell.js
+++ b/packages/cf-component-table/test/TableCell.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { TableCell, createTableCell } from '../../cf-component-table/src/index';
-import { felaSnapshot, felaTestContext } from 'cf-style-provider';
+import felaTestContext from '../../cf-style-provider/src/felaTestContext';
+import felaSnapshot from '../../cf-style-provider/src/felaSnapshot';
 import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 

--- a/packages/cf-component-table/test/TableCell.js
+++ b/packages/cf-component-table/test/TableCell.js
@@ -1,22 +1,29 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { TableCell } from '../../cf-component-table/src/index';
+import { TableCell, createTableCell } from '../../cf-component-table/src/index';
+import { felaSnapshot } from 'cf-style-provider';
 
-test('should render', () => {
-  const component = renderer.create(<TableCell>TableCell</TableCell>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+describe('TableCell', () => {
+  it('should render', () => {
+    const snapshot = felaSnapshot(<TableCell>TableCell</TableCell>);
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render extra class name', () => {
-  const component = renderer.create(
-    <TableCell className="extra">TableCell</TableCell>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
-});
+  it('should render with align', () => {
+    const snapshot = felaSnapshot(
+      <TableCell align="center">TableCell</TableCell>
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render with align', () => {
-  const component = renderer.create(
-    <TableCell align="center">TableCell</TableCell>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
+  it('should compose with styles overrides', () => {
+    const TableCell = createTableCell(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = felaSnapshot(<TableCell>TableCell</TableCell>);
+    expect(snapshot).toMatchSnapshot();
+  });
 });

--- a/packages/cf-component-table/test/TableFoot.js
+++ b/packages/cf-component-table/test/TableFoot.js
@@ -1,15 +1,64 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import { TableFoot } from '../../cf-component-table/src/index';
+import {
+  Table,
+  TableFoot,
+  TableRow,
+  createTableFoot
+} from '../../cf-component-table/src/index';
+import { felaTestContext } from 'cf-style-provider';
+import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 
-test('should render', () => {
-  const component = renderer.create(<TableFoot>TableFoot</TableFoot>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+describe('TableFoot', () => {
+  it('should render', () => {
+    const wrapper = mount(
+      felaTestContext(
+        <table>
+          <TableFoot>
+            <TableRow />
+          </TableFoot>
+        </table>
+      )
+    );
 
-test('should render extra class name', () => {
-  const component = renderer.create(
-    <TableFoot className="extra">TableFoot</TableFoot>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
+  it('should pass down CSS query props', () => {
+    const wrapper = mount(
+      felaTestContext(
+        <table>
+          <TableFoot striped hover bordered condensed bare>
+            <TableRow />
+            <TableRow />
+          </TableFoot>
+        </table>
+      )
+    );
+
+    const trs = wrapper.find(TableRow);
+
+    for (let i = 0; i < 2; i++) {
+      expect(trs.at(i).prop('condensed')).toBeTruthy();
+      expect(trs.at(i).prop('striped')).toBeTruthy();
+      expect(trs.at(i).prop('bordered')).toBeTruthy();
+      expect(trs.at(i).prop('hover')).toBeTruthy();
+      expect(trs.at(i).prop('bare')).toBeTruthy();
+      expect(trs.at(i).prop('tfootIndex')).toBe(0);
+    }
+
+    expect(trs.at(0).prop('rowIndex')).toBe(0);
+    expect(trs.at(1).prop('rowIndex')).toBe(-1);
+  });
+
+  it('should compose with styles overrides', () => {
+    const TableFoot = createTableFoot(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const tree = mount(felaTestContext(<Table><TableFoot /></Table>));
+    expect(toJSON(tree)).toMatchSnapshot();
+  });
 });

--- a/packages/cf-component-table/test/TableFoot.js
+++ b/packages/cf-component-table/test/TableFoot.js
@@ -6,7 +6,7 @@ import {
   TableCell,
   createTableFoot
 } from '../../cf-component-table/src/index';
-import { felaTestContext } from 'cf-style-provider';
+import felaTestContext from '../../cf-style-provider/src/felaTestContext';
 import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 

--- a/packages/cf-component-table/test/TableFoot.js
+++ b/packages/cf-component-table/test/TableFoot.js
@@ -3,6 +3,7 @@ import {
   Table,
   TableFoot,
   TableRow,
+  TableCell,
   createTableFoot
 } from '../../cf-component-table/src/index';
 import { felaTestContext } from 'cf-style-provider';
@@ -60,5 +61,49 @@ describe('TableFoot', () => {
     }));
     const tree = mount(felaTestContext(<Table><TableFoot /></Table>));
     expect(toJSON(tree)).toMatchSnapshot();
+  });
+});
+
+describe('createTableFoot', () => {
+  it('should compose with styles overrides', () => {
+    const TableFoot = createTableFoot(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <table>
+            <TableFoot />
+          </table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should be able to render a div', () => {
+    const TableFoot = createTableFoot(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <Table is="div">
+            <TableFoot is="div">
+              <TableRow is="div">
+                <TableCell is="div" />
+              </TableRow>
+            </TableFoot>
+          </Table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
   });
 });

--- a/packages/cf-component-table/test/TableHead.js
+++ b/packages/cf-component-table/test/TableHead.js
@@ -6,7 +6,7 @@ import {
   TableCell,
   createTableHead
 } from '../../cf-component-table/src/index';
-import { felaTestContext } from 'cf-style-provider';
+import felaTestContext from '../../cf-style-provider/src/felaTestContext';
 import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 

--- a/packages/cf-component-table/test/TableHead.js
+++ b/packages/cf-component-table/test/TableHead.js
@@ -1,15 +1,63 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import { TableHead } from '../../cf-component-table/src/index';
+import {
+  Table,
+  TableHead,
+  TableRow,
+  createTableHead
+} from '../../cf-component-table/src/index';
+import { felaTestContext } from 'cf-style-provider';
+import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 
-test('should render', () => {
-  const component = renderer.create(<TableHead>TableHead</TableHead>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+describe('TableHead', () => {
+  it('should render', () => {
+    const wrapper = mount(
+      felaTestContext(
+        <table>
+          <TableHead>
+            <TableRow />
+          </TableHead>
+        </table>
+      )
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
 
-test('should render extra class name', () => {
-  const component = renderer.create(
-    <TableHead className="extra">TableHead</TableHead>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
+  it('should pass down CSS query props', () => {
+    const wrapper = mount(
+      felaTestContext(
+        <table>
+          <TableHead striped hover bordered condensed bare>
+            <TableRow />
+            <TableRow />
+          </TableHead>
+        </table>
+      )
+    );
+
+    const trs = wrapper.find(TableRow);
+
+    for (let i = 0; i < 2; i++) {
+      expect(trs.at(i).prop('condensed')).toBeTruthy();
+      expect(trs.at(i).prop('striped')).toBeTruthy();
+      expect(trs.at(i).prop('bordered')).toBeTruthy();
+      expect(trs.at(i).prop('hover')).toBeTruthy();
+      expect(trs.at(i).prop('bare')).toBeTruthy();
+      expect(trs.at(i).prop('theadIndex')).toBe(0);
+    }
+
+    expect(trs.at(0).prop('rowIndex')).toBe(0);
+    expect(trs.at(1).prop('rowIndex')).toBe(-1);
+  });
+
+  it('should compose with styles overrides', () => {
+    const TableHead = createTableHead(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const tree = mount(felaTestContext(<Table><TableHead /></Table>));
+    expect(toJSON(tree)).toMatchSnapshot();
+  });
 });

--- a/packages/cf-component-table/test/TableHead.js
+++ b/packages/cf-component-table/test/TableHead.js
@@ -3,6 +3,7 @@ import {
   Table,
   TableHead,
   TableRow,
+  TableCell,
   createTableHead
 } from '../../cf-component-table/src/index';
 import { felaTestContext } from 'cf-style-provider';
@@ -59,5 +60,49 @@ describe('TableHead', () => {
     }));
     const tree = mount(felaTestContext(<Table><TableHead /></Table>));
     expect(toJSON(tree)).toMatchSnapshot();
+  });
+});
+
+describe('createTableHead', () => {
+  it('should compose with styles overrides', () => {
+    const TableHead = createTableHead(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <table>
+            <TableHead />
+          </table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should be able to render a div', () => {
+    const TableHead = createTableHead(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <Table is="div">
+            <TableHead is="div">
+              <TableRow is="div">
+                <TableCell is="div" />
+              </TableRow>
+            </TableHead>
+          </Table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
   });
 });

--- a/packages/cf-component-table/test/TableHeadCell.js
+++ b/packages/cf-component-table/test/TableHeadCell.js
@@ -4,14 +4,18 @@ import {
   TableHeadCell,
   createTableHeadCell
 } from '../../cf-component-table/src/index';
-import { felaSnapshot } from 'cf-style-provider';
+import { felaSnapshot, felaTestContext } from 'cf-style-provider';
+import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 
 describe('TableHeadCell', () => {
   it('should render', () => {
     const snapshot = felaSnapshot(<TableHeadCell>TableHeadCell</TableHeadCell>);
     expect(snapshot).toMatchSnapshot();
   });
+});
 
+describe('createTableHeadCell', () => {
   it('should compose with styles overrides', () => {
     const TableHeadCell = createTableHeadCell(({ theme }) => ({
       verticalAlign: 'right',
@@ -19,7 +23,30 @@ describe('TableHeadCell', () => {
         width: '1000px'
       }
     }));
-    const snapshot = felaSnapshot(<TableHeadCell>TableHeadCell</TableHeadCell>);
+    const snapshot = toJSON(
+      mount(
+        felaTestContext(
+          <table>
+            <thead>
+              <tr>
+                <TableHeadCell />
+              </tr>
+            </thead>
+          </table>
+        )
+      )
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should be able to render a div', () => {
+    const TableHeadCell = createTableHeadCell(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = toJSON(mount(felaTestContext(<TableHeadCell is="div" />)));
     expect(snapshot).toMatchSnapshot();
   });
 });

--- a/packages/cf-component-table/test/TableHeadCell.js
+++ b/packages/cf-component-table/test/TableHeadCell.js
@@ -4,7 +4,8 @@ import {
   TableHeadCell,
   createTableHeadCell
 } from '../../cf-component-table/src/index';
-import { felaSnapshot, felaTestContext } from 'cf-style-provider';
+import felaTestContext from '../../cf-style-provider/src/felaTestContext';
+import felaSnapshot from '../../cf-style-provider/src/felaSnapshot';
 import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 

--- a/packages/cf-component-table/test/TableHeadCell.js
+++ b/packages/cf-component-table/test/TableHeadCell.js
@@ -1,17 +1,25 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { TableHeadCell } from '../../cf-component-table/src/index';
+import {
+  TableHeadCell,
+  createTableHeadCell
+} from '../../cf-component-table/src/index';
+import { felaSnapshot } from 'cf-style-provider';
 
-test('should render', () => {
-  const component = renderer.create(
-    <TableHeadCell>TableHeadCell</TableHeadCell>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
-});
+describe('TableHeadCell', () => {
+  it('should render', () => {
+    const snapshot = felaSnapshot(<TableHeadCell>TableHeadCell</TableHeadCell>);
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render extra class name', () => {
-  const component = renderer.create(
-    <TableHeadCell className="extra">TableHeadCell</TableHeadCell>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
+  it('should compose with styles overrides', () => {
+    const TableHeadCell = createTableHeadCell(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = felaSnapshot(<TableHeadCell>TableHeadCell</TableHeadCell>);
+    expect(snapshot).toMatchSnapshot();
+  });
 });

--- a/packages/cf-component-table/test/TableRow.js
+++ b/packages/cf-component-table/test/TableRow.js
@@ -5,7 +5,8 @@ import {
   TableCell,
   createTableRow
 } from '../../cf-component-table/src/index';
-import { felaSnapshot, felaTestContext } from 'cf-style-provider';
+import felaTestContext from '../../cf-style-provider/src/felaTestContext';
+import felaSnapshot from '../../cf-style-provider/src/felaSnapshot';
 import { mount } from 'enzyme';
 import toJSON from 'enzyme-to-json';
 

--- a/packages/cf-component-table/test/TableRow.js
+++ b/packages/cf-component-table/test/TableRow.js
@@ -75,3 +75,29 @@ describe('TableRow', () => {
     expect(snapshot).toMatchSnapshot();
   });
 });
+
+describe('createTableRow', () => {
+  it('should compose with styles overrides', () => {
+    const TableRow = createTableRow(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = felaSnapshot(<TableRow><TableCell /></TableRow>);
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('should be able to render a div', () => {
+    const TableRow = createTableRow(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = felaSnapshot(
+      <TableRow is="div"><TableCell is="div" /></TableRow>
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
+});

--- a/packages/cf-component-table/test/TableRow.js
+++ b/packages/cf-component-table/test/TableRow.js
@@ -1,27 +1,77 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { TableRow } from '../../cf-component-table/src/index';
+import {
+  TableRow,
+  TableCell,
+  createTableRow
+} from '../../cf-component-table/src/index';
+import { felaSnapshot, felaTestContext } from 'cf-style-provider';
+import { mount } from 'enzyme';
+import toJSON from 'enzyme-to-json';
 
-test('should render', () => {
-  const component = renderer.create(<TableRow>TableRow</TableRow>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+describe('TableRow', () => {
+  it('should render', () => {
+    const snapshot = felaSnapshot(<TableRow>TableRow</TableRow>);
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render extra class name', () => {
-  const component = renderer.create(
-    <TableRow className="extra">TableRow</TableRow>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
-});
+  it('should render with type', () => {
+    const snapshot = felaSnapshot(<TableRow type="error">TableRow</TableRow>);
+    expect(snapshot).toMatchSnapshot();
+  });
 
-test('should render with type', () => {
-  const component = renderer.create(<TableRow type="error">TableRow</TableRow>);
-  expect(component.toJSON()).toMatchSnapshot();
-});
+  it('should pass down CSS query props', () => {
+    const wrapper = mount(
+      felaTestContext(
+        <table>
+          <tbody>
+            <TableRow
+              condensed
+              striped
+              bordered
+              hover
+              bare
+              type="info"
+              theadIndex={0}
+              tbodyIndex={0}
+              tfootIndex={0}
+              rowIndex={0}
+            >
+              <TableCell />
+              <TableCell />
+            </TableRow>
+          </tbody>
+        </table>
+      )
+    );
 
-test('should render with accent', () => {
-  const component = renderer.create(
-    <TableRow accent="orange">TableRow</TableRow>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
+    const cells = wrapper.find(TableCell);
+
+    for (let i = 0; i < 2; i++) {
+      expect(cells.at(i).prop('condensed')).toBeTruthy();
+      expect(cells.at(i).prop('striped')).toBeTruthy();
+      expect(cells.at(i).prop('bordered')).toBeTruthy();
+      expect(cells.at(i).prop('hover')).toBeTruthy();
+      expect(cells.at(i).prop('bare')).toBeTruthy();
+      expect(cells.at(i).prop('rowType')).toBe('info');
+      expect(cells.at(i).prop('theadIndex')).toBe(0);
+      expect(cells.at(i).prop('tbodyIndex')).toBe(0);
+      expect(cells.at(i).prop('tfootIndex')).toBe(0);
+      expect(cells.at(i).prop('rowIndex')).toBe(0);
+    }
+
+    expect(cells.at(0).prop('cellIndex')).toBe(0);
+    expect(cells.at(1).prop('cellIndex')).toBe(-1);
+  });
+
+  it('should compose with styles overrides', () => {
+    const TableRow = createTableRow(({ theme }) => ({
+      verticalAlign: 'right',
+      [`@media (min-width: ${theme.breakpoints.desktopLarge})`]: {
+        width: '1000px'
+      }
+    }));
+    const snapshot = felaSnapshot(<TableRow><TableCell /></TableRow>);
+    expect(snapshot).toMatchSnapshot();
+  });
 });

--- a/packages/cf-component-table/test/__snapshots__/Table.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/Table.js.snap
@@ -14,15 +14,24 @@ Object {
   max-width: 100%;
   width: 100%;
   vertical-align: right
-}@media (max-width: 47.2em){.1gskw3r {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
-}}@media screen and (max-width: 47.2em){.1gskw3r {
-  display: block
-}}@media (min-width: 97.6em){.1gskw3r {
-  width: 1000px
-}}",
+}
+@media (max-width: 47.2em) {
+  .1gskw3r {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .1gskw3r {
+    display: block
+  }
+}
+@media (min-width: 97.6em) {
+  .1gskw3r {
+    width: 1000px
+  }
+}",
 }
 `;
 
@@ -39,13 +48,19 @@ Object {
   border-spacing: 0px;
   max-width: 100%;
   width: 100%
-}@media (max-width: 47.2em){.46sr0r {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
-}}@media screen and (max-width: 47.2em){.46sr0r {
-  display: block
-}}",
+}
+@media (max-width: 47.2em) {
+  .46sr0r {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .46sr0r {
+    display: block
+  }
+}",
 }
 `;
 
@@ -62,13 +77,19 @@ Object {
   border-spacing: 0px;
   max-width: 100%;
   width: 100%
-}@media (max-width: 47.2em){.46sr0r {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
-}}@media screen and (max-width: 47.2em){.46sr0r {
-  display: block
-}}",
+}
+@media (max-width: 47.2em) {
+  .46sr0r {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .46sr0r {
+    display: block
+  }
+}",
 }
 `;
 
@@ -85,13 +106,19 @@ Object {
   border-spacing: 0px;
   max-width: 100%;
   width: 100%
-}@media (max-width: 47.2em){.46sr0r {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
-}}@media screen and (max-width: 47.2em){.46sr0r {
-  display: block
-}}",
+}
+@media (max-width: 47.2em) {
+  .46sr0r {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .46sr0r {
+    display: block
+  }
+}",
 }
 `;
 
@@ -108,13 +135,19 @@ Object {
   border-spacing: 0px;
   max-width: 100%;
   width: 100%
-}@media (max-width: 47.2em){.46sr0r {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
-}}@media screen and (max-width: 47.2em){.46sr0r {
-  display: block
-}}",
+}
+@media (max-width: 47.2em) {
+  .46sr0r {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .46sr0r {
+    display: block
+  }
+}",
 }
 `;
 
@@ -131,13 +164,19 @@ Object {
   border-spacing: 0px;
   max-width: 100%;
   width: 100%
-}@media (max-width: 47.2em){.46sr0r {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
-}}@media screen and (max-width: 47.2em){.46sr0r {
-  display: block
-}}",
+}
+@media (max-width: 47.2em) {
+  .46sr0r {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .46sr0r {
+    display: block
+  }
+}",
 }
 `;
 

--- a/packages/cf-component-table/test/__snapshots__/Table.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/Table.js.snap
@@ -140,3 +140,790 @@ Object {
 }}",
 }
 `;
+
+exports[`createTable should be able to render a div 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1c43i05": true,
+          "1gskw3r": true,
+          "d1fi02": true,
+          "dotb8y": true,
+          "kk9pov": true,
+          "zos2pn": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".1gskw3r {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .d1fi02 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1c43i05 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .kk9pov {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        border-top-width: 0px
+      }
+      
+      .zos2pn {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .dotb8y {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "(min-width: 97.6em)": ".1gskw3r {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".1gskw3r {
+        display: block
+      }
+      
+      .d1fi02 {
+        display: none
+      }
+      
+      .1c43i05:after {
+        content: \\"\\";
+        display: table;
+        clear: both
+      }
+      
+      .1c43i05 {
+        display: block;
+        padding: 0.73333333333rem;
+        border-top: 1px solid #dedede;
+        background-color: #ccc
+      }
+      
+      .kk9pov {
+        display: block;
+        border: none;
+        float: left;
+        clear: left;
+        padding: 0px
+      }
+      
+      .zos2pn {
+        display: block
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".1gskw3r {
+        background: #fff;
+        border-collapse: collapse;
+        border-spacing: 0px;
+        max-width: 100%;
+        width: 100%;
+        vertical-align: right
+      }
+      
+      .d1fi02 {
+        background: #dedede
+      }
+      
+      .1c43i05 {
+        display: -webkit-box;
+        display: -moz-box;
+        display: -ms-flexbox;
+        display: -webkit-flex;
+        display: flex;
+        flex-wrap: nowrap;
+        -webkit-box-lines: nowrap;
+        -webkit-flex-wrap: nowrap;
+        justify-content: space-around;
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-around;
+        align-items: center;
+        -webkit-box-align: center;
+        -webkit-align-items: center;
+        border-color: #dedede
+      }
+      
+      .kk9pov {
+        display: inline-block;
+        flex: auto;
+        -webkit-flex: auto;
+        border-top: 1px solid #dedede;
+        line-height: 1.5;
+        padding: 0.73333333333rem;
+        vertical-align: middle;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .1gskw3r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100%; vertical-align: right } .d1fi02 { background: #dedede } .1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .1gskw3r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1c43i05 { display: block; width: 100%; box-sizing: border-box } .kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .zos2pn { display: block; width: 100%; box-sizing: border-box } .dotb8y { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .1gskw3r { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .1gskw3r { display: block } .d1fi02 { display: none } .1c43i05:after { content: ""; display: table; clear: both } .1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .kk9pov { display: block; border: none; float: left; clear: left; padding: 0px } .zos2pn { display: block }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent
+        is="div"
+      >
+        <FelaComponent
+          is="div"
+        >
+          <TableStyles
+            _felaRule={[Function]}
+            is="div"
+            passThrough={Array []}
+          >
+            <TableStyles
+              _felaRule={[Function]}
+              is="div"
+              passThrough={Array []}
+            >
+              <div
+                className="1gskw3r"
+                is="div"
+              >
+                <ThemedComponent
+                  is="div"
+                >
+                  <TableHeadStyles
+                    is="div"
+                  >
+                    <TableHeadStyles
+                      _felaRule={[Function]}
+                      is="div"
+                      passThrough={Array []}
+                    >
+                      <div
+                        className="d1fi02"
+                        is="div"
+                      >
+                        <ThemedComponent
+                          is="div"
+                        >
+                          <TableRowStyles
+                            is="div"
+                          >
+                            <TableRowStyles
+                              _felaRule={[Function]}
+                              is="div"
+                              passThrough={Array []}
+                            >
+                              <div
+                                className="1c43i05"
+                                is="div"
+                              >
+                                <ThemedComponent
+                                  is="div"
+                                >
+                                  <TableCellStyles
+                                    is="div"
+                                  >
+                                    <TableCellStyles
+                                      _felaRule={[Function]}
+                                      is="div"
+                                      passThrough={Array []}
+                                    >
+                                      <div
+                                        className="kk9pov"
+                                        is="div"
+                                      />
+                                    </TableCellStyles>
+                                  </TableCellStyles>
+                                </ThemedComponent>
+                              </div>
+                            </TableRowStyles>
+                          </TableRowStyles>
+                        </ThemedComponent>
+                      </div>
+                    </TableHeadStyles>
+                  </TableHeadStyles>
+                </ThemedComponent>
+                <ThemedComponent
+                  is="div"
+                >
+                  <TableBodyStyles
+                    is="div"
+                  >
+                    <TableBodyStyles
+                      _felaRule={[Function]}
+                      is="div"
+                      passThrough={Array []}
+                    >
+                      <div
+                        className="zos2pn"
+                        is="div"
+                      >
+                        <ThemedComponent
+                          is="div"
+                        >
+                          <TableRowStyles
+                            is="div"
+                          >
+                            <TableRowStyles
+                              _felaRule={[Function]}
+                              is="div"
+                              passThrough={Array []}
+                            >
+                              <div
+                                className="1c43i05"
+                                is="div"
+                              >
+                                <ThemedComponent
+                                  is="div"
+                                >
+                                  <TableCellStyles
+                                    is="div"
+                                  >
+                                    <TableCellStyles
+                                      _felaRule={[Function]}
+                                      is="div"
+                                      passThrough={Array []}
+                                    >
+                                      <div
+                                        className="kk9pov"
+                                        is="div"
+                                      />
+                                    </TableCellStyles>
+                                  </TableCellStyles>
+                                </ThemedComponent>
+                              </div>
+                            </TableRowStyles>
+                          </TableRowStyles>
+                        </ThemedComponent>
+                      </div>
+                    </TableBodyStyles>
+                  </TableBodyStyles>
+                </ThemedComponent>
+                <ThemedComponent
+                  is="div"
+                >
+                  <TableFootStyles
+                    is="div"
+                  >
+                    <TableFootStyles
+                      _felaRule={[Function]}
+                      is="div"
+                      passThrough={Array []}
+                    >
+                      <div
+                        className="dotb8y"
+                        is="div"
+                      >
+                        <ThemedComponent
+                          is="div"
+                        >
+                          <TableRowStyles
+                            is="div"
+                          >
+                            <TableRowStyles
+                              _felaRule={[Function]}
+                              is="div"
+                              passThrough={Array []}
+                            >
+                              <div
+                                className="1c43i05"
+                                is="div"
+                              >
+                                <ThemedComponent
+                                  is="div"
+                                >
+                                  <TableCellStyles
+                                    is="div"
+                                  >
+                                    <TableCellStyles
+                                      _felaRule={[Function]}
+                                      is="div"
+                                      passThrough={Array []}
+                                    >
+                                      <div
+                                        className="kk9pov"
+                                        is="div"
+                                      />
+                                    </TableCellStyles>
+                                  </TableCellStyles>
+                                </ThemedComponent>
+                              </div>
+                            </TableRowStyles>
+                          </TableRowStyles>
+                        </ThemedComponent>
+                      </div>
+                    </TableFootStyles>
+                  </TableFootStyles>
+                </ThemedComponent>
+              </div>
+            </TableStyles>
+          </TableStyles>
+        </FelaComponent>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;
+
+exports[`createTable should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "d1fi02": true,
+          "dotb8y": true,
+          "zos2pn": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".d1fi02 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .zos2pn {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .dotb8y {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "screen and (max-width: 47.2em)": ".d1fi02 {
+        display: none
+      }
+      
+      .zos2pn {
+        display: block
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".d1fi02 {
+        background: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .d1fi02 { background: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .d1fi02 { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box } .dotb8y { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .1gskw3r { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .d1fi02 { display: none } .zos2pn { display: block }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <ThemedComponent>
+          <TableHeadStyles>
+            <TableHeadStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableHead
+                className="d1fi02"
+                is="thead"
+              >
+                <thead
+                  className="d1fi02"
+                />
+              </TableHead>
+            </TableHeadStyles>
+          </TableHeadStyles>
+        </ThemedComponent>
+        <ThemedComponent>
+          <TableBodyStyles>
+            <TableBodyStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableBody
+                className="zos2pn"
+                is="tbody"
+              >
+                <tbody
+                  className="zos2pn"
+                />
+              </TableBody>
+            </TableBodyStyles>
+          </TableBodyStyles>
+        </ThemedComponent>
+        <ThemedComponent>
+          <TableFootStyles>
+            <TableFootStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableFoot
+                className="dotb8y"
+                is="tfoot"
+              >
+                <tfoot
+                  className="dotb8y"
+                />
+              </TableFoot>
+            </TableFootStyles>
+          </TableFootStyles>
+        </ThemedComponent>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;

--- a/packages/cf-component-table/test/__snapshots__/Table.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/Table.js.snap
@@ -458,191 +458,125 @@ exports[`createTable should be able to render a div 1`] = `
         <FelaComponent
           is="div"
         >
-          <TableStyles
-            _felaRule={[Function]}
+          <div
+            className="1gskw3r"
             is="div"
-            passThrough={Array []}
           >
-            <TableStyles
-              _felaRule={[Function]}
+            <ThemedComponent
               is="div"
-              passThrough={Array []}
             >
-              <div
-                className="1gskw3r"
+              <FelaComponent
                 is="div"
               >
-                <ThemedComponent
+                <div
+                  className="d1fi02"
                   is="div"
                 >
-                  <TableHeadStyles
+                  <ThemedComponent
                     is="div"
                   >
-                    <TableHeadStyles
-                      _felaRule={[Function]}
+                    <FelaComponent
                       is="div"
-                      passThrough={Array []}
                     >
                       <div
-                        className="d1fi02"
+                        className="1c43i05"
                         is="div"
                       >
                         <ThemedComponent
                           is="div"
                         >
-                          <TableRowStyles
+                          <FelaComponent
                             is="div"
                           >
-                            <TableRowStyles
-                              _felaRule={[Function]}
+                            <div
+                              className="kk9pov"
                               is="div"
-                              passThrough={Array []}
-                            >
-                              <div
-                                className="1c43i05"
-                                is="div"
-                              >
-                                <ThemedComponent
-                                  is="div"
-                                >
-                                  <TableCellStyles
-                                    is="div"
-                                  >
-                                    <TableCellStyles
-                                      _felaRule={[Function]}
-                                      is="div"
-                                      passThrough={Array []}
-                                    >
-                                      <div
-                                        className="kk9pov"
-                                        is="div"
-                                      />
-                                    </TableCellStyles>
-                                  </TableCellStyles>
-                                </ThemedComponent>
-                              </div>
-                            </TableRowStyles>
-                          </TableRowStyles>
+                            />
+                          </FelaComponent>
                         </ThemedComponent>
                       </div>
-                    </TableHeadStyles>
-                  </TableHeadStyles>
-                </ThemedComponent>
-                <ThemedComponent
+                    </FelaComponent>
+                  </ThemedComponent>
+                </div>
+              </FelaComponent>
+            </ThemedComponent>
+            <ThemedComponent
+              is="div"
+            >
+              <FelaComponent
+                is="div"
+              >
+                <div
+                  className="zos2pn"
                   is="div"
                 >
-                  <TableBodyStyles
+                  <ThemedComponent
                     is="div"
                   >
-                    <TableBodyStyles
-                      _felaRule={[Function]}
+                    <FelaComponent
                       is="div"
-                      passThrough={Array []}
                     >
                       <div
-                        className="zos2pn"
+                        className="1c43i05"
                         is="div"
                       >
                         <ThemedComponent
                           is="div"
                         >
-                          <TableRowStyles
+                          <FelaComponent
                             is="div"
                           >
-                            <TableRowStyles
-                              _felaRule={[Function]}
+                            <div
+                              className="kk9pov"
                               is="div"
-                              passThrough={Array []}
-                            >
-                              <div
-                                className="1c43i05"
-                                is="div"
-                              >
-                                <ThemedComponent
-                                  is="div"
-                                >
-                                  <TableCellStyles
-                                    is="div"
-                                  >
-                                    <TableCellStyles
-                                      _felaRule={[Function]}
-                                      is="div"
-                                      passThrough={Array []}
-                                    >
-                                      <div
-                                        className="kk9pov"
-                                        is="div"
-                                      />
-                                    </TableCellStyles>
-                                  </TableCellStyles>
-                                </ThemedComponent>
-                              </div>
-                            </TableRowStyles>
-                          </TableRowStyles>
+                            />
+                          </FelaComponent>
                         </ThemedComponent>
                       </div>
-                    </TableBodyStyles>
-                  </TableBodyStyles>
-                </ThemedComponent>
-                <ThemedComponent
+                    </FelaComponent>
+                  </ThemedComponent>
+                </div>
+              </FelaComponent>
+            </ThemedComponent>
+            <ThemedComponent
+              is="div"
+            >
+              <FelaComponent
+                is="div"
+              >
+                <div
+                  className="dotb8y"
                   is="div"
                 >
-                  <TableFootStyles
+                  <ThemedComponent
                     is="div"
                   >
-                    <TableFootStyles
-                      _felaRule={[Function]}
+                    <FelaComponent
                       is="div"
-                      passThrough={Array []}
                     >
                       <div
-                        className="dotb8y"
+                        className="1c43i05"
                         is="div"
                       >
                         <ThemedComponent
                           is="div"
                         >
-                          <TableRowStyles
+                          <FelaComponent
                             is="div"
                           >
-                            <TableRowStyles
-                              _felaRule={[Function]}
+                            <div
+                              className="kk9pov"
                               is="div"
-                              passThrough={Array []}
-                            >
-                              <div
-                                className="1c43i05"
-                                is="div"
-                              >
-                                <ThemedComponent
-                                  is="div"
-                                >
-                                  <TableCellStyles
-                                    is="div"
-                                  >
-                                    <TableCellStyles
-                                      _felaRule={[Function]}
-                                      is="div"
-                                      passThrough={Array []}
-                                    >
-                                      <div
-                                        className="kk9pov"
-                                        is="div"
-                                      />
-                                    </TableCellStyles>
-                                  </TableCellStyles>
-                                </ThemedComponent>
-                              </div>
-                            </TableRowStyles>
-                          </TableRowStyles>
+                            />
+                          </FelaComponent>
                         </ThemedComponent>
                       </div>
-                    </TableFootStyles>
-                  </TableFootStyles>
-                </ThemedComponent>
-              </div>
-            </TableStyles>
-          </TableStyles>
+                    </FelaComponent>
+                  </ThemedComponent>
+                </div>
+              </FelaComponent>
+            </ThemedComponent>
+          </div>
         </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
@@ -872,55 +806,40 @@ exports[`createTable should compose with styles overrides 1`] = `
     >
       <table>
         <ThemedComponent>
-          <TableHeadStyles>
-            <TableHeadStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+          <FelaComponent>
+            <TableHead
+              className="d1fi02"
+              is="thead"
             >
-              <TableHead
+              <thead
                 className="d1fi02"
-                is="thead"
-              >
-                <thead
-                  className="d1fi02"
-                />
-              </TableHead>
-            </TableHeadStyles>
-          </TableHeadStyles>
+              />
+            </TableHead>
+          </FelaComponent>
         </ThemedComponent>
         <ThemedComponent>
-          <TableBodyStyles>
-            <TableBodyStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+          <FelaComponent>
+            <TableBody
+              className="zos2pn"
+              is="tbody"
             >
-              <TableBody
+              <tbody
                 className="zos2pn"
-                is="tbody"
-              >
-                <tbody
-                  className="zos2pn"
-                />
-              </TableBody>
-            </TableBodyStyles>
-          </TableBodyStyles>
+              />
+            </TableBody>
+          </FelaComponent>
         </ThemedComponent>
         <ThemedComponent>
-          <TableFootStyles>
-            <TableFootStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+          <FelaComponent>
+            <TableFoot
+              className="dotb8y"
+              is="tfoot"
             >
-              <TableFoot
+              <tfoot
                 className="dotb8y"
-                is="tfoot"
-              >
-                <tfoot
-                  className="dotb8y"
-                />
-              </TableFoot>
-            </TableFootStyles>
-          </TableFootStyles>
+              />
+            </TableFoot>
+          </FelaComponent>
         </ThemedComponent>
       </table>
     </ThemeProvider>

--- a/packages/cf-component-table/test/__snapshots__/Table.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/Table.js.snap
@@ -3,11 +3,11 @@
 exports[`Table should compose with styles overrides 1`] = `
 Object {
   "component": <table
-    className="1gskw3r"
+    className="cf-1gskw3r"
 >
     Table
 </table>,
-  "styles": ".1gskw3r {
+  "styles": ".cf-1gskw3r {
   background: #fff;
   border-collapse: collapse;
   border-spacing: 0px;
@@ -16,19 +16,19 @@ Object {
   vertical-align: right
 }
 @media (max-width: 47.2em) {
-  .1gskw3r {
+  .cf-1gskw3r {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
 }
 @media screen and (max-width: 47.2em) {
-  .1gskw3r {
+  .cf-1gskw3r {
     display: block
   }
 }
 @media (min-width: 97.6em) {
-  .1gskw3r {
+  .cf-1gskw3r {
     width: 1000px
   }
 }",
@@ -38,11 +38,11 @@ Object {
 exports[`Table should render 1`] = `
 Object {
   "component": <table
-    className="46sr0r"
+    className="cf-46sr0r"
 >
     Table
 </table>,
-  "styles": ".46sr0r {
+  "styles": ".cf-46sr0r {
   background: #fff;
   border-collapse: collapse;
   border-spacing: 0px;
@@ -50,14 +50,14 @@ Object {
   width: 100%
 }
 @media (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
 }
 @media screen and (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block
   }
 }",
@@ -67,11 +67,11 @@ Object {
 exports[`Table should render condensed 1`] = `
 Object {
   "component": <table
-    className="46sr0r"
+    className="cf-46sr0r"
 >
     Table
 </table>,
-  "styles": ".46sr0r {
+  "styles": ".cf-46sr0r {
   background: #fff;
   border-collapse: collapse;
   border-spacing: 0px;
@@ -79,14 +79,14 @@ Object {
   width: 100%
 }
 @media (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
 }
 @media screen and (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block
   }
 }",
@@ -96,11 +96,11 @@ Object {
 exports[`Table should render hover 1`] = `
 Object {
   "component": <table
-    className="46sr0r"
+    className="cf-46sr0r"
 >
     Table
 </table>,
-  "styles": ".46sr0r {
+  "styles": ".cf-46sr0r {
   background: #fff;
   border-collapse: collapse;
   border-spacing: 0px;
@@ -108,14 +108,14 @@ Object {
   width: 100%
 }
 @media (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
 }
 @media screen and (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block
   }
 }",
@@ -125,11 +125,11 @@ Object {
 exports[`Table should render not bordered 1`] = `
 Object {
   "component": <table
-    className="46sr0r"
+    className="cf-46sr0r"
 >
     Table
 </table>,
-  "styles": ".46sr0r {
+  "styles": ".cf-46sr0r {
   background: #fff;
   border-collapse: collapse;
   border-spacing: 0px;
@@ -137,14 +137,14 @@ Object {
   width: 100%
 }
 @media (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
 }
 @media screen and (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block
   }
 }",
@@ -154,11 +154,11 @@ Object {
 exports[`Table should render striped 1`] = `
 Object {
   "component": <table
-    className="46sr0r"
+    className="cf-46sr0r"
 >
     Table
 </table>,
-  "styles": ".46sr0r {
+  "styles": ".cf-46sr0r {
   background: #fff;
   border-collapse: collapse;
   border-spacing: 0px;
@@ -166,14 +166,14 @@ Object {
   width: 100%
 }
 @media (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
 }
 @media screen and (max-width: 47.2em) {
-  .46sr0r {
+  .cf-46sr0r {
     display: block
   }
 }",
@@ -191,12 +191,12 @@ exports[`createTable should be able to render a div 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1c43i05": true,
-          "1gskw3r": true,
-          "d1fi02": true,
-          "dotb8y": true,
-          "kk9pov": true,
-          "zos2pn": true,
+          "cf-1c43i05": true,
+          "cf-1gskw3r": true,
+          "cf-d1fi02": true,
+          "cf-dotb8y": true,
+          "cf-kk9pov": true,
+          "cf-zos2pn": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -212,67 +212,67 @@ exports[`createTable should be able to render a div 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".1gskw3r {
+          "(max-width: 47.2em)": ".cf-1gskw3r {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .d1fi02 {
+      .cf-d1fi02 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: block;
         width: 100%;
         box-sizing: border-box;
         border-top-width: 0px
       }
       
-      .zos2pn {
+      .cf-zos2pn {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .dotb8y {
+      .cf-dotb8y {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "(min-width: 97.6em)": ".1gskw3r {
+          "(min-width: 97.6em)": ".cf-1gskw3r {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".1gskw3r {
+          "screen and (max-width: 47.2em)": ".cf-1gskw3r {
         display: block
       }
       
-      .d1fi02 {
+      .cf-d1fi02 {
         display: none
       }
       
-      .1c43i05:after {
+      .cf-1c43i05:after {
         content: \\"\\";
         display: table;
         clear: both
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: block;
         padding: 0.73333333333rem;
         border-top: 1px solid #dedede;
         background-color: #ccc
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: block;
         border: none;
         float: left;
@@ -280,7 +280,7 @@ exports[`createTable should be able to render a div 1`] = `
         padding: 0px
       }
       
-      .zos2pn {
+      .cf-zos2pn {
         display: block
       }",
         },
@@ -299,7 +299,7 @@ exports[`createTable should be able to render a div 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".1gskw3r {
+        "rules": ".cf-1gskw3r {
         background: #fff;
         border-collapse: collapse;
         border-spacing: 0px;
@@ -308,11 +308,11 @@ exports[`createTable should be able to render a div 1`] = `
         vertical-align: right
       }
       
-      .d1fi02 {
+      .cf-d1fi02 {
         background: #dedede
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: -webkit-box;
         display: -moz-box;
         display: -ms-flexbox;
@@ -330,7 +330,7 @@ exports[`createTable should be able to render a div 1`] = `
         border-color: #dedede
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: inline-block;
         flex: auto;
         -webkit-flex: auto;
@@ -343,35 +343,35 @@ exports[`createTable should be able to render a div 1`] = `
         text-overflow: ellipsis;
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .1gskw3r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100%; vertical-align: right } .d1fi02 { background: #dedede } .1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+            .cf-1gskw3r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100%; vertical-align: right } .cf-d1fi02 { background: #dedede } .cf-1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .cf-kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .1gskw3r { display: block; width: 100%; box-sizing: border-box } .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1c43i05 { display: block; width: 100%; box-sizing: border-box } .kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .zos2pn { display: block; width: 100%; box-sizing: border-box } .dotb8y { display: block; width: 100%; box-sizing: border-box }
+            .cf-1gskw3r { display: block; width: 100%; box-sizing: border-box } .cf-d1fi02 { display: block; width: 100%; box-sizing: border-box } .cf-1c43i05 { display: block; width: 100%; box-sizing: border-box } .cf-kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px } .cf-zos2pn { display: block; width: 100%; box-sizing: border-box } .cf-dotb8y { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .1gskw3r { width: 1000px }
+            .cf-1gskw3r { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .1gskw3r { display: block } .d1fi02 { display: none } .1c43i05:after { content: ""; display: table; clear: both } .1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .kk9pov { display: block; border: none; float: left; clear: left; padding: 0px } .zos2pn { display: block }
+            .cf-1gskw3r { display: block } .cf-d1fi02 { display: none } .cf-1c43i05:after { content: ""; display: table; clear: both } .cf-1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .cf-kk9pov { display: block; border: none; float: left; clear: left; padding: 0px } .cf-zos2pn { display: block }
       </style>,
         },
         "subscribe": [Function],
@@ -498,7 +498,7 @@ exports[`createTable should be able to render a div 1`] = `
           is="div"
         >
           <div
-            className="1gskw3r"
+            className="cf-1gskw3r"
             is="div"
           >
             <ThemedComponent
@@ -508,7 +508,7 @@ exports[`createTable should be able to render a div 1`] = `
                 is="div"
               >
                 <div
-                  className="d1fi02"
+                  className="cf-d1fi02"
                   is="div"
                 >
                   <ThemedComponent
@@ -518,7 +518,7 @@ exports[`createTable should be able to render a div 1`] = `
                       is="div"
                     >
                       <div
-                        className="1c43i05"
+                        className="cf-1c43i05"
                         is="div"
                       >
                         <ThemedComponent
@@ -528,7 +528,7 @@ exports[`createTable should be able to render a div 1`] = `
                             is="div"
                           >
                             <div
-                              className="kk9pov"
+                              className="cf-kk9pov"
                               is="div"
                             />
                           </FelaComponent>
@@ -546,7 +546,7 @@ exports[`createTable should be able to render a div 1`] = `
                 is="div"
               >
                 <div
-                  className="zos2pn"
+                  className="cf-zos2pn"
                   is="div"
                 >
                   <ThemedComponent
@@ -556,7 +556,7 @@ exports[`createTable should be able to render a div 1`] = `
                       is="div"
                     >
                       <div
-                        className="1c43i05"
+                        className="cf-1c43i05"
                         is="div"
                       >
                         <ThemedComponent
@@ -566,7 +566,7 @@ exports[`createTable should be able to render a div 1`] = `
                             is="div"
                           >
                             <div
-                              className="kk9pov"
+                              className="cf-kk9pov"
                               is="div"
                             />
                           </FelaComponent>
@@ -584,7 +584,7 @@ exports[`createTable should be able to render a div 1`] = `
                 is="div"
               >
                 <div
-                  className="dotb8y"
+                  className="cf-dotb8y"
                   is="div"
                 >
                   <ThemedComponent
@@ -594,7 +594,7 @@ exports[`createTable should be able to render a div 1`] = `
                       is="div"
                     >
                       <div
-                        className="1c43i05"
+                        className="cf-1c43i05"
                         is="div"
                       >
                         <ThemedComponent
@@ -604,7 +604,7 @@ exports[`createTable should be able to render a div 1`] = `
                             is="div"
                           >
                             <div
-                              className="kk9pov"
+                              className="cf-kk9pov"
                               is="div"
                             />
                           </FelaComponent>
@@ -634,9 +634,9 @@ exports[`createTable should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "d1fi02": true,
-          "dotb8y": true,
-          "zos2pn": true,
+          "cf-d1fi02": true,
+          "cf-dotb8y": true,
+          "cf-zos2pn": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -652,28 +652,28 @@ exports[`createTable should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".d1fi02 {
+          "(max-width: 47.2em)": ".cf-d1fi02 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .zos2pn {
+      .cf-zos2pn {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .dotb8y {
+      .cf-dotb8y {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "screen and (max-width: 47.2em)": ".d1fi02 {
+          "screen and (max-width: 47.2em)": ".cf-d1fi02 {
         display: none
       }
       
-      .zos2pn {
+      .cf-zos2pn {
         display: block
       }",
         },
@@ -692,38 +692,38 @@ exports[`createTable should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".d1fi02 {
+        "rules": ".cf-d1fi02 {
         background: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .d1fi02 { background: #dedede }
+            .cf-d1fi02 { background: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .d1fi02 { display: block; width: 100%; box-sizing: border-box } .zos2pn { display: block; width: 100%; box-sizing: border-box } .dotb8y { display: block; width: 100%; box-sizing: border-box }
+            .cf-d1fi02 { display: block; width: 100%; box-sizing: border-box } .cf-zos2pn { display: block; width: 100%; box-sizing: border-box } .cf-dotb8y { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .1gskw3r { width: 1000px }
+            .cf-1gskw3r { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .d1fi02 { display: none } .zos2pn { display: block }
+            .cf-d1fi02 { display: none } .cf-zos2pn { display: block }
       </style>,
         },
         "subscribe": [Function],
@@ -847,11 +847,11 @@ exports[`createTable should compose with styles overrides 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableHead
-              className="d1fi02"
+              className="cf-d1fi02"
               is="thead"
             >
               <thead
-                className="d1fi02"
+                className="cf-d1fi02"
               />
             </TableHead>
           </FelaComponent>
@@ -859,11 +859,11 @@ exports[`createTable should compose with styles overrides 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableBody
-              className="zos2pn"
+              className="cf-zos2pn"
               is="tbody"
             >
               <tbody
-                className="zos2pn"
+                className="cf-zos2pn"
               />
             </TableBody>
           </FelaComponent>
@@ -871,11 +871,11 @@ exports[`createTable should compose with styles overrides 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableFoot
-              className="dotb8y"
+              className="cf-dotb8y"
               is="tfoot"
             >
               <tfoot
-                className="dotb8y"
+                className="cf-dotb8y"
               />
             </TableFoot>
           </FelaComponent>

--- a/packages/cf-component-table/test/__snapshots__/Table.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/Table.js.snap
@@ -1,49 +1,142 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
-<table
-  className="cf-table cf-table--bordered"
+exports[`Table should compose with styles overrides 1`] = `
+Object {
+  "component": <table
+    className="1gskw3r"
 >
-  Table
-</table>
+    Table
+</table>,
+  "styles": ".1gskw3r {
+  background: #fff;
+  border-collapse: collapse;
+  border-spacing: 0px;
+  max-width: 100%;
+  width: 100%;
+  vertical-align: right
+}@media (max-width: 47.2em){.1gskw3r {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}}@media screen and (max-width: 47.2em){.1gskw3r {
+  display: block
+}}@media (min-width: 97.6em){.1gskw3r {
+  width: 1000px
+}}",
+}
 `;
 
-exports[`should render condensed 1`] = `
-<table
-  className="cf-table cf-table--bordered cf-table--condensed"
+exports[`Table should render 1`] = `
+Object {
+  "component": <table
+    className="46sr0r"
 >
-  Table
-</table>
+    Table
+</table>,
+  "styles": ".46sr0r {
+  background: #fff;
+  border-collapse: collapse;
+  border-spacing: 0px;
+  max-width: 100%;
+  width: 100%
+}@media (max-width: 47.2em){.46sr0r {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}}@media screen and (max-width: 47.2em){.46sr0r {
+  display: block
+}}",
+}
 `;
 
-exports[`should render extra class names 1`] = `
-<table
-  className="cf-table cf-table--bordered extra"
+exports[`Table should render condensed 1`] = `
+Object {
+  "component": <table
+    className="46sr0r"
 >
-  Table
-</table>
+    Table
+</table>,
+  "styles": ".46sr0r {
+  background: #fff;
+  border-collapse: collapse;
+  border-spacing: 0px;
+  max-width: 100%;
+  width: 100%
+}@media (max-width: 47.2em){.46sr0r {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}}@media screen and (max-width: 47.2em){.46sr0r {
+  display: block
+}}",
+}
 `;
 
-exports[`should render hover 1`] = `
-<table
-  className="cf-table cf-table--hover cf-table--bordered"
+exports[`Table should render hover 1`] = `
+Object {
+  "component": <table
+    className="46sr0r"
 >
-  Table
-</table>
+    Table
+</table>,
+  "styles": ".46sr0r {
+  background: #fff;
+  border-collapse: collapse;
+  border-spacing: 0px;
+  max-width: 100%;
+  width: 100%
+}@media (max-width: 47.2em){.46sr0r {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}}@media screen and (max-width: 47.2em){.46sr0r {
+  display: block
+}}",
+}
 `;
 
-exports[`should render not bordered 1`] = `
-<table
-  className="cf-table"
+exports[`Table should render not bordered 1`] = `
+Object {
+  "component": <table
+    className="46sr0r"
 >
-  Table
-</table>
+    Table
+</table>,
+  "styles": ".46sr0r {
+  background: #fff;
+  border-collapse: collapse;
+  border-spacing: 0px;
+  max-width: 100%;
+  width: 100%
+}@media (max-width: 47.2em){.46sr0r {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}}@media screen and (max-width: 47.2em){.46sr0r {
+  display: block
+}}",
+}
 `;
 
-exports[`should render striped 1`] = `
-<table
-  className="cf-table cf-table--striped cf-table--bordered"
+exports[`Table should render striped 1`] = `
+Object {
+  "component": <table
+    className="46sr0r"
 >
-  Table
-</table>
+    Table
+</table>,
+  "styles": ".46sr0r {
+  background: #fff;
+  border-collapse: collapse;
+  border-spacing: 0px;
+  max-width: 100%;
+  width: 100%
+}@media (max-width: 47.2em){.46sr0r {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}}@media screen and (max-width: 47.2em){.46sr0r {
+  display: block
+}}",
+}
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableBody.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableBody.js.snap
@@ -596,3 +596,615 @@ exports[`TableBody should render 1`] = `
   </Provider>
 </StyleProvider>
 `;
+
+exports[`createTableBody should be able to render a div 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1c43i05": true,
+          "46sr0r": true,
+          "7q381j": true,
+          "kk9pov": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".46sr0r {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .7q381j {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1c43i05 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .kk9pov {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        border-top-width: 0px
+      }",
+          "(min-width: 97.6em)": ".7q381j {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".46sr0r {
+        display: block
+      }
+      
+      .7q381j {
+        display: block
+      }
+      
+      .1c43i05:after {
+        content: \\"\\";
+        display: table;
+        clear: both
+      }
+      
+      .1c43i05 {
+        display: block;
+        padding: 0.73333333333rem;
+        border-top: 1px solid #dedede;
+        background-color: #ccc
+      }
+      
+      .kk9pov {
+        display: block;
+        border: none;
+        float: left;
+        clear: left;
+        padding: 0px
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".46sr0r {
+        background: #fff;
+        border-collapse: collapse;
+        border-spacing: 0px;
+        max-width: 100%;
+        width: 100%
+      }
+      
+      .7q381j {
+        vertical-align: right
+      }
+      
+      .1c43i05 {
+        display: -webkit-box;
+        display: -moz-box;
+        display: -ms-flexbox;
+        display: -webkit-flex;
+        display: flex;
+        flex-wrap: nowrap;
+        -webkit-box-lines: nowrap;
+        -webkit-flex-wrap: nowrap;
+        justify-content: space-around;
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-around;
+        align-items: center;
+        -webkit-box-align: center;
+        -webkit-align-items: center;
+        border-color: #dedede
+      }
+      
+      .kk9pov {
+        display: inline-block;
+        flex: auto;
+        -webkit-flex: auto;
+        border-top: 1px solid #dedede;
+        line-height: 1.5;
+        padding: 0.73333333333rem;
+        vertical-align: middle;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .7q381j { vertical-align: right } .1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .46sr0r { display: block; width: 100%; box-sizing: border-box } .7q381j { display: block; width: 100%; box-sizing: border-box } .1c43i05 { display: block; width: 100%; box-sizing: border-box } .kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .7q381j { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .46sr0r { display: block } .7q381j { display: block } .1c43i05:after { content: ""; display: table; clear: both } .1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent
+        is="div"
+      >
+        <TableStyles
+          is="div"
+        >
+          <TableStyles
+            _felaRule={[Function]}
+            is="div"
+            passThrough={Array []}
+          >
+            <div
+              className="46sr0r"
+              is="div"
+            >
+              <ThemedComponent
+                is="div"
+              >
+                <FelaComponent
+                  is="div"
+                >
+                  <TableBodyStyles
+                    _felaRule={[Function]}
+                    is="div"
+                    passThrough={Array []}
+                  >
+                    <TableBodyStyles
+                      _felaRule={[Function]}
+                      is="div"
+                      passThrough={Array []}
+                    >
+                      <div
+                        className="7q381j"
+                        is="div"
+                      >
+                        <ThemedComponent
+                          is="div"
+                        >
+                          <TableRowStyles
+                            is="div"
+                          >
+                            <TableRowStyles
+                              _felaRule={[Function]}
+                              is="div"
+                              passThrough={Array []}
+                            >
+                              <div
+                                className="1c43i05"
+                                is="div"
+                              >
+                                <ThemedComponent
+                                  is="div"
+                                >
+                                  <TableCellStyles
+                                    is="div"
+                                  >
+                                    <TableCellStyles
+                                      _felaRule={[Function]}
+                                      is="div"
+                                      passThrough={Array []}
+                                    >
+                                      <div
+                                        className="kk9pov"
+                                        is="div"
+                                      />
+                                    </TableCellStyles>
+                                  </TableCellStyles>
+                                </ThemedComponent>
+                              </div>
+                            </TableRowStyles>
+                          </TableRowStyles>
+                        </ThemedComponent>
+                      </div>
+                    </TableBodyStyles>
+                  </TableBodyStyles>
+                </FelaComponent>
+              </ThemedComponent>
+            </div>
+          </TableStyles>
+        </TableStyles>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;
+
+exports[`createTableBody should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "7q381j": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".7q381j {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "(min-width: 97.6em)": ".7q381j {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".7q381j {
+        display: block
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".7q381j {
+        vertical-align: right
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .7q381j { vertical-align: right }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .7q381j { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .7q381j { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .7q381j { display: block }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <ThemedComponent>
+          <FelaComponent>
+            <TableBodyStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableBodyStyles
+                _felaRule={[Function]}
+                passThrough={Array []}
+              >
+                <TableBody
+                  className="7q381j"
+                  is="tbody"
+                >
+                  <tbody
+                    className="7q381j"
+                  />
+                </TableBody>
+              </TableBodyStyles>
+            </TableBodyStyles>
+          </FelaComponent>
+        </ThemedComponent>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;

--- a/packages/cf-component-table/test/__snapshots__/TableBody.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableBody.js.snap
@@ -11,8 +11,8 @@ exports[`TableBody should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "46sr0r": true,
-          "7q381j": true,
+          "cf-46sr0r": true,
+          "cf-7q381j": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -28,25 +28,25 @@ exports[`TableBody should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".46sr0r {
+          "(max-width: 47.2em)": ".cf-46sr0r {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .7q381j {
+      .cf-7q381j {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "(min-width: 97.6em)": ".7q381j {
+          "(min-width: 97.6em)": ".cf-7q381j {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".46sr0r {
+          "screen and (max-width: 47.2em)": ".cf-46sr0r {
         display: block
       }
       
-      .7q381j {
+      .cf-7q381j {
         display: block
       }",
         },
@@ -65,7 +65,7 @@ exports[`TableBody should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".46sr0r {
+        "rules": ".cf-46sr0r {
         background: #fff;
         border-collapse: collapse;
         border-spacing: 0px;
@@ -73,38 +73,38 @@ exports[`TableBody should compose with styles overrides 1`] = `
         width: 100%
       }
       
-      .7q381j {
+      .cf-7q381j {
         vertical-align: right
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .7q381j { vertical-align: right }
+            .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-7q381j { vertical-align: right }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .46sr0r { display: block; width: 100%; box-sizing: border-box } .7q381j { display: block; width: 100%; box-sizing: border-box }
+            .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-7q381j { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .7q381j { width: 1000px }
+            .cf-7q381j { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .46sr0r { display: block } .7q381j { display: block }
+            .cf-46sr0r { display: block } .cf-7q381j { display: block }
       </style>,
         },
         "subscribe": [Function],
@@ -229,14 +229,14 @@ exports[`TableBody should compose with styles overrides 1`] = `
           <Table
             bare={false}
             bordered={true}
-            className="46sr0r"
+            className="cf-46sr0r"
             condensed={false}
             hover={false}
             is="table"
             striped={false}
           >
             <table
-              className="46sr0r"
+              className="cf-46sr0r"
             >
               <ThemedComponent
                 bare={false}
@@ -255,14 +255,14 @@ exports[`TableBody should compose with styles overrides 1`] = `
                   <TableBody
                     bare={false}
                     bordered={true}
-                    className="7q381j"
+                    className="cf-7q381j"
                     condensed={false}
                     hover={false}
                     is="tbody"
                     striped={false}
                   >
                     <tbody
-                      className="7q381j"
+                      className="cf-7q381j"
                     />
                   </TableBody>
                 </FelaComponent>
@@ -287,9 +287,9 @@ exports[`TableBody should render 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1b0jccb": true,
-          "t9kph0": true,
-          "zos2pn": true,
+          "cf-1b0jccb": true,
+          "cf-t9kph0": true,
+          "cf-zos2pn": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -305,51 +305,51 @@ exports[`TableBody should render 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".zos2pn {
+          "(max-width: 47.2em)": ".cf-zos2pn {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1b0jccb {
+      .cf-1b0jccb {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .t9kph0 {
+      .cf-t9kph0 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "screen and (max-width: 47.2em)": ".zos2pn {
+          "screen and (max-width: 47.2em)": ".cf-zos2pn {
         display: block
       }
       
-      .1b0jccb:after {
+      .cf-1b0jccb:after {
         content: \\"\\";
         display: table;
         clear: both
       }
       
-      .1b0jccb {
+      .cf-1b0jccb {
         display: block;
         padding: 0.73333333333rem;
         border-top: none;
         background-color: #ccc
       }
       
-      .t9kph0:after {
+      .cf-t9kph0:after {
         content: \\"\\";
         display: table;
         clear: both
       }
       
-      .t9kph0:hover> td {
+      .cf-t9kph0:hover> td {
         background-color: transparent
       }
       
-      .t9kph0 {
+      .cf-t9kph0 {
         display: block;
         padding: 0.73333333333rem;
         border-top: none;
@@ -371,35 +371,35 @@ exports[`TableBody should render 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".1b0jccb {
+        "rules": ".cf-1b0jccb {
         border-color: #dedede
       }
       
-      .t9kph0 {
+      .cf-t9kph0 {
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .1b0jccb { border-color: #dedede } .t9kph0 { border-color: #dedede }
+            .cf-1b0jccb { border-color: #dedede } .cf-t9kph0 { border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .zos2pn { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .t9kph0 { display: block; width: 100%; box-sizing: border-box }
+            .cf-zos2pn { display: block; width: 100%; box-sizing: border-box } .cf-1b0jccb { display: block; width: 100%; box-sizing: border-box } .cf-t9kph0 { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .zos2pn { display: block } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .t9kph0:after { content: ""; display: table; clear: both } .t9kph0:hover> td { background-color: transparent } .t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
+            .cf-zos2pn { display: block } .cf-1b0jccb:after { content: ""; display: table; clear: both } .cf-1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .cf-t9kph0:after { content: ""; display: table; clear: both } .cf-t9kph0:hover> td { background-color: transparent } .cf-t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
       </style>,
         },
         "subscribe": [Function],
@@ -523,11 +523,11 @@ exports[`TableBody should render 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableBody
-              className="zos2pn"
+              className="cf-zos2pn"
               is="tbody"
             >
               <tbody
-                className="zos2pn"
+                className="cf-zos2pn"
               >
                 <ThemedComponent
                   rowIndex={-0}
@@ -538,14 +538,14 @@ exports[`TableBody should render 1`] = `
                     tbodyIndex={0}
                   >
                     <TableRow
-                      className="t9kph0"
+                      className="cf-t9kph0"
                       is="tr"
                       rowIndex={-0}
                       tbodyIndex={0}
                       type="default"
                     >
                       <tr
-                        className="t9kph0"
+                        className="cf-t9kph0"
                       />
                     </TableRow>
                   </FelaComponent>
@@ -571,10 +571,10 @@ exports[`createTableBody should be able to render a div 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1c43i05": true,
-          "46sr0r": true,
-          "7q381j": true,
-          "kk9pov": true,
+          "cf-1c43i05": true,
+          "cf-46sr0r": true,
+          "cf-7q381j": true,
+          "cf-kk9pov": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -590,55 +590,55 @@ exports[`createTableBody should be able to render a div 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".46sr0r {
+          "(max-width: 47.2em)": ".cf-46sr0r {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .7q381j {
+      .cf-7q381j {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: block;
         width: 100%;
         box-sizing: border-box;
         border-top-width: 0px
       }",
-          "(min-width: 97.6em)": ".7q381j {
+          "(min-width: 97.6em)": ".cf-7q381j {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".46sr0r {
+          "screen and (max-width: 47.2em)": ".cf-46sr0r {
         display: block
       }
       
-      .7q381j {
+      .cf-7q381j {
         display: block
       }
       
-      .1c43i05:after {
+      .cf-1c43i05:after {
         content: \\"\\";
         display: table;
         clear: both
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: block;
         padding: 0.73333333333rem;
         border-top: 1px solid #dedede;
         background-color: #ccc
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: block;
         border: none;
         float: left;
@@ -661,7 +661,7 @@ exports[`createTableBody should be able to render a div 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".46sr0r {
+        "rules": ".cf-46sr0r {
         background: #fff;
         border-collapse: collapse;
         border-spacing: 0px;
@@ -669,11 +669,11 @@ exports[`createTableBody should be able to render a div 1`] = `
         width: 100%
       }
       
-      .7q381j {
+      .cf-7q381j {
         vertical-align: right
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: -webkit-box;
         display: -moz-box;
         display: -ms-flexbox;
@@ -691,7 +691,7 @@ exports[`createTableBody should be able to render a div 1`] = `
         border-color: #dedede
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: inline-block;
         flex: auto;
         -webkit-flex: auto;
@@ -704,35 +704,35 @@ exports[`createTableBody should be able to render a div 1`] = `
         text-overflow: ellipsis;
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .7q381j { vertical-align: right } .1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+            .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-7q381j { vertical-align: right } .cf-1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .cf-kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .46sr0r { display: block; width: 100%; box-sizing: border-box } .7q381j { display: block; width: 100%; box-sizing: border-box } .1c43i05 { display: block; width: 100%; box-sizing: border-box } .kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+            .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-7q381j { display: block; width: 100%; box-sizing: border-box } .cf-1c43i05 { display: block; width: 100%; box-sizing: border-box } .cf-kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .7q381j { width: 1000px }
+            .cf-7q381j { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .46sr0r { display: block } .7q381j { display: block } .1c43i05:after { content: ""; display: table; clear: both } .1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
+            .cf-46sr0r { display: block } .cf-7q381j { display: block } .cf-1c43i05:after { content: ""; display: table; clear: both } .cf-1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .cf-kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
       </style>,
         },
         "subscribe": [Function],
@@ -859,7 +859,7 @@ exports[`createTableBody should be able to render a div 1`] = `
           is="div"
         >
           <div
-            className="46sr0r"
+            className="cf-46sr0r"
             is="div"
           >
             <ThemedComponent
@@ -869,7 +869,7 @@ exports[`createTableBody should be able to render a div 1`] = `
                 is="div"
               >
                 <div
-                  className="7q381j"
+                  className="cf-7q381j"
                   is="div"
                 >
                   <ThemedComponent
@@ -879,7 +879,7 @@ exports[`createTableBody should be able to render a div 1`] = `
                       is="div"
                     >
                       <div
-                        className="1c43i05"
+                        className="cf-1c43i05"
                         is="div"
                       >
                         <ThemedComponent
@@ -889,7 +889,7 @@ exports[`createTableBody should be able to render a div 1`] = `
                             is="div"
                           >
                             <div
-                              className="kk9pov"
+                              className="cf-kk9pov"
                               is="div"
                             />
                           </FelaComponent>
@@ -919,7 +919,7 @@ exports[`createTableBody should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "7q381j": true,
+          "cf-7q381j": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -935,15 +935,15 @@ exports[`createTableBody should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".7q381j {
+          "(max-width: 47.2em)": ".cf-7q381j {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "(min-width: 97.6em)": ".7q381j {
+          "(min-width: 97.6em)": ".cf-7q381j {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".7q381j {
+          "screen and (max-width: 47.2em)": ".cf-7q381j {
         display: block
       }",
         },
@@ -962,38 +962,38 @@ exports[`createTableBody should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".7q381j {
+        "rules": ".cf-7q381j {
         vertical-align: right
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .7q381j { vertical-align: right }
+            .cf-7q381j { vertical-align: right }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .7q381j { display: block; width: 100%; box-sizing: border-box }
+            .cf-7q381j { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .7q381j { width: 1000px }
+            .cf-7q381j { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .7q381j { display: block }
+            .cf-7q381j { display: block }
       </style>,
         },
         "subscribe": [Function],
@@ -1117,11 +1117,11 @@ exports[`createTableBody should compose with styles overrides 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableBody
-              className="7q381j"
+              className="cf-7q381j"
               is="tbody"
             >
               <tbody
-                className="7q381j"
+                className="cf-7q381j"
               />
             </TableBody>
           </FelaComponent>

--- a/packages/cf-component-table/test/__snapshots__/TableBody.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableBody.js.snap
@@ -225,76 +225,51 @@ exports[`TableBody should compose with styles overrides 1`] = `
       }
     >
       <ThemedComponent>
-        <TableStyles>
-          <TableStyles
-            _felaRule={[Function]}
-            passThrough={Array []}
+        <FelaComponent>
+          <Table
+            bare={false}
+            bordered={true}
+            className="46sr0r"
+            condensed={false}
+            hover={false}
+            is="table"
+            striped={false}
           >
-            <Table
-              bare={false}
-              bordered={true}
+            <table
               className="46sr0r"
-              condensed={false}
-              hover={false}
-              is="table"
-              striped={false}
             >
-              <table
-                className="46sr0r"
+              <ThemedComponent
+                bare={false}
+                bordered={true}
+                condensed={false}
+                hover={false}
+                striped={false}
               >
-                <ThemedComponent
+                <FelaComponent
                   bare={false}
                   bordered={true}
                   condensed={false}
                   hover={false}
                   striped={false}
                 >
-                  <FelaComponent
+                  <TableBody
                     bare={false}
                     bordered={true}
+                    className="7q381j"
                     condensed={false}
                     hover={false}
+                    is="tbody"
                     striped={false}
                   >
-                    <TableBodyStyles
-                      _felaRule={[Function]}
-                      bare={false}
-                      bordered={true}
-                      condensed={false}
-                      hover={false}
-                      passThrough={Array []}
-                      striped={false}
-                    >
-                      <TableBodyStyles
-                        _felaRule={[Function]}
-                        bare={false}
-                        bordered={true}
-                        condensed={false}
-                        hover={false}
-                        passThrough={Array []}
-                        striped={false}
-                      >
-                        <TableBody
-                          bare={false}
-                          bordered={true}
-                          className="7q381j"
-                          condensed={false}
-                          hover={false}
-                          is="tbody"
-                          striped={false}
-                        >
-                          <tbody
-                            className="7q381j"
-                          />
-                        </TableBody>
-                      </TableBodyStyles>
-                    </TableBodyStyles>
-                  </FelaComponent>
-                </ThemedComponent>
-              </table>
-            </Table>
-          </TableStyles>
-        </TableStyles>
+                    <tbody
+                      className="7q381j"
+                    />
+                  </TableBody>
+                </FelaComponent>
+              </ThemedComponent>
+            </table>
+          </Table>
+        </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
   </Provider>
@@ -546,50 +521,38 @@ exports[`TableBody should render 1`] = `
     >
       <table>
         <ThemedComponent>
-          <TableBodyStyles>
-            <TableBodyStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+          <FelaComponent>
+            <TableBody
+              className="zos2pn"
+              is="tbody"
             >
-              <TableBody
+              <tbody
                 className="zos2pn"
-                is="tbody"
               >
-                <tbody
-                  className="zos2pn"
+                <ThemedComponent
+                  rowIndex={-0}
+                  tbodyIndex={0}
                 >
-                  <ThemedComponent
+                  <FelaComponent
                     rowIndex={-0}
                     tbodyIndex={0}
                   >
-                    <TableRowStyles
+                    <TableRow
+                      className="t9kph0"
+                      is="tr"
                       rowIndex={-0}
                       tbodyIndex={0}
+                      type="default"
                     >
-                      <TableRowStyles
-                        _felaRule={[Function]}
-                        passThrough={Array []}
-                        rowIndex={-0}
-                        tbodyIndex={0}
-                      >
-                        <TableRow
-                          className="t9kph0"
-                          is="tr"
-                          rowIndex={-0}
-                          tbodyIndex={0}
-                          type="default"
-                        >
-                          <tr
-                            className="t9kph0"
-                          />
-                        </TableRow>
-                      </TableRowStyles>
-                    </TableRowStyles>
-                  </ThemedComponent>
-                </tbody>
-              </TableBody>
-            </TableBodyStyles>
-          </TableBodyStyles>
+                      <tr
+                        className="t9kph0"
+                      />
+                    </TableRow>
+                  </FelaComponent>
+                </ThemedComponent>
+              </tbody>
+            </TableBody>
+          </FelaComponent>
         </ThemedComponent>
       </table>
     </ThemeProvider>
@@ -892,83 +855,53 @@ exports[`createTableBody should be able to render a div 1`] = `
       <ThemedComponent
         is="div"
       >
-        <TableStyles
+        <FelaComponent
           is="div"
         >
-          <TableStyles
-            _felaRule={[Function]}
+          <div
+            className="46sr0r"
             is="div"
-            passThrough={Array []}
           >
-            <div
-              className="46sr0r"
+            <ThemedComponent
               is="div"
             >
-              <ThemedComponent
+              <FelaComponent
                 is="div"
               >
-                <FelaComponent
+                <div
+                  className="7q381j"
                   is="div"
                 >
-                  <TableBodyStyles
-                    _felaRule={[Function]}
+                  <ThemedComponent
                     is="div"
-                    passThrough={Array []}
                   >
-                    <TableBodyStyles
-                      _felaRule={[Function]}
+                    <FelaComponent
                       is="div"
-                      passThrough={Array []}
                     >
                       <div
-                        className="7q381j"
+                        className="1c43i05"
                         is="div"
                       >
                         <ThemedComponent
                           is="div"
                         >
-                          <TableRowStyles
+                          <FelaComponent
                             is="div"
                           >
-                            <TableRowStyles
-                              _felaRule={[Function]}
+                            <div
+                              className="kk9pov"
                               is="div"
-                              passThrough={Array []}
-                            >
-                              <div
-                                className="1c43i05"
-                                is="div"
-                              >
-                                <ThemedComponent
-                                  is="div"
-                                >
-                                  <TableCellStyles
-                                    is="div"
-                                  >
-                                    <TableCellStyles
-                                      _felaRule={[Function]}
-                                      is="div"
-                                      passThrough={Array []}
-                                    >
-                                      <div
-                                        className="kk9pov"
-                                        is="div"
-                                      />
-                                    </TableCellStyles>
-                                  </TableCellStyles>
-                                </ThemedComponent>
-                              </div>
-                            </TableRowStyles>
-                          </TableRowStyles>
+                            />
+                          </FelaComponent>
                         </ThemedComponent>
                       </div>
-                    </TableBodyStyles>
-                  </TableBodyStyles>
-                </FelaComponent>
-              </ThemedComponent>
-            </div>
-          </TableStyles>
-        </TableStyles>
+                    </FelaComponent>
+                  </ThemedComponent>
+                </div>
+              </FelaComponent>
+            </ThemedComponent>
+          </div>
+        </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
   </Provider>
@@ -1183,24 +1116,14 @@ exports[`createTableBody should compose with styles overrides 1`] = `
       <table>
         <ThemedComponent>
           <FelaComponent>
-            <TableBodyStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+            <TableBody
+              className="7q381j"
+              is="tbody"
             >
-              <TableBodyStyles
-                _felaRule={[Function]}
-                passThrough={Array []}
-              >
-                <TableBody
-                  className="7q381j"
-                  is="tbody"
-                >
-                  <tbody
-                    className="7q381j"
-                  />
-                </TableBody>
-              </TableBodyStyles>
-            </TableBodyStyles>
+              <tbody
+                className="7q381j"
+              />
+            </TableBody>
           </FelaComponent>
         </ThemedComponent>
       </table>

--- a/packages/cf-component-table/test/__snapshots__/TableBody.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableBody.js.snap
@@ -1,17 +1,598 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
-<tbody
-  className="cf-table__body"
+exports[`TableBody should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
 >
-  TableBody
-</tbody>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "46sr0r": true,
+          "7q381j": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".46sr0r {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .7q381j {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "(min-width: 97.6em)": ".7q381j {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".46sr0r {
+        display: block
+      }
+      
+      .7q381j {
+        display: block
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".46sr0r {
+        background: #fff;
+        border-collapse: collapse;
+        border-spacing: 0px;
+        max-width: 100%;
+        width: 100%
+      }
+      
+      .7q381j {
+        vertical-align: right
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .7q381j { vertical-align: right }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .46sr0r { display: block; width: 100%; box-sizing: border-box } .7q381j { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .7q381j { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .46sr0r { display: block } .7q381j { display: block }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent>
+        <TableStyles>
+          <TableStyles
+            _felaRule={[Function]}
+            passThrough={Array []}
+          >
+            <Table
+              bare={false}
+              bordered={true}
+              className="46sr0r"
+              condensed={false}
+              hover={false}
+              is="table"
+              striped={false}
+            >
+              <table
+                className="46sr0r"
+              >
+                <ThemedComponent
+                  bare={false}
+                  bordered={true}
+                  condensed={false}
+                  hover={false}
+                  striped={false}
+                >
+                  <FelaComponent
+                    bare={false}
+                    bordered={true}
+                    condensed={false}
+                    hover={false}
+                    striped={false}
+                  >
+                    <TableBodyStyles
+                      _felaRule={[Function]}
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      passThrough={Array []}
+                      striped={false}
+                    >
+                      <TableBodyStyles
+                        _felaRule={[Function]}
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        passThrough={Array []}
+                        striped={false}
+                      >
+                        <TableBody
+                          bare={false}
+                          bordered={true}
+                          className="7q381j"
+                          condensed={false}
+                          hover={false}
+                          is="tbody"
+                          striped={false}
+                        >
+                          <tbody
+                            className="7q381j"
+                          />
+                        </TableBody>
+                      </TableBodyStyles>
+                    </TableBodyStyles>
+                  </FelaComponent>
+                </ThemedComponent>
+              </table>
+            </Table>
+          </TableStyles>
+        </TableStyles>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
 `;
 
-exports[`should render extra class names 1`] = `
-<tbody
-  className="cf-table__body extra"
+exports[`TableBody should render 1`] = `
+<StyleProvider
+  dev={true}
 >
-  TableBody
-</tbody>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1b0jccb": true,
+          "t9kph0": true,
+          "zos2pn": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".zos2pn {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1b0jccb {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .t9kph0 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "screen and (max-width: 47.2em)": ".zos2pn {
+        display: block
+      }
+      
+      .1b0jccb:after {
+        content: \\"\\";
+        display: table;
+        clear: both
+      }
+      
+      .1b0jccb {
+        display: block;
+        padding: 0.73333333333rem;
+        border-top: none;
+        background-color: #ccc
+      }
+      
+      .t9kph0:after {
+        content: \\"\\";
+        display: table;
+        clear: both
+      }
+      
+      .t9kph0:hover> td {
+        background-color: transparent
+      }
+      
+      .t9kph0 {
+        display: block;
+        padding: 0.73333333333rem;
+        border-top: none;
+        background-color: #ccc
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".1b0jccb {
+        border-color: #dedede
+      }
+      
+      .t9kph0 {
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .1b0jccb { border-color: #dedede } .t9kph0 { border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .zos2pn { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box } .t9kph0 { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .zos2pn { display: block } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc } .t9kph0:after { content: ""; display: table; clear: both } .t9kph0:hover> td { background-color: transparent } .t9kph0 { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <ThemedComponent>
+          <TableBodyStyles>
+            <TableBodyStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableBody
+                className="zos2pn"
+                is="tbody"
+              >
+                <tbody
+                  className="zos2pn"
+                >
+                  <ThemedComponent
+                    rowIndex={-0}
+                    tbodyIndex={0}
+                  >
+                    <TableRowStyles
+                      rowIndex={-0}
+                      tbodyIndex={0}
+                    >
+                      <TableRowStyles
+                        _felaRule={[Function]}
+                        passThrough={Array []}
+                        rowIndex={-0}
+                        tbodyIndex={0}
+                      >
+                        <TableRow
+                          className="t9kph0"
+                          is="tr"
+                          rowIndex={-0}
+                          tbodyIndex={0}
+                          type="default"
+                        >
+                          <tr
+                            className="t9kph0"
+                          />
+                        </TableRow>
+                      </TableRowStyles>
+                    </TableRowStyles>
+                  </ThemedComponent>
+                </tbody>
+              </TableBody>
+            </TableBodyStyles>
+          </TableBodyStyles>
+        </ThemedComponent>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
@@ -7,7 +7,7 @@ Object {
     bare={undefined}
     bordered={undefined}
     cellIndex={undefined}
-    className="kk9pov"
+    className="cf-kk9pov"
     colSpan={undefined}
     condensed={undefined}
     headers={undefined}
@@ -24,7 +24,7 @@ Object {
 >
     TableCell
 </div>,
-  "styles": ".kk9pov {
+  "styles": ".cf-kk9pov {
   display: inline-block;
   flex: auto;
   -webkit-flex: auto;
@@ -38,7 +38,7 @@ Object {
   border-color: #dedede
 }
 @media (max-width: 47.2em) {
-  .kk9pov {
+  .cf-kk9pov {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -46,7 +46,7 @@ Object {
   }
 }
 @media screen and (max-width: 47.2em) {
-  .kk9pov {
+  .cf-kk9pov {
     display: block;
     border: none;
     float: left;
@@ -60,13 +60,13 @@ Object {
 exports[`TableCell should render 1`] = `
 Object {
   "component": <td
-    className="c5609r"
+    className="cf-c5609r"
     colSpan={undefined}
     rowSpan={undefined}
 >
     TableCell
 </td>,
-  "styles": ".c5609r {
+  "styles": ".cf-c5609r {
   border-top: 1px solid #dedede;
   line-height: 1.5;
   padding: 0.73333333333rem;
@@ -77,7 +77,7 @@ Object {
   border-color: #dedede
 }
 @media (max-width: 47.2em) {
-  .c5609r {
+  .cf-c5609r {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -85,7 +85,7 @@ Object {
   }
 }
 @media screen and (max-width: 47.2em) {
-  .c5609r {
+  .cf-c5609r {
     display: block;
     border: none;
     float: left;
@@ -99,13 +99,13 @@ Object {
 exports[`TableCell should render with align 1`] = `
 Object {
   "component": <td
-    className="2n3suq"
+    className="cf-2n3suq"
     colSpan={undefined}
     rowSpan={undefined}
 >
     TableCell
 </td>,
-  "styles": ".2n3suq {
+  "styles": ".cf-2n3suq {
   border-top: 1px solid #dedede;
   line-height: 1.5;
   padding: 0.73333333333rem;
@@ -117,7 +117,7 @@ Object {
   border-color: #dedede
 }
 @media (max-width: 47.2em) {
-  .2n3suq {
+  .cf-2n3suq {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -125,7 +125,7 @@ Object {
   }
 }
 @media screen and (max-width: 47.2em) {
-  .2n3suq {
+  .cf-2n3suq {
     display: block;
     border: none;
     float: left;
@@ -147,7 +147,7 @@ exports[`createTableCell should be able to render a div 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "6ddffr": true,
+          "cf-6ddffr": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -163,16 +163,16 @@ exports[`createTableCell should be able to render a div 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".6ddffr {
+          "(max-width: 47.2em)": ".cf-6ddffr {
         display: block;
         width: 100%;
         box-sizing: border-box;
         border-top-width: 0px
       }",
-          "(min-width: 97.6em)": ".6ddffr {
+          "(min-width: 97.6em)": ".cf-6ddffr {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".6ddffr {
+          "screen and (max-width: 47.2em)": ".cf-6ddffr {
         display: block;
         border: none;
         float: left;
@@ -195,7 +195,7 @@ exports[`createTableCell should be able to render a div 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".6ddffr {
+        "rules": ".cf-6ddffr {
         display: inline-block;
         flex: auto;
         -webkit-flex: auto;
@@ -208,35 +208,35 @@ exports[`createTableCell should be able to render a div 1`] = `
         text-overflow: ellipsis;
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .6ddffr { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+            .cf-6ddffr { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .6ddffr { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+            .cf-6ddffr { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .6ddffr { width: 1000px }
+            .cf-6ddffr { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .6ddffr { display: block; border: none; float: left; clear: left; padding: 0px }
+            .cf-6ddffr { display: block; border: none; float: left; clear: left; padding: 0px }
       </style>,
         },
         "subscribe": [Function],
@@ -363,7 +363,7 @@ exports[`createTableCell should be able to render a div 1`] = `
           is="div"
         >
           <div
-            className="6ddffr"
+            className="cf-6ddffr"
             is="div"
           />
         </FelaComponent>
@@ -384,7 +384,7 @@ exports[`createTableCell should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "19q41br": true,
+          "cf-19q41br": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -400,16 +400,16 @@ exports[`createTableCell should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".19q41br {
+          "(max-width: 47.2em)": ".cf-19q41br {
         display: block;
         width: 100%;
         box-sizing: border-box;
         border-top-width: 0px
       }",
-          "(min-width: 97.6em)": ".19q41br {
+          "(min-width: 97.6em)": ".cf-19q41br {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".19q41br {
+          "screen and (max-width: 47.2em)": ".cf-19q41br {
         display: block;
         border: none;
         float: left;
@@ -432,7 +432,7 @@ exports[`createTableCell should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".19q41br {
+        "rules": ".cf-19q41br {
         border-top: 1px solid #dedede;
         line-height: 1.5;
         padding: 0.73333333333rem;
@@ -442,35 +442,35 @@ exports[`createTableCell should compose with styles overrides 1`] = `
         text-overflow: ellipsis;
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .19q41br { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+            .cf-19q41br { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .19q41br { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+            .cf-19q41br { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .19q41br { width: 1000px }
+            .cf-19q41br { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .19q41br { display: block; border: none; float: left; clear: left; padding: 0px }
+            .cf-19q41br { display: block; border: none; float: left; clear: left; padding: 0px }
       </style>,
         },
         "subscribe": [Function],
@@ -597,11 +597,11 @@ exports[`createTableCell should compose with styles overrides 1`] = `
               <FelaComponent>
                 <TableCell
                   align="left"
-                  className="19q41br"
+                  className="cf-19q41br"
                   is="td"
                 >
                   <td
-                    className="19q41br"
+                    className="cf-19q41br"
                   />
                 </TableCell>
               </FelaComponent>

--- a/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
@@ -350,22 +350,10 @@ exports[`createTableCell should be able to render a div 1`] = `
         <FelaComponent
           is="div"
         >
-          <TableCellStyles
-            _felaRule={[Function]}
+          <div
+            className="6ddffr"
             is="div"
-            passThrough={Array []}
-          >
-            <TableCellStyles
-              _felaRule={[Function]}
-              is="div"
-              passThrough={Array []}
-            >
-              <div
-                className="6ddffr"
-                is="div"
-              />
-            </TableCellStyles>
-          </TableCellStyles>
+          />
         </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
@@ -595,25 +583,15 @@ exports[`createTableCell should compose with styles overrides 1`] = `
           <tr>
             <ThemedComponent>
               <FelaComponent>
-                <TableCellStyles
-                  _felaRule={[Function]}
-                  passThrough={Array []}
+                <TableCell
+                  align="left"
+                  className="19q41br"
+                  is="td"
                 >
-                  <TableCellStyles
-                    _felaRule={[Function]}
-                    passThrough={Array []}
-                  >
-                    <TableCell
-                      align="left"
-                      className="19q41br"
-                      is="td"
-                    >
-                      <td
-                        className="19q41br"
-                      />
-                    </TableCell>
-                  </TableCellStyles>
-                </TableCellStyles>
+                  <td
+                    className="19q41br"
+                  />
+                </TableCell>
               </FelaComponent>
             </ThemedComponent>
           </tr>

--- a/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
@@ -1,25 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
-<td
-  className="cf-table__cell"
+exports[`TableCell should compose with styles overrides 1`] = `
+Object {
+  "component": <td
+    className="19q41br"
+    colSpan={undefined}
+    rowSpan={undefined}
 >
-  TableCell
-</td>
+    TableCell
+</td>,
+  "styles": ".19q41br {
+  border-top: 1px solid #dedede;
+  line-height: 1.5;
+  padding: 0.73333333333rem;
+  vertical-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-color: #dedede
+}@media (max-width: 47.2em){.19q41br {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-width: 0px
+}}@media screen and (max-width: 47.2em){.19q41br {
+  display: block;
+  border: none;
+  float: left;
+  clear: left;
+  padding: 0px
+}}@media (min-width: 97.6em){.19q41br {
+  width: 1000px
+}}",
+}
 `;
 
-exports[`should render extra class name 1`] = `
-<td
-  className="cf-table__cell extra"
+exports[`TableCell should render 1`] = `
+Object {
+  "component": <td
+    className="c5609r"
+    colSpan={undefined}
+    rowSpan={undefined}
 >
-  TableCell
-</td>
+    TableCell
+</td>,
+  "styles": "
+.c5609r {
+  border-top: 1px solid #dedede;
+  line-height: 1.5;
+  padding: 0.73333333333rem;
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-color: #dedede
+}@media (max-width: 47.2em){
+    .c5609r {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-width: 0px
+}}@media screen and (max-width: 47.2em){
+    .c5609r {
+  display: block;
+  border: none;
+  float: left;
+  clear: left;
+  padding: 0px
+}}",
+}
 `;
 
-exports[`should render with align 1`] = `
-<td
-  className="cf-table__cell cf-table__cell--align-center"
+exports[`TableCell should render with align 1`] = `
+Object {
+  "component": <td
+    className="2n3suq"
+    colSpan={undefined}
+    rowSpan={undefined}
 >
-  TableCell
-</td>
+    TableCell
+</td>,
+  "styles": ".2n3suq {
+  border-top: 1px solid #dedede;
+  line-height: 1.5;
+  padding: 0.73333333333rem;
+  vertical-align: middle;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-color: #dedede
+}@media (max-width: 47.2em){.2n3suq {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-width: 0px
+}}@media screen and (max-width: 47.2em){.2n3suq {
+  display: block;
+  border: none;
+  float: left;
+  clear: left;
+  padding: 0px
+}}",
+}
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
@@ -1,36 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableCell should compose with styles overrides 1`] = `
+exports[`TableCell can render a div 1`] = `
 Object {
-  "component": <td
-    className="19q41br"
+  "component": <div
+    align={undefined}
+    bare={undefined}
+    bordered={undefined}
+    cellIndex={undefined}
+    className="kk9pov"
     colSpan={undefined}
+    condensed={undefined}
+    headers={undefined}
+    hover={undefined}
+    is="div"
+    rowIndex={undefined}
     rowSpan={undefined}
+    rowType={undefined}
+    striped={undefined}
+    tbodyIndex={undefined}
+    tfootIndex={undefined}
+    theadIndex={undefined}
+    width={undefined}
 >
     TableCell
-</td>,
-  "styles": ".19q41br {
+</div>,
+  "styles": "
+.kk9pov {
+  display: inline-block;
+  flex: auto;
+  -webkit-flex: auto;
   border-top: 1px solid #dedede;
   line-height: 1.5;
   padding: 0.73333333333rem;
-  vertical-align: right;
+  vertical-align: middle;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   border-color: #dedede
-}@media (max-width: 47.2em){.19q41br {
+}@media (max-width: 47.2em){
+    .kk9pov {
   display: block;
   width: 100%;
   box-sizing: border-box;
   border-top-width: 0px
-}}@media screen and (max-width: 47.2em){.19q41br {
+}}@media screen and (max-width: 47.2em){
+    .kk9pov {
   display: block;
   border: none;
   float: left;
   clear: left;
   padding: 0px
-}}@media (min-width: 97.6em){.19q41br {
-  width: 1000px
 }}",
 }
 `;
@@ -103,4 +122,504 @@ Object {
   padding: 0px
 }}",
 }
+`;
+
+exports[`createTableCell should be able to render a div 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "6ddffr": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".6ddffr {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        border-top-width: 0px
+      }",
+          "(min-width: 97.6em)": ".6ddffr {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".6ddffr {
+        display: block;
+        border: none;
+        float: left;
+        clear: left;
+        padding: 0px
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".6ddffr {
+        display: inline-block;
+        flex: auto;
+        -webkit-flex: auto;
+        border-top: 1px solid #dedede;
+        line-height: 1.5;
+        padding: 0.73333333333rem;
+        vertical-align: right;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .6ddffr { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .6ddffr { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .6ddffr { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .6ddffr { display: block; border: none; float: left; clear: left; padding: 0px }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent
+        is="div"
+      >
+        <FelaComponent
+          is="div"
+        >
+          <TableCellStyles
+            _felaRule={[Function]}
+            is="div"
+            passThrough={Array []}
+          >
+            <TableCellStyles
+              _felaRule={[Function]}
+              is="div"
+              passThrough={Array []}
+            >
+              <div
+                className="6ddffr"
+                is="div"
+              />
+            </TableCellStyles>
+          </TableCellStyles>
+        </FelaComponent>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;
+
+exports[`createTableCell should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "19q41br": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".19q41br {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        border-top-width: 0px
+      }",
+          "(min-width: 97.6em)": ".19q41br {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".19q41br {
+        display: block;
+        border: none;
+        float: left;
+        clear: left;
+        padding: 0px
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".19q41br {
+        border-top: 1px solid #dedede;
+        line-height: 1.5;
+        padding: 0.73333333333rem;
+        vertical-align: right;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .19q41br { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .19q41br { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .19q41br { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .19q41br { display: block; border: none; float: left; clear: left; padding: 0px }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <tbody>
+          <tr>
+            <ThemedComponent>
+              <FelaComponent>
+                <TableCellStyles
+                  _felaRule={[Function]}
+                  passThrough={Array []}
+                >
+                  <TableCellStyles
+                    _felaRule={[Function]}
+                    passThrough={Array []}
+                  >
+                    <TableCell
+                      align="left"
+                      className="19q41br"
+                      is="td"
+                    >
+                      <td
+                        className="19q41br"
+                      />
+                    </TableCell>
+                  </TableCellStyles>
+                </TableCellStyles>
+              </FelaComponent>
+            </ThemedComponent>
+          </tr>
+        </tbody>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableCell.js.snap
@@ -24,8 +24,7 @@ Object {
 >
     TableCell
 </div>,
-  "styles": "
-.kk9pov {
+  "styles": ".kk9pov {
   display: inline-block;
   flex: auto;
   -webkit-flex: auto;
@@ -37,20 +36,24 @@ Object {
   overflow: hidden;
   text-overflow: ellipsis;
   border-color: #dedede
-}@media (max-width: 47.2em){
-    .kk9pov {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-width: 0px
-}}@media screen and (max-width: 47.2em){
-    .kk9pov {
-  display: block;
-  border: none;
-  float: left;
-  clear: left;
-  padding: 0px
-}}",
+}
+@media (max-width: 47.2em) {
+  .kk9pov {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border-top-width: 0px
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .kk9pov {
+    display: block;
+    border: none;
+    float: left;
+    clear: left;
+    padding: 0px
+  }
+}",
 }
 `;
 
@@ -63,8 +66,7 @@ Object {
 >
     TableCell
 </td>,
-  "styles": "
-.c5609r {
+  "styles": ".c5609r {
   border-top: 1px solid #dedede;
   line-height: 1.5;
   padding: 0.73333333333rem;
@@ -73,20 +75,24 @@ Object {
   overflow: hidden;
   text-overflow: ellipsis;
   border-color: #dedede
-}@media (max-width: 47.2em){
-    .c5609r {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-width: 0px
-}}@media screen and (max-width: 47.2em){
-    .c5609r {
-  display: block;
-  border: none;
-  float: left;
-  clear: left;
-  padding: 0px
-}}",
+}
+@media (max-width: 47.2em) {
+  .c5609r {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border-top-width: 0px
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .c5609r {
+    display: block;
+    border: none;
+    float: left;
+    clear: left;
+    padding: 0px
+  }
+}",
 }
 `;
 
@@ -109,18 +115,24 @@ Object {
   overflow: hidden;
   text-overflow: ellipsis;
   border-color: #dedede
-}@media (max-width: 47.2em){.2n3suq {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-width: 0px
-}}@media screen and (max-width: 47.2em){.2n3suq {
-  display: block;
-  border: none;
-  float: left;
-  clear: left;
-  padding: 0px
-}}",
+}
+@media (max-width: 47.2em) {
+  .2n3suq {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border-top-width: 0px
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .2n3suq {
+    display: block;
+    border: none;
+    float: left;
+    clear: left;
+    padding: 0px
+  }
+}",
 }
 `;
 

--- a/packages/cf-component-table/test/__snapshots__/TableFoot.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableFoot.js.snap
@@ -221,76 +221,51 @@ exports[`TableFoot should compose with styles overrides 1`] = `
       }
     >
       <ThemedComponent>
-        <TableStyles>
-          <TableStyles
-            _felaRule={[Function]}
-            passThrough={Array []}
+        <FelaComponent>
+          <Table
+            bare={false}
+            bordered={true}
+            className="46sr0r"
+            condensed={false}
+            hover={false}
+            is="table"
+            striped={false}
           >
-            <Table
-              bare={false}
-              bordered={true}
+            <table
               className="46sr0r"
-              condensed={false}
-              hover={false}
-              is="table"
-              striped={false}
             >
-              <table
-                className="46sr0r"
+              <ThemedComponent
+                bare={false}
+                bordered={true}
+                condensed={false}
+                hover={false}
+                striped={false}
               >
-                <ThemedComponent
+                <FelaComponent
                   bare={false}
                   bordered={true}
                   condensed={false}
                   hover={false}
                   striped={false}
                 >
-                  <FelaComponent
+                  <TableFoot
                     bare={false}
                     bordered={true}
+                    className="116rzb2"
                     condensed={false}
                     hover={false}
+                    is="tfoot"
                     striped={false}
                   >
-                    <TableFootStyles
-                      _felaRule={[Function]}
-                      bare={false}
-                      bordered={true}
-                      condensed={false}
-                      hover={false}
-                      passThrough={Array []}
-                      striped={false}
-                    >
-                      <TableFootStyles
-                        _felaRule={[Function]}
-                        bare={false}
-                        bordered={true}
-                        condensed={false}
-                        hover={false}
-                        passThrough={Array []}
-                        striped={false}
-                      >
-                        <TableFoot
-                          bare={false}
-                          bordered={true}
-                          className="116rzb2"
-                          condensed={false}
-                          hover={false}
-                          is="tfoot"
-                          striped={false}
-                        >
-                          <tfoot
-                            className="116rzb2"
-                          />
-                        </TableFoot>
-                      </TableFootStyles>
-                    </TableFootStyles>
-                  </FelaComponent>
-                </ThemedComponent>
-              </table>
-            </Table>
-          </TableStyles>
-        </TableStyles>
+                    <tfoot
+                      className="116rzb2"
+                    />
+                  </TableFoot>
+                </FelaComponent>
+              </ThemedComponent>
+            </table>
+          </Table>
+        </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
   </Provider>
@@ -510,50 +485,38 @@ exports[`TableFoot should render 1`] = `
     >
       <table>
         <ThemedComponent>
-          <TableFootStyles>
-            <TableFootStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+          <FelaComponent>
+            <TableFoot
+              className="dotb8y"
+              is="tfoot"
             >
-              <TableFoot
+              <tfoot
                 className="dotb8y"
-                is="tfoot"
               >
-                <tfoot
-                  className="dotb8y"
+                <ThemedComponent
+                  rowIndex={-0}
+                  tfootIndex={0}
                 >
-                  <ThemedComponent
+                  <FelaComponent
                     rowIndex={-0}
                     tfootIndex={0}
                   >
-                    <TableRowStyles
+                    <TableRow
+                      className="1b0jccb"
+                      is="tr"
                       rowIndex={-0}
                       tfootIndex={0}
+                      type="default"
                     >
-                      <TableRowStyles
-                        _felaRule={[Function]}
-                        passThrough={Array []}
-                        rowIndex={-0}
-                        tfootIndex={0}
-                      >
-                        <TableRow
-                          className="1b0jccb"
-                          is="tr"
-                          rowIndex={-0}
-                          tfootIndex={0}
-                          type="default"
-                        >
-                          <tr
-                            className="1b0jccb"
-                          />
-                        </TableRow>
-                      </TableRowStyles>
-                    </TableRowStyles>
-                  </ThemedComponent>
-                </tfoot>
-              </TableFoot>
-            </TableFootStyles>
-          </TableFootStyles>
+                      <tr
+                        className="1b0jccb"
+                      />
+                    </TableRow>
+                  </FelaComponent>
+                </ThemedComponent>
+              </tfoot>
+            </TableFoot>
+          </FelaComponent>
         </ThemedComponent>
       </table>
     </ThemeProvider>
@@ -852,83 +815,53 @@ exports[`createTableFoot should be able to render a div 1`] = `
       <ThemedComponent
         is="div"
       >
-        <TableStyles
+        <FelaComponent
           is="div"
         >
-          <TableStyles
-            _felaRule={[Function]}
+          <div
+            className="46sr0r"
             is="div"
-            passThrough={Array []}
           >
-            <div
-              className="46sr0r"
+            <ThemedComponent
               is="div"
             >
-              <ThemedComponent
+              <FelaComponent
                 is="div"
               >
-                <FelaComponent
+                <div
+                  className="116rzb2"
                   is="div"
                 >
-                  <TableFootStyles
-                    _felaRule={[Function]}
+                  <ThemedComponent
                     is="div"
-                    passThrough={Array []}
                   >
-                    <TableFootStyles
-                      _felaRule={[Function]}
+                    <FelaComponent
                       is="div"
-                      passThrough={Array []}
                     >
                       <div
-                        className="116rzb2"
+                        className="1c43i05"
                         is="div"
                       >
                         <ThemedComponent
                           is="div"
                         >
-                          <TableRowStyles
+                          <FelaComponent
                             is="div"
                           >
-                            <TableRowStyles
-                              _felaRule={[Function]}
+                            <div
+                              className="kk9pov"
                               is="div"
-                              passThrough={Array []}
-                            >
-                              <div
-                                className="1c43i05"
-                                is="div"
-                              >
-                                <ThemedComponent
-                                  is="div"
-                                >
-                                  <TableCellStyles
-                                    is="div"
-                                  >
-                                    <TableCellStyles
-                                      _felaRule={[Function]}
-                                      is="div"
-                                      passThrough={Array []}
-                                    >
-                                      <div
-                                        className="kk9pov"
-                                        is="div"
-                                      />
-                                    </TableCellStyles>
-                                  </TableCellStyles>
-                                </ThemedComponent>
-                              </div>
-                            </TableRowStyles>
-                          </TableRowStyles>
+                            />
+                          </FelaComponent>
                         </ThemedComponent>
                       </div>
-                    </TableFootStyles>
-                  </TableFootStyles>
-                </FelaComponent>
-              </ThemedComponent>
-            </div>
-          </TableStyles>
-        </TableStyles>
+                    </FelaComponent>
+                  </ThemedComponent>
+                </div>
+              </FelaComponent>
+            </ThemedComponent>
+          </div>
+        </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
   </Provider>
@@ -1140,24 +1073,14 @@ exports[`createTableFoot should compose with styles overrides 1`] = `
       <table>
         <ThemedComponent>
           <FelaComponent>
-            <TableFootStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+            <TableFoot
+              className="116rzb2"
+              is="tfoot"
             >
-              <TableFootStyles
-                _felaRule={[Function]}
-                passThrough={Array []}
-              >
-                <TableFoot
-                  className="116rzb2"
-                  is="tfoot"
-                >
-                  <tfoot
-                    className="116rzb2"
-                  />
-                </TableFoot>
-              </TableFootStyles>
-            </TableFootStyles>
+              <tfoot
+                className="116rzb2"
+              />
+            </TableFoot>
           </FelaComponent>
         </ThemedComponent>
       </table>

--- a/packages/cf-component-table/test/__snapshots__/TableFoot.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableFoot.js.snap
@@ -1,17 +1,562 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
-<tfoot
-  className="cf-table__foot"
+exports[`TableFoot should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
 >
-  TableFoot
-</tfoot>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "116rzb2": true,
+          "46sr0r": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".46sr0r {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .116rzb2 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "(min-width: 97.6em)": ".116rzb2 {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".46sr0r {
+        display: block
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".46sr0r {
+        background: #fff;
+        border-collapse: collapse;
+        border-spacing: 0px;
+        max-width: 100%;
+        width: 100%
+      }
+      
+      .116rzb2 {
+        vertical-align: right
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .116rzb2 { vertical-align: right }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .46sr0r { display: block; width: 100%; box-sizing: border-box } .116rzb2 { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .116rzb2 { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .46sr0r { display: block }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent>
+        <TableStyles>
+          <TableStyles
+            _felaRule={[Function]}
+            passThrough={Array []}
+          >
+            <Table
+              bare={false}
+              bordered={true}
+              className="46sr0r"
+              condensed={false}
+              hover={false}
+              is="table"
+              striped={false}
+            >
+              <table
+                className="46sr0r"
+              >
+                <ThemedComponent
+                  bare={false}
+                  bordered={true}
+                  condensed={false}
+                  hover={false}
+                  striped={false}
+                >
+                  <FelaComponent
+                    bare={false}
+                    bordered={true}
+                    condensed={false}
+                    hover={false}
+                    striped={false}
+                  >
+                    <TableFootStyles
+                      _felaRule={[Function]}
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      passThrough={Array []}
+                      striped={false}
+                    >
+                      <TableFootStyles
+                        _felaRule={[Function]}
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        passThrough={Array []}
+                        striped={false}
+                      >
+                        <TableFoot
+                          bare={false}
+                          bordered={true}
+                          className="116rzb2"
+                          condensed={false}
+                          hover={false}
+                          is="tfoot"
+                          striped={false}
+                        >
+                          <tfoot
+                            className="116rzb2"
+                          />
+                        </TableFoot>
+                      </TableFootStyles>
+                    </TableFootStyles>
+                  </FelaComponent>
+                </ThemedComponent>
+              </table>
+            </Table>
+          </TableStyles>
+        </TableStyles>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
 `;
 
-exports[`should render extra class name 1`] = `
-<tfoot
-  className="cf-table__foot extra"
+exports[`TableFoot should render 1`] = `
+<StyleProvider
+  dev={true}
 >
-  TableFoot
-</tfoot>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1b0jccb": true,
+          "dotb8y": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".dotb8y {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1b0jccb {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "screen and (max-width: 47.2em)": ".1b0jccb:after {
+        content: \\"\\";
+        display: table;
+        clear: both
+      }
+      
+      .1b0jccb {
+        display: block;
+        padding: 0.73333333333rem;
+        border-top: none;
+        background-color: #ccc
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".1b0jccb {
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .1b0jccb { border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .dotb8y { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <ThemedComponent>
+          <TableFootStyles>
+            <TableFootStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableFoot
+                className="dotb8y"
+                is="tfoot"
+              >
+                <tfoot
+                  className="dotb8y"
+                >
+                  <ThemedComponent
+                    rowIndex={-0}
+                    tfootIndex={0}
+                  >
+                    <TableRowStyles
+                      rowIndex={-0}
+                      tfootIndex={0}
+                    >
+                      <TableRowStyles
+                        _felaRule={[Function]}
+                        passThrough={Array []}
+                        rowIndex={-0}
+                        tfootIndex={0}
+                      >
+                        <TableRow
+                          className="1b0jccb"
+                          is="tr"
+                          rowIndex={-0}
+                          tfootIndex={0}
+                          type="default"
+                        >
+                          <tr
+                            className="1b0jccb"
+                          />
+                        </TableRow>
+                      </TableRowStyles>
+                    </TableRowStyles>
+                  </ThemedComponent>
+                </tfoot>
+              </TableFoot>
+            </TableFootStyles>
+          </TableFootStyles>
+        </ThemedComponent>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableFoot.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableFoot.js.snap
@@ -560,3 +560,608 @@ exports[`TableFoot should render 1`] = `
   </Provider>
 </StyleProvider>
 `;
+
+exports[`createTableFoot should be able to render a div 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "116rzb2": true,
+          "1c43i05": true,
+          "46sr0r": true,
+          "kk9pov": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".46sr0r {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .116rzb2 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1c43i05 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .kk9pov {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        border-top-width: 0px
+      }",
+          "(min-width: 97.6em)": ".116rzb2 {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".46sr0r {
+        display: block
+      }
+      
+      .1c43i05:after {
+        content: \\"\\";
+        display: table;
+        clear: both
+      }
+      
+      .1c43i05 {
+        display: block;
+        padding: 0.73333333333rem;
+        border-top: 1px solid #dedede;
+        background-color: #ccc
+      }
+      
+      .kk9pov {
+        display: block;
+        border: none;
+        float: left;
+        clear: left;
+        padding: 0px
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".46sr0r {
+        background: #fff;
+        border-collapse: collapse;
+        border-spacing: 0px;
+        max-width: 100%;
+        width: 100%
+      }
+      
+      .116rzb2 {
+        vertical-align: right
+      }
+      
+      .1c43i05 {
+        display: -webkit-box;
+        display: -moz-box;
+        display: -ms-flexbox;
+        display: -webkit-flex;
+        display: flex;
+        flex-wrap: nowrap;
+        -webkit-box-lines: nowrap;
+        -webkit-flex-wrap: nowrap;
+        justify-content: space-around;
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-around;
+        align-items: center;
+        -webkit-box-align: center;
+        -webkit-align-items: center;
+        border-color: #dedede
+      }
+      
+      .kk9pov {
+        display: inline-block;
+        flex: auto;
+        -webkit-flex: auto;
+        border-top: 1px solid #dedede;
+        line-height: 1.5;
+        padding: 0.73333333333rem;
+        vertical-align: middle;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .116rzb2 { vertical-align: right } .1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .46sr0r { display: block; width: 100%; box-sizing: border-box } .116rzb2 { display: block; width: 100%; box-sizing: border-box } .1c43i05 { display: block; width: 100%; box-sizing: border-box } .kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .116rzb2 { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .46sr0r { display: block } .1c43i05:after { content: ""; display: table; clear: both } .1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent
+        is="div"
+      >
+        <TableStyles
+          is="div"
+        >
+          <TableStyles
+            _felaRule={[Function]}
+            is="div"
+            passThrough={Array []}
+          >
+            <div
+              className="46sr0r"
+              is="div"
+            >
+              <ThemedComponent
+                is="div"
+              >
+                <FelaComponent
+                  is="div"
+                >
+                  <TableFootStyles
+                    _felaRule={[Function]}
+                    is="div"
+                    passThrough={Array []}
+                  >
+                    <TableFootStyles
+                      _felaRule={[Function]}
+                      is="div"
+                      passThrough={Array []}
+                    >
+                      <div
+                        className="116rzb2"
+                        is="div"
+                      >
+                        <ThemedComponent
+                          is="div"
+                        >
+                          <TableRowStyles
+                            is="div"
+                          >
+                            <TableRowStyles
+                              _felaRule={[Function]}
+                              is="div"
+                              passThrough={Array []}
+                            >
+                              <div
+                                className="1c43i05"
+                                is="div"
+                              >
+                                <ThemedComponent
+                                  is="div"
+                                >
+                                  <TableCellStyles
+                                    is="div"
+                                  >
+                                    <TableCellStyles
+                                      _felaRule={[Function]}
+                                      is="div"
+                                      passThrough={Array []}
+                                    >
+                                      <div
+                                        className="kk9pov"
+                                        is="div"
+                                      />
+                                    </TableCellStyles>
+                                  </TableCellStyles>
+                                </ThemedComponent>
+                              </div>
+                            </TableRowStyles>
+                          </TableRowStyles>
+                        </ThemedComponent>
+                      </div>
+                    </TableFootStyles>
+                  </TableFootStyles>
+                </FelaComponent>
+              </ThemedComponent>
+            </div>
+          </TableStyles>
+        </TableStyles>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;
+
+exports[`createTableFoot should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "116rzb2": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".116rzb2 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "(min-width: 97.6em)": ".116rzb2 {
+        width: 1000px
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".116rzb2 {
+        vertical-align: right
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .116rzb2 { vertical-align: right }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .116rzb2 { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .116rzb2 { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .46sr0r { display: block }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <ThemedComponent>
+          <FelaComponent>
+            <TableFootStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableFootStyles
+                _felaRule={[Function]}
+                passThrough={Array []}
+              >
+                <TableFoot
+                  className="116rzb2"
+                  is="tfoot"
+                >
+                  <tfoot
+                    className="116rzb2"
+                  />
+                </TableFoot>
+              </TableFootStyles>
+            </TableFootStyles>
+          </FelaComponent>
+        </ThemedComponent>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;

--- a/packages/cf-component-table/test/__snapshots__/TableFoot.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableFoot.js.snap
@@ -11,8 +11,8 @@ exports[`TableFoot should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "116rzb2": true,
-          "46sr0r": true,
+          "cf-116rzb2": true,
+          "cf-46sr0r": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -28,21 +28,21 @@ exports[`TableFoot should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".46sr0r {
+          "(max-width: 47.2em)": ".cf-46sr0r {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .116rzb2 {
+      .cf-116rzb2 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "(min-width: 97.6em)": ".116rzb2 {
+          "(min-width: 97.6em)": ".cf-116rzb2 {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".46sr0r {
+          "screen and (max-width: 47.2em)": ".cf-46sr0r {
         display: block
       }",
         },
@@ -61,7 +61,7 @@ exports[`TableFoot should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".46sr0r {
+        "rules": ".cf-46sr0r {
         background: #fff;
         border-collapse: collapse;
         border-spacing: 0px;
@@ -69,38 +69,38 @@ exports[`TableFoot should compose with styles overrides 1`] = `
         width: 100%
       }
       
-      .116rzb2 {
+      .cf-116rzb2 {
         vertical-align: right
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .116rzb2 { vertical-align: right }
+            .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-116rzb2 { vertical-align: right }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .46sr0r { display: block; width: 100%; box-sizing: border-box } .116rzb2 { display: block; width: 100%; box-sizing: border-box }
+            .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-116rzb2 { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .116rzb2 { width: 1000px }
+            .cf-116rzb2 { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .46sr0r { display: block }
+            .cf-46sr0r { display: block }
       </style>,
         },
         "subscribe": [Function],
@@ -225,14 +225,14 @@ exports[`TableFoot should compose with styles overrides 1`] = `
           <Table
             bare={false}
             bordered={true}
-            className="46sr0r"
+            className="cf-46sr0r"
             condensed={false}
             hover={false}
             is="table"
             striped={false}
           >
             <table
-              className="46sr0r"
+              className="cf-46sr0r"
             >
               <ThemedComponent
                 bare={false}
@@ -251,14 +251,14 @@ exports[`TableFoot should compose with styles overrides 1`] = `
                   <TableFoot
                     bare={false}
                     bordered={true}
-                    className="116rzb2"
+                    className="cf-116rzb2"
                     condensed={false}
                     hover={false}
                     is="tfoot"
                     striped={false}
                   >
                     <tfoot
-                      className="116rzb2"
+                      className="cf-116rzb2"
                     />
                   </TableFoot>
                 </FelaComponent>
@@ -283,8 +283,8 @@ exports[`TableFoot should render 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1b0jccb": true,
-          "dotb8y": true,
+          "cf-1b0jccb": true,
+          "cf-dotb8y": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -300,24 +300,24 @@ exports[`TableFoot should render 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".dotb8y {
+          "(max-width: 47.2em)": ".cf-dotb8y {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1b0jccb {
+      .cf-1b0jccb {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "screen and (max-width: 47.2em)": ".1b0jccb:after {
+          "screen and (max-width: 47.2em)": ".cf-1b0jccb:after {
         content: \\"\\";
         display: table;
         clear: both
       }
       
-      .1b0jccb {
+      .cf-1b0jccb {
         display: block;
         padding: 0.73333333333rem;
         border-top: none;
@@ -339,31 +339,31 @@ exports[`TableFoot should render 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".1b0jccb {
+        "rules": ".cf-1b0jccb {
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .1b0jccb { border-color: #dedede }
+            .cf-1b0jccb { border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .dotb8y { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box }
+            .cf-dotb8y { display: block; width: 100%; box-sizing: border-box } .cf-1b0jccb { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
+            .cf-1b0jccb:after { content: ""; display: table; clear: both } .cf-1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
       </style>,
         },
         "subscribe": [Function],
@@ -487,11 +487,11 @@ exports[`TableFoot should render 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableFoot
-              className="dotb8y"
+              className="cf-dotb8y"
               is="tfoot"
             >
               <tfoot
-                className="dotb8y"
+                className="cf-dotb8y"
               >
                 <ThemedComponent
                   rowIndex={-0}
@@ -502,14 +502,14 @@ exports[`TableFoot should render 1`] = `
                     tfootIndex={0}
                   >
                     <TableRow
-                      className="1b0jccb"
+                      className="cf-1b0jccb"
                       is="tr"
                       rowIndex={-0}
                       tfootIndex={0}
                       type="default"
                     >
                       <tr
-                        className="1b0jccb"
+                        className="cf-1b0jccb"
                       />
                     </TableRow>
                   </FelaComponent>
@@ -535,10 +535,10 @@ exports[`createTableFoot should be able to render a div 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "116rzb2": true,
-          "1c43i05": true,
-          "46sr0r": true,
-          "kk9pov": true,
+          "cf-116rzb2": true,
+          "cf-1c43i05": true,
+          "cf-46sr0r": true,
+          "cf-kk9pov": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -554,51 +554,51 @@ exports[`createTableFoot should be able to render a div 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".46sr0r {
+          "(max-width: 47.2em)": ".cf-46sr0r {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .116rzb2 {
+      .cf-116rzb2 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: block;
         width: 100%;
         box-sizing: border-box;
         border-top-width: 0px
       }",
-          "(min-width: 97.6em)": ".116rzb2 {
+          "(min-width: 97.6em)": ".cf-116rzb2 {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".46sr0r {
+          "screen and (max-width: 47.2em)": ".cf-46sr0r {
         display: block
       }
       
-      .1c43i05:after {
+      .cf-1c43i05:after {
         content: \\"\\";
         display: table;
         clear: both
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: block;
         padding: 0.73333333333rem;
         border-top: 1px solid #dedede;
         background-color: #ccc
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: block;
         border: none;
         float: left;
@@ -621,7 +621,7 @@ exports[`createTableFoot should be able to render a div 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".46sr0r {
+        "rules": ".cf-46sr0r {
         background: #fff;
         border-collapse: collapse;
         border-spacing: 0px;
@@ -629,11 +629,11 @@ exports[`createTableFoot should be able to render a div 1`] = `
         width: 100%
       }
       
-      .116rzb2 {
+      .cf-116rzb2 {
         vertical-align: right
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: -webkit-box;
         display: -moz-box;
         display: -ms-flexbox;
@@ -651,7 +651,7 @@ exports[`createTableFoot should be able to render a div 1`] = `
         border-color: #dedede
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: inline-block;
         flex: auto;
         -webkit-flex: auto;
@@ -664,35 +664,35 @@ exports[`createTableFoot should be able to render a div 1`] = `
         text-overflow: ellipsis;
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .116rzb2 { vertical-align: right } .1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+            .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-116rzb2 { vertical-align: right } .cf-1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .cf-kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .46sr0r { display: block; width: 100%; box-sizing: border-box } .116rzb2 { display: block; width: 100%; box-sizing: border-box } .1c43i05 { display: block; width: 100%; box-sizing: border-box } .kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+            .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-116rzb2 { display: block; width: 100%; box-sizing: border-box } .cf-1c43i05 { display: block; width: 100%; box-sizing: border-box } .cf-kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .116rzb2 { width: 1000px }
+            .cf-116rzb2 { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .46sr0r { display: block } .1c43i05:after { content: ""; display: table; clear: both } .1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
+            .cf-46sr0r { display: block } .cf-1c43i05:after { content: ""; display: table; clear: both } .cf-1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .cf-kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
       </style>,
         },
         "subscribe": [Function],
@@ -819,7 +819,7 @@ exports[`createTableFoot should be able to render a div 1`] = `
           is="div"
         >
           <div
-            className="46sr0r"
+            className="cf-46sr0r"
             is="div"
           >
             <ThemedComponent
@@ -829,7 +829,7 @@ exports[`createTableFoot should be able to render a div 1`] = `
                 is="div"
               >
                 <div
-                  className="116rzb2"
+                  className="cf-116rzb2"
                   is="div"
                 >
                   <ThemedComponent
@@ -839,7 +839,7 @@ exports[`createTableFoot should be able to render a div 1`] = `
                       is="div"
                     >
                       <div
-                        className="1c43i05"
+                        className="cf-1c43i05"
                         is="div"
                       >
                         <ThemedComponent
@@ -849,7 +849,7 @@ exports[`createTableFoot should be able to render a div 1`] = `
                             is="div"
                           >
                             <div
-                              className="kk9pov"
+                              className="cf-kk9pov"
                               is="div"
                             />
                           </FelaComponent>
@@ -879,7 +879,7 @@ exports[`createTableFoot should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "116rzb2": true,
+          "cf-116rzb2": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -895,12 +895,12 @@ exports[`createTableFoot should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".116rzb2 {
+          "(max-width: 47.2em)": ".cf-116rzb2 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "(min-width: 97.6em)": ".116rzb2 {
+          "(min-width: 97.6em)": ".cf-116rzb2 {
         width: 1000px
       }",
         },
@@ -919,38 +919,38 @@ exports[`createTableFoot should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".116rzb2 {
+        "rules": ".cf-116rzb2 {
         vertical-align: right
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .116rzb2 { vertical-align: right }
+            .cf-116rzb2 { vertical-align: right }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .116rzb2 { display: block; width: 100%; box-sizing: border-box }
+            .cf-116rzb2 { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .116rzb2 { width: 1000px }
+            .cf-116rzb2 { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .46sr0r { display: block }
+            .cf-46sr0r { display: block }
       </style>,
         },
         "subscribe": [Function],
@@ -1074,11 +1074,11 @@ exports[`createTableFoot should compose with styles overrides 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableFoot
-              className="116rzb2"
+              className="cf-116rzb2"
               is="tfoot"
             >
               <tfoot
-                className="116rzb2"
+                className="cf-116rzb2"
               />
             </TableFoot>
           </FelaComponent>

--- a/packages/cf-component-table/test/__snapshots__/TableHead.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHead.js.snap
@@ -11,8 +11,8 @@ exports[`TableHead should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1n3j7e6": true,
-          "46sr0r": true,
+          "cf-1n3j7e6": true,
+          "cf-46sr0r": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -28,25 +28,25 @@ exports[`TableHead should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".46sr0r {
+          "(max-width: 47.2em)": ".cf-46sr0r {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1n3j7e6 {
+      .cf-1n3j7e6 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "(min-width: 97.6em)": ".1n3j7e6 {
+          "(min-width: 97.6em)": ".cf-1n3j7e6 {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".46sr0r {
+          "screen and (max-width: 47.2em)": ".cf-46sr0r {
         display: block
       }
       
-      .1n3j7e6 {
+      .cf-1n3j7e6 {
         display: none
       }",
         },
@@ -65,7 +65,7 @@ exports[`TableHead should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".46sr0r {
+        "rules": ".cf-46sr0r {
         background: #fff;
         border-collapse: collapse;
         border-spacing: 0px;
@@ -73,39 +73,39 @@ exports[`TableHead should compose with styles overrides 1`] = `
         width: 100%
       }
       
-      .1n3j7e6 {
+      .cf-1n3j7e6 {
         background: #dedede;
         vertical-align: right
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .1n3j7e6 { background: #dedede; vertical-align: right }
+            .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-1n3j7e6 { background: #dedede; vertical-align: right }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .46sr0r { display: block; width: 100%; box-sizing: border-box } .1n3j7e6 { display: block; width: 100%; box-sizing: border-box }
+            .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-1n3j7e6 { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .1n3j7e6 { width: 1000px }
+            .cf-1n3j7e6 { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .46sr0r { display: block } .1n3j7e6 { display: none }
+            .cf-46sr0r { display: block } .cf-1n3j7e6 { display: none }
       </style>,
         },
         "subscribe": [Function],
@@ -230,14 +230,14 @@ exports[`TableHead should compose with styles overrides 1`] = `
           <Table
             bare={false}
             bordered={true}
-            className="46sr0r"
+            className="cf-46sr0r"
             condensed={false}
             hover={false}
             is="table"
             striped={false}
           >
             <table
-              className="46sr0r"
+              className="cf-46sr0r"
             >
               <ThemedComponent
                 bare={false}
@@ -256,14 +256,14 @@ exports[`TableHead should compose with styles overrides 1`] = `
                   <TableHead
                     bare={false}
                     bordered={true}
-                    className="1n3j7e6"
+                    className="cf-1n3j7e6"
                     condensed={false}
                     hover={false}
                     is="thead"
                     striped={false}
                   >
                     <thead
-                      className="1n3j7e6"
+                      className="cf-1n3j7e6"
                     />
                   </TableHead>
                 </FelaComponent>
@@ -288,8 +288,8 @@ exports[`TableHead should render 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1b0jccb": true,
-          "d1fi02": true,
+          "cf-1b0jccb": true,
+          "cf-d1fi02": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -305,28 +305,28 @@ exports[`TableHead should render 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".d1fi02 {
+          "(max-width: 47.2em)": ".cf-d1fi02 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1b0jccb {
+      .cf-1b0jccb {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "screen and (max-width: 47.2em)": ".d1fi02 {
+          "screen and (max-width: 47.2em)": ".cf-d1fi02 {
         display: none
       }
       
-      .1b0jccb:after {
+      .cf-1b0jccb:after {
         content: \\"\\";
         display: table;
         clear: both
       }
       
-      .1b0jccb {
+      .cf-1b0jccb {
         display: block;
         padding: 0.73333333333rem;
         border-top: none;
@@ -348,35 +348,35 @@ exports[`TableHead should render 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".d1fi02 {
+        "rules": ".cf-d1fi02 {
         background: #dedede
       }
       
-      .1b0jccb {
+      .cf-1b0jccb {
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede }
+            .cf-d1fi02 { background: #dedede } .cf-1b0jccb { border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box }
+            .cf-d1fi02 { display: block; width: 100%; box-sizing: border-box } .cf-1b0jccb { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
+            .cf-d1fi02 { display: none } .cf-1b0jccb:after { content: ""; display: table; clear: both } .cf-1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
       </style>,
         },
         "subscribe": [Function],
@@ -500,11 +500,11 @@ exports[`TableHead should render 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableHead
-              className="d1fi02"
+              className="cf-d1fi02"
               is="thead"
             >
               <thead
-                className="d1fi02"
+                className="cf-d1fi02"
               >
                 <ThemedComponent
                   rowIndex={-0}
@@ -515,14 +515,14 @@ exports[`TableHead should render 1`] = `
                     theadIndex={0}
                   >
                     <TableRow
-                      className="1b0jccb"
+                      className="cf-1b0jccb"
                       is="tr"
                       rowIndex={-0}
                       theadIndex={0}
                       type="default"
                     >
                       <tr
-                        className="1b0jccb"
+                        className="cf-1b0jccb"
                       />
                     </TableRow>
                   </FelaComponent>
@@ -548,10 +548,10 @@ exports[`createTableHead should be able to render a div 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1c43i05": true,
-          "1n3j7e6": true,
-          "46sr0r": true,
-          "kk9pov": true,
+          "cf-1c43i05": true,
+          "cf-1n3j7e6": true,
+          "cf-46sr0r": true,
+          "cf-kk9pov": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -567,55 +567,55 @@ exports[`createTableHead should be able to render a div 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".46sr0r {
+          "(max-width: 47.2em)": ".cf-46sr0r {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1n3j7e6 {
+      .cf-1n3j7e6 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: block;
         width: 100%;
         box-sizing: border-box;
         border-top-width: 0px
       }",
-          "(min-width: 97.6em)": ".1n3j7e6 {
+          "(min-width: 97.6em)": ".cf-1n3j7e6 {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".46sr0r {
+          "screen and (max-width: 47.2em)": ".cf-46sr0r {
         display: block
       }
       
-      .1n3j7e6 {
+      .cf-1n3j7e6 {
         display: none
       }
       
-      .1c43i05:after {
+      .cf-1c43i05:after {
         content: \\"\\";
         display: table;
         clear: both
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: block;
         padding: 0.73333333333rem;
         border-top: 1px solid #dedede;
         background-color: #ccc
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: block;
         border: none;
         float: left;
@@ -638,7 +638,7 @@ exports[`createTableHead should be able to render a div 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".46sr0r {
+        "rules": ".cf-46sr0r {
         background: #fff;
         border-collapse: collapse;
         border-spacing: 0px;
@@ -646,12 +646,12 @@ exports[`createTableHead should be able to render a div 1`] = `
         width: 100%
       }
       
-      .1n3j7e6 {
+      .cf-1n3j7e6 {
         background: #dedede;
         vertical-align: right
       }
       
-      .1c43i05 {
+      .cf-1c43i05 {
         display: -webkit-box;
         display: -moz-box;
         display: -ms-flexbox;
@@ -669,7 +669,7 @@ exports[`createTableHead should be able to render a div 1`] = `
         border-color: #dedede
       }
       
-      .kk9pov {
+      .cf-kk9pov {
         display: inline-block;
         flex: auto;
         -webkit-flex: auto;
@@ -682,35 +682,35 @@ exports[`createTableHead should be able to render a div 1`] = `
         text-overflow: ellipsis;
         border-color: #dedede
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .1n3j7e6 { background: #dedede; vertical-align: right } .1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+            .cf-46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .cf-1n3j7e6 { background: #dedede; vertical-align: right } .cf-1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .cf-kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .46sr0r { display: block; width: 100%; box-sizing: border-box } .1n3j7e6 { display: block; width: 100%; box-sizing: border-box } .1c43i05 { display: block; width: 100%; box-sizing: border-box } .kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+            .cf-46sr0r { display: block; width: 100%; box-sizing: border-box } .cf-1n3j7e6 { display: block; width: 100%; box-sizing: border-box } .cf-1c43i05 { display: block; width: 100%; box-sizing: border-box } .cf-kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .1n3j7e6 { width: 1000px }
+            .cf-1n3j7e6 { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .46sr0r { display: block } .1n3j7e6 { display: none } .1c43i05:after { content: ""; display: table; clear: both } .1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
+            .cf-46sr0r { display: block } .cf-1n3j7e6 { display: none } .cf-1c43i05:after { content: ""; display: table; clear: both } .cf-1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .cf-kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
       </style>,
         },
         "subscribe": [Function],
@@ -837,7 +837,7 @@ exports[`createTableHead should be able to render a div 1`] = `
           is="div"
         >
           <div
-            className="46sr0r"
+            className="cf-46sr0r"
             is="div"
           >
             <ThemedComponent
@@ -847,7 +847,7 @@ exports[`createTableHead should be able to render a div 1`] = `
                 is="div"
               >
                 <div
-                  className="1n3j7e6"
+                  className="cf-1n3j7e6"
                   is="div"
                 >
                   <ThemedComponent
@@ -857,7 +857,7 @@ exports[`createTableHead should be able to render a div 1`] = `
                       is="div"
                     >
                       <div
-                        className="1c43i05"
+                        className="cf-1c43i05"
                         is="div"
                       >
                         <ThemedComponent
@@ -867,7 +867,7 @@ exports[`createTableHead should be able to render a div 1`] = `
                             is="div"
                           >
                             <div
-                              className="kk9pov"
+                              className="cf-kk9pov"
                               is="div"
                             />
                           </FelaComponent>
@@ -897,7 +897,7 @@ exports[`createTableHead should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1n3j7e6": true,
+          "cf-1n3j7e6": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -913,15 +913,15 @@ exports[`createTableHead should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".1n3j7e6 {
+          "(max-width: 47.2em)": ".cf-1n3j7e6 {
         display: block;
         width: 100%;
         box-sizing: border-box
       }",
-          "(min-width: 97.6em)": ".1n3j7e6 {
+          "(min-width: 97.6em)": ".cf-1n3j7e6 {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".1n3j7e6 {
+          "screen and (max-width: 47.2em)": ".cf-1n3j7e6 {
         display: none
       }",
         },
@@ -940,39 +940,39 @@ exports[`createTableHead should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".1n3j7e6 {
+        "rules": ".cf-1n3j7e6 {
         background: #dedede;
         vertical-align: right
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .1n3j7e6 { background: #dedede; vertical-align: right }
+            .cf-1n3j7e6 { background: #dedede; vertical-align: right }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .1n3j7e6 { display: block; width: 100%; box-sizing: border-box }
+            .cf-1n3j7e6 { display: block; width: 100%; box-sizing: border-box }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .1n3j7e6 { width: 1000px }
+            .cf-1n3j7e6 { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .1n3j7e6 { display: none }
+            .cf-1n3j7e6 { display: none }
       </style>,
         },
         "subscribe": [Function],
@@ -1096,11 +1096,11 @@ exports[`createTableHead should compose with styles overrides 1`] = `
         <ThemedComponent>
           <FelaComponent>
             <TableHead
-              className="1n3j7e6"
+              className="cf-1n3j7e6"
               is="thead"
             >
               <thead
-                className="1n3j7e6"
+                className="cf-1n3j7e6"
               />
             </TableHead>
           </FelaComponent>

--- a/packages/cf-component-table/test/__snapshots__/TableHead.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHead.js.snap
@@ -226,76 +226,51 @@ exports[`TableHead should compose with styles overrides 1`] = `
       }
     >
       <ThemedComponent>
-        <TableStyles>
-          <TableStyles
-            _felaRule={[Function]}
-            passThrough={Array []}
+        <FelaComponent>
+          <Table
+            bare={false}
+            bordered={true}
+            className="46sr0r"
+            condensed={false}
+            hover={false}
+            is="table"
+            striped={false}
           >
-            <Table
-              bare={false}
-              bordered={true}
+            <table
               className="46sr0r"
-              condensed={false}
-              hover={false}
-              is="table"
-              striped={false}
             >
-              <table
-                className="46sr0r"
+              <ThemedComponent
+                bare={false}
+                bordered={true}
+                condensed={false}
+                hover={false}
+                striped={false}
               >
-                <ThemedComponent
+                <FelaComponent
                   bare={false}
                   bordered={true}
                   condensed={false}
                   hover={false}
                   striped={false}
                 >
-                  <FelaComponent
+                  <TableHead
                     bare={false}
                     bordered={true}
+                    className="1n3j7e6"
                     condensed={false}
                     hover={false}
+                    is="thead"
                     striped={false}
                   >
-                    <TableHeadStyles
-                      _felaRule={[Function]}
-                      bare={false}
-                      bordered={true}
-                      condensed={false}
-                      hover={false}
-                      passThrough={Array []}
-                      striped={false}
-                    >
-                      <TableHeadStyles
-                        _felaRule={[Function]}
-                        bare={false}
-                        bordered={true}
-                        condensed={false}
-                        hover={false}
-                        passThrough={Array []}
-                        striped={false}
-                      >
-                        <TableHead
-                          bare={false}
-                          bordered={true}
-                          className="1n3j7e6"
-                          condensed={false}
-                          hover={false}
-                          is="thead"
-                          striped={false}
-                        >
-                          <thead
-                            className="1n3j7e6"
-                          />
-                        </TableHead>
-                      </TableHeadStyles>
-                    </TableHeadStyles>
-                  </FelaComponent>
-                </ThemedComponent>
-              </table>
-            </Table>
-          </TableStyles>
-        </TableStyles>
+                    <thead
+                      className="1n3j7e6"
+                    />
+                  </TableHead>
+                </FelaComponent>
+              </ThemedComponent>
+            </table>
+          </Table>
+        </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
   </Provider>
@@ -523,50 +498,38 @@ exports[`TableHead should render 1`] = `
     >
       <table>
         <ThemedComponent>
-          <TableHeadStyles>
-            <TableHeadStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+          <FelaComponent>
+            <TableHead
+              className="d1fi02"
+              is="thead"
             >
-              <TableHead
+              <thead
                 className="d1fi02"
-                is="thead"
               >
-                <thead
-                  className="d1fi02"
+                <ThemedComponent
+                  rowIndex={-0}
+                  theadIndex={0}
                 >
-                  <ThemedComponent
+                  <FelaComponent
                     rowIndex={-0}
                     theadIndex={0}
                   >
-                    <TableRowStyles
+                    <TableRow
+                      className="1b0jccb"
+                      is="tr"
                       rowIndex={-0}
                       theadIndex={0}
+                      type="default"
                     >
-                      <TableRowStyles
-                        _felaRule={[Function]}
-                        passThrough={Array []}
-                        rowIndex={-0}
-                        theadIndex={0}
-                      >
-                        <TableRow
-                          className="1b0jccb"
-                          is="tr"
-                          rowIndex={-0}
-                          theadIndex={0}
-                          type="default"
-                        >
-                          <tr
-                            className="1b0jccb"
-                          />
-                        </TableRow>
-                      </TableRowStyles>
-                    </TableRowStyles>
-                  </ThemedComponent>
-                </thead>
-              </TableHead>
-            </TableHeadStyles>
-          </TableHeadStyles>
+                      <tr
+                        className="1b0jccb"
+                      />
+                    </TableRow>
+                  </FelaComponent>
+                </ThemedComponent>
+              </thead>
+            </TableHead>
+          </FelaComponent>
         </ThemedComponent>
       </table>
     </ThemeProvider>
@@ -870,83 +833,53 @@ exports[`createTableHead should be able to render a div 1`] = `
       <ThemedComponent
         is="div"
       >
-        <TableStyles
+        <FelaComponent
           is="div"
         >
-          <TableStyles
-            _felaRule={[Function]}
+          <div
+            className="46sr0r"
             is="div"
-            passThrough={Array []}
           >
-            <div
-              className="46sr0r"
+            <ThemedComponent
               is="div"
             >
-              <ThemedComponent
+              <FelaComponent
                 is="div"
               >
-                <FelaComponent
+                <div
+                  className="1n3j7e6"
                   is="div"
                 >
-                  <TableHeadStyles
-                    _felaRule={[Function]}
+                  <ThemedComponent
                     is="div"
-                    passThrough={Array []}
                   >
-                    <TableHeadStyles
-                      _felaRule={[Function]}
+                    <FelaComponent
                       is="div"
-                      passThrough={Array []}
                     >
                       <div
-                        className="1n3j7e6"
+                        className="1c43i05"
                         is="div"
                       >
                         <ThemedComponent
                           is="div"
                         >
-                          <TableRowStyles
+                          <FelaComponent
                             is="div"
                           >
-                            <TableRowStyles
-                              _felaRule={[Function]}
+                            <div
+                              className="kk9pov"
                               is="div"
-                              passThrough={Array []}
-                            >
-                              <div
-                                className="1c43i05"
-                                is="div"
-                              >
-                                <ThemedComponent
-                                  is="div"
-                                >
-                                  <TableCellStyles
-                                    is="div"
-                                  >
-                                    <TableCellStyles
-                                      _felaRule={[Function]}
-                                      is="div"
-                                      passThrough={Array []}
-                                    >
-                                      <div
-                                        className="kk9pov"
-                                        is="div"
-                                      />
-                                    </TableCellStyles>
-                                  </TableCellStyles>
-                                </ThemedComponent>
-                              </div>
-                            </TableRowStyles>
-                          </TableRowStyles>
+                            />
+                          </FelaComponent>
                         </ThemedComponent>
                       </div>
-                    </TableHeadStyles>
-                  </TableHeadStyles>
-                </FelaComponent>
-              </ThemedComponent>
-            </div>
-          </TableStyles>
-        </TableStyles>
+                    </FelaComponent>
+                  </ThemedComponent>
+                </div>
+              </FelaComponent>
+            </ThemedComponent>
+          </div>
+        </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
   </Provider>
@@ -1162,24 +1095,14 @@ exports[`createTableHead should compose with styles overrides 1`] = `
       <table>
         <ThemedComponent>
           <FelaComponent>
-            <TableHeadStyles
-              _felaRule={[Function]}
-              passThrough={Array []}
+            <TableHead
+              className="1n3j7e6"
+              is="thead"
             >
-              <TableHeadStyles
-                _felaRule={[Function]}
-                passThrough={Array []}
-              >
-                <TableHead
-                  className="1n3j7e6"
-                  is="thead"
-                >
-                  <thead
-                    className="1n3j7e6"
-                  />
-                </TableHead>
-              </TableHeadStyles>
-            </TableHeadStyles>
+              <thead
+                className="1n3j7e6"
+              />
+            </TableHead>
           </FelaComponent>
         </ThemedComponent>
       </table>

--- a/packages/cf-component-table/test/__snapshots__/TableHead.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHead.js.snap
@@ -573,3 +573,617 @@ exports[`TableHead should render 1`] = `
   </Provider>
 </StyleProvider>
 `;
+
+exports[`createTableHead should be able to render a div 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1c43i05": true,
+          "1n3j7e6": true,
+          "46sr0r": true,
+          "kk9pov": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".46sr0r {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1n3j7e6 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1c43i05 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .kk9pov {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        border-top-width: 0px
+      }",
+          "(min-width: 97.6em)": ".1n3j7e6 {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".46sr0r {
+        display: block
+      }
+      
+      .1n3j7e6 {
+        display: none
+      }
+      
+      .1c43i05:after {
+        content: \\"\\";
+        display: table;
+        clear: both
+      }
+      
+      .1c43i05 {
+        display: block;
+        padding: 0.73333333333rem;
+        border-top: 1px solid #dedede;
+        background-color: #ccc
+      }
+      
+      .kk9pov {
+        display: block;
+        border: none;
+        float: left;
+        clear: left;
+        padding: 0px
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".46sr0r {
+        background: #fff;
+        border-collapse: collapse;
+        border-spacing: 0px;
+        max-width: 100%;
+        width: 100%
+      }
+      
+      .1n3j7e6 {
+        background: #dedede;
+        vertical-align: right
+      }
+      
+      .1c43i05 {
+        display: -webkit-box;
+        display: -moz-box;
+        display: -ms-flexbox;
+        display: -webkit-flex;
+        display: flex;
+        flex-wrap: nowrap;
+        -webkit-box-lines: nowrap;
+        -webkit-flex-wrap: nowrap;
+        justify-content: space-around;
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-around;
+        align-items: center;
+        -webkit-box-align: center;
+        -webkit-align-items: center;
+        border-color: #dedede
+      }
+      
+      .kk9pov {
+        display: inline-block;
+        flex: auto;
+        -webkit-flex: auto;
+        border-top: 1px solid #dedede;
+        line-height: 1.5;
+        padding: 0.73333333333rem;
+        vertical-align: middle;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .1n3j7e6 { background: #dedede; vertical-align: right } .1c43i05 { display: -webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex; flex-wrap: nowrap; -webkit-box-lines: nowrap; -webkit-flex-wrap: nowrap; justify-content: space-around; -webkit-box-pack: justify; -webkit-justify-content: space-around; align-items: center; -webkit-box-align: center; -webkit-align-items: center; border-color: #dedede } .kk9pov { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: middle; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .46sr0r { display: block; width: 100%; box-sizing: border-box } .1n3j7e6 { display: block; width: 100%; box-sizing: border-box } .1c43i05 { display: block; width: 100%; box-sizing: border-box } .kk9pov { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .1n3j7e6 { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .46sr0r { display: block } .1n3j7e6 { display: none } .1c43i05:after { content: ""; display: table; clear: both } .1c43i05 { display: block; padding: 0.73333333333rem; border-top: 1px solid #dedede; background-color: #ccc } .kk9pov { display: block; border: none; float: left; clear: left; padding: 0px }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent
+        is="div"
+      >
+        <TableStyles
+          is="div"
+        >
+          <TableStyles
+            _felaRule={[Function]}
+            is="div"
+            passThrough={Array []}
+          >
+            <div
+              className="46sr0r"
+              is="div"
+            >
+              <ThemedComponent
+                is="div"
+              >
+                <FelaComponent
+                  is="div"
+                >
+                  <TableHeadStyles
+                    _felaRule={[Function]}
+                    is="div"
+                    passThrough={Array []}
+                  >
+                    <TableHeadStyles
+                      _felaRule={[Function]}
+                      is="div"
+                      passThrough={Array []}
+                    >
+                      <div
+                        className="1n3j7e6"
+                        is="div"
+                      >
+                        <ThemedComponent
+                          is="div"
+                        >
+                          <TableRowStyles
+                            is="div"
+                          >
+                            <TableRowStyles
+                              _felaRule={[Function]}
+                              is="div"
+                              passThrough={Array []}
+                            >
+                              <div
+                                className="1c43i05"
+                                is="div"
+                              >
+                                <ThemedComponent
+                                  is="div"
+                                >
+                                  <TableCellStyles
+                                    is="div"
+                                  >
+                                    <TableCellStyles
+                                      _felaRule={[Function]}
+                                      is="div"
+                                      passThrough={Array []}
+                                    >
+                                      <div
+                                        className="kk9pov"
+                                        is="div"
+                                      />
+                                    </TableCellStyles>
+                                  </TableCellStyles>
+                                </ThemedComponent>
+                              </div>
+                            </TableRowStyles>
+                          </TableRowStyles>
+                        </ThemedComponent>
+                      </div>
+                    </TableHeadStyles>
+                  </TableHeadStyles>
+                </FelaComponent>
+              </ThemedComponent>
+            </div>
+          </TableStyles>
+        </TableStyles>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;
+
+exports[`createTableHead should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1n3j7e6": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".1n3j7e6 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "(min-width: 97.6em)": ".1n3j7e6 {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".1n3j7e6 {
+        display: none
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".1n3j7e6 {
+        background: #dedede;
+        vertical-align: right
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .1n3j7e6 { background: #dedede; vertical-align: right }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .1n3j7e6 { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .1n3j7e6 { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .1n3j7e6 { display: none }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <ThemedComponent>
+          <FelaComponent>
+            <TableHeadStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableHeadStyles
+                _felaRule={[Function]}
+                passThrough={Array []}
+              >
+                <TableHead
+                  className="1n3j7e6"
+                  is="thead"
+                >
+                  <thead
+                    className="1n3j7e6"
+                  />
+                </TableHead>
+              </TableHeadStyles>
+            </TableHeadStyles>
+          </FelaComponent>
+        </ThemedComponent>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;

--- a/packages/cf-component-table/test/__snapshots__/TableHead.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHead.js.snap
@@ -1,17 +1,575 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
-<thead
-  className="cf-table__head"
+exports[`TableHead should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
 >
-  TableHead
-</thead>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1n3j7e6": true,
+          "46sr0r": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".46sr0r {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1n3j7e6 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "(min-width: 97.6em)": ".1n3j7e6 {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".46sr0r {
+        display: block
+      }
+      
+      .1n3j7e6 {
+        display: none
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".46sr0r {
+        background: #fff;
+        border-collapse: collapse;
+        border-spacing: 0px;
+        max-width: 100%;
+        width: 100%
+      }
+      
+      .1n3j7e6 {
+        background: #dedede;
+        vertical-align: right
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .46sr0r { background: #fff; border-collapse: collapse; border-spacing: 0px; max-width: 100%; width: 100% } .1n3j7e6 { background: #dedede; vertical-align: right }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .46sr0r { display: block; width: 100%; box-sizing: border-box } .1n3j7e6 { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .1n3j7e6 { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .46sr0r { display: block } .1n3j7e6 { display: none }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent>
+        <TableStyles>
+          <TableStyles
+            _felaRule={[Function]}
+            passThrough={Array []}
+          >
+            <Table
+              bare={false}
+              bordered={true}
+              className="46sr0r"
+              condensed={false}
+              hover={false}
+              is="table"
+              striped={false}
+            >
+              <table
+                className="46sr0r"
+              >
+                <ThemedComponent
+                  bare={false}
+                  bordered={true}
+                  condensed={false}
+                  hover={false}
+                  striped={false}
+                >
+                  <FelaComponent
+                    bare={false}
+                    bordered={true}
+                    condensed={false}
+                    hover={false}
+                    striped={false}
+                  >
+                    <TableHeadStyles
+                      _felaRule={[Function]}
+                      bare={false}
+                      bordered={true}
+                      condensed={false}
+                      hover={false}
+                      passThrough={Array []}
+                      striped={false}
+                    >
+                      <TableHeadStyles
+                        _felaRule={[Function]}
+                        bare={false}
+                        bordered={true}
+                        condensed={false}
+                        hover={false}
+                        passThrough={Array []}
+                        striped={false}
+                      >
+                        <TableHead
+                          bare={false}
+                          bordered={true}
+                          className="1n3j7e6"
+                          condensed={false}
+                          hover={false}
+                          is="thead"
+                          striped={false}
+                        >
+                          <thead
+                            className="1n3j7e6"
+                          />
+                        </TableHead>
+                      </TableHeadStyles>
+                    </TableHeadStyles>
+                  </FelaComponent>
+                </ThemedComponent>
+              </table>
+            </Table>
+          </TableStyles>
+        </TableStyles>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
 `;
 
-exports[`should render extra class name 1`] = `
-<thead
-  className="cf-table__head extra"
+exports[`TableHead should render 1`] = `
+<StyleProvider
+  dev={true}
 >
-  TableHead
-</thead>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1b0jccb": true,
+          "d1fi02": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".d1fi02 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }
+      
+      .1b0jccb {
+        display: block;
+        width: 100%;
+        box-sizing: border-box
+      }",
+          "screen and (max-width: 47.2em)": ".d1fi02 {
+        display: none
+      }
+      
+      .1b0jccb:after {
+        content: \\"\\";
+        display: table;
+        clear: both
+      }
+      
+      .1b0jccb {
+        display: block;
+        padding: 0.73333333333rem;
+        border-top: none;
+        background-color: #ccc
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".d1fi02 {
+        background: #dedede
+      }
+      
+      .1b0jccb {
+        border-color: #dedede
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .d1fi02 { background: #dedede } .1b0jccb { border-color: #dedede }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .d1fi02 { display: block; width: 100%; box-sizing: border-box } .1b0jccb { display: block; width: 100%; box-sizing: border-box }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .d1fi02 { display: none } .1b0jccb:after { content: ""; display: table; clear: both } .1b0jccb { display: block; padding: 0.73333333333rem; border-top: none; background-color: #ccc }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <ThemedComponent>
+          <TableHeadStyles>
+            <TableHeadStyles
+              _felaRule={[Function]}
+              passThrough={Array []}
+            >
+              <TableHead
+                className="d1fi02"
+                is="thead"
+              >
+                <thead
+                  className="d1fi02"
+                >
+                  <ThemedComponent
+                    rowIndex={-0}
+                    theadIndex={0}
+                  >
+                    <TableRowStyles
+                      rowIndex={-0}
+                      theadIndex={0}
+                    >
+                      <TableRowStyles
+                        _felaRule={[Function]}
+                        passThrough={Array []}
+                        rowIndex={-0}
+                        theadIndex={0}
+                      >
+                        <TableRow
+                          className="1b0jccb"
+                          is="tr"
+                          rowIndex={-0}
+                          theadIndex={0}
+                          type="default"
+                        >
+                          <tr
+                            className="1b0jccb"
+                          />
+                        </TableRow>
+                      </TableRowStyles>
+                    </TableRowStyles>
+                  </ThemedComponent>
+                </thead>
+              </TableHead>
+            </TableHeadStyles>
+          </TableHeadStyles>
+        </ThemedComponent>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
@@ -1,17 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
-<th
-  className="cf-table__cell cf-table__cell--head"
+exports[`TableHeadCell should compose with styles overrides 1`] = `
+Object {
+  "component": <th
+    className="6zfuo5"
 >
-  TableHeadCell
-</th>
+    TableHeadCell
+</th>,
+  "styles": ".6zfuo5:first-letter {
+  text-transform: capitalize
+}
+
+.6zfuo5 {
+  border-top: 1px solid #dedede;
+  line-height: 1.5;
+  padding: 0.73333333333rem;
+  vertical-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-color: #dedede;
+  text-align: left;
+  font-weight: 600
+}@media (max-width: 47.2em){.6zfuo5 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-width: 0px
+}}@media screen and (max-width: 47.2em){.6zfuo5 {
+  display: block;
+  border: none;
+  float: left;
+  clear: left;
+  padding: 0px
+}}@media (min-width: 97.6em){.6zfuo5 {
+  width: 1000px
+}}",
+}
 `;
 
-exports[`should render extra class name 1`] = `
-<th
-  className="cf-table__cell cf-table__cell--head extra"
+exports[`TableHeadCell should render 1`] = `
+Object {
+  "component": <th
+    className="1u7kqkt"
 >
-  TableHeadCell
-</th>
+    TableHeadCell
+</th>,
+  "styles": ".1u7kqkt:first-letter {
+  text-transform: capitalize
+}
+
+.1u7kqkt {
+  border-top: 1px solid #dedede;
+  line-height: 1.5;
+  padding: 0.73333333333rem;
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-color: #dedede;
+  text-align: left;
+  font-weight: 600
+}@media (max-width: 47.2em){.1u7kqkt {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-width: 0px
+}}@media screen and (max-width: 47.2em){.1u7kqkt {
+  display: block;
+  border: none;
+  float: left;
+  clear: left;
+  padding: 0px
+}}",
+}
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
@@ -1,44 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableHeadCell should compose with styles overrides 1`] = `
-Object {
-  "component": <th
-    className="6zfuo5"
->
-    TableHeadCell
-</th>,
-  "styles": ".6zfuo5:first-letter {
-  text-transform: capitalize
-}
-
-.6zfuo5 {
-  border-top: 1px solid #dedede;
-  line-height: 1.5;
-  padding: 0.73333333333rem;
-  vertical-align: right;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  border-color: #dedede;
-  text-align: left;
-  font-weight: 600
-}@media (max-width: 47.2em){.6zfuo5 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-width: 0px
-}}@media screen and (max-width: 47.2em){.6zfuo5 {
-  display: block;
-  border: none;
-  float: left;
-  clear: left;
-  padding: 0px
-}}@media (min-width: 97.6em){.6zfuo5 {
-  width: 1000px
-}}",
-}
-`;
-
 exports[`TableHeadCell should render 1`] = `
 Object {
   "component": <th
@@ -74,4 +35,526 @@ Object {
   padding: 0px
 }}",
 }
+`;
+
+exports[`createTableHeadCell should be able to render a div 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "1f998t1": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".1f998t1 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        border-top-width: 0px
+      }",
+          "(min-width: 97.6em)": ".1f998t1 {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".1f998t1 {
+        display: block;
+        border: none;
+        float: left;
+        clear: left;
+        padding: 0px
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".1f998t1:first-letter {
+        text-transform: capitalize
+      }
+      
+      .1f998t1 {
+        display: inline-block;
+        flex: auto;
+        -webkit-flex: auto;
+        border-top: 1px solid #dedede;
+        line-height: 1.5;
+        padding: 0.73333333333rem;
+        vertical-align: right;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-color: #dedede;
+        text-align: left;
+        font-weight: 600
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .1f998t1:first-letter { text-transform: capitalize } .1f998t1 { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede; text-align: left; font-weight: 600 }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .1f998t1 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .1f998t1 { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .1f998t1 { display: block; border: none; float: left; clear: left; padding: 0px }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <ThemedComponent
+        is="div"
+      >
+        <FelaComponent
+          is="div"
+        >
+          <TableHeadCellStyles
+            _felaRule={[Function]}
+            is="div"
+            passThrough={Array []}
+          >
+            <TableCellStyles
+              _felaRule={[Function]}
+              is="div"
+              passThrough={Array []}
+            >
+              <TableCellStyles
+                _felaRule={[Function]}
+                is="div"
+                passThrough={Array []}
+              >
+                <div
+                  className="1f998t1"
+                  is="div"
+                />
+              </TableCellStyles>
+            </TableCellStyles>
+          </TableHeadCellStyles>
+        </FelaComponent>
+      </ThemedComponent>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
+`;
+
+exports[`createTableHeadCell should compose with styles overrides 1`] = `
+<StyleProvider
+  dev={true}
+>
+  <Provider
+    renderer={
+      Object {
+        "_emitChange": [Function],
+        "_renderStyleToCache": [Function],
+        "_renderStyleToClassNames": [Function],
+        "cache": Object {
+          "6zfuo5": true,
+        },
+        "clear": [Function],
+        "fontFaces": "",
+        "keyframePrefixes": Array [
+          "-webkit-",
+          "-moz-",
+          "",
+        ],
+        "keyframes": "",
+        "listeners": Array [
+          [Function],
+          [Function],
+        ],
+        "mediaQueryOrder": Array [],
+        "mediaRules": Object {
+          "(max-width: 47.2em)": ".6zfuo5 {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        border-top-width: 0px
+      }",
+          "(min-width: 97.6em)": ".6zfuo5 {
+        width: 1000px
+      }",
+          "screen and (max-width: 47.2em)": ".6zfuo5 {
+        display: block;
+        border: none;
+        float: left;
+        clear: left;
+        padding: 0px
+      }",
+        },
+        "plugins": Array [
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "prettySelectors": false,
+        "renderFont": [Function],
+        "renderKeyframe": [Function],
+        "renderRule": [Function],
+        "renderStatic": [Function],
+        "renderToString": [Function],
+        "rules": ".6zfuo5:first-letter {
+        text-transform: capitalize
+      }
+      
+      .6zfuo5 {
+        border-top: 1px solid #dedede;
+        line-height: 1.5;
+        padding: 0.73333333333rem;
+        vertical-align: right;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border-color: #dedede;
+        text-align: left;
+        font-weight: 600
+      }",
+        "selectorPrefix": "",
+        "statics": "",
+        "styleNodes": Object {
+          "RULE": <style
+            data-fela-type="RULE"
+            type="text/css"
+      >
+            .6zfuo5:first-letter { text-transform: capitalize } .6zfuo5 { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede; text-align: left; font-weight: 600 }
+      </style>,
+          "RULE(max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(max-width: 47.2em)"
+      >
+            .6zfuo5 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+      </style>,
+          "RULE(min-width: 97.6em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="(min-width: 97.6em)"
+      >
+            .6zfuo5 { width: 1000px }
+      </style>,
+          "RULEscreen and (max-width: 47.2em)": <style
+            data-fela-type="RULE"
+            type="text/css"
+            media="screen and (max-width: 47.2em)"
+      >
+            .6zfuo5 { display: block; border: none; float: left; clear: left; padding: 0px }
+      </style>,
+        },
+        "subscribe": [Function],
+        "uniqueKeyframeIdentifier": 0,
+        "uniqueRuleIdentifier": 0,
+      }
+    }
+  >
+    <ThemeProvider
+      overwrite={false}
+      theme={
+        Object {
+          "arrowSize": "5px",
+          "bodyAccentColor": "#333",
+          "bodyBackground": "#ebebeb",
+          "bodyOffsetColor": "#787878",
+          "borderRadius": "2px",
+          "boxShadow": "0 0 20px 0 rgba(136,136,136,0.50)",
+          "breakpoints": Object {
+            "desktop": "64em",
+            "desktopLarge": "97.6em",
+            "mobile": "13.6em",
+            "mobileWide": "30.4em",
+            "tablet": "47.2em",
+          },
+          "color": Object {
+            "apple": "#BD2527",
+            "carrot": "#f56500",
+            "cement": "#7D7D7D",
+            "charcoal": "#333333",
+            "dawn": "#F16975",
+            "dew": "#85CBA8",
+            "dusk": "#4D4D4F",
+            "grass": "#9BCA3E",
+            "hail": "#BCBEC0",
+            "lightning": "#FFDB6F",
+            "marine": "#2F7BBF",
+            "moonshine": "#F7F7F7",
+            "night": "#404041",
+            "rain": "#408BC9",
+            "sky": "#76C4E2",
+            "smoke": "#e0e0e0",
+            "storm": "#808285",
+            "sunrise": "#F69259",
+            "sunset": "#BA77B1",
+            "tangerine": "#FF7900",
+            "twilight": "#8176B5",
+          },
+          "colorBlack": "#000",
+          "colorBlue": "#2f7bbf",
+          "colorBlueDark": "#2869a2",
+          "colorBlueLight": "#62a1d8",
+          "colorError": "#ff3100",
+          "colorFacebookBlue": "#3b5998",
+          "colorGray": "#7c7c7c",
+          "colorGrayBorder": "#666",
+          "colorGrayDark": "#333",
+          "colorGrayLight": "#dedede",
+          "colorGrayLightOnboarding": "#F7F7F7",
+          "colorGreen": "#9bca3e",
+          "colorGreenDark": "#87b331",
+          "colorGreenLight": "#bada7a",
+          "colorImportantInformation": "rgba(64,139,201,0.2)",
+          "colorInfo": "#00a9eb",
+          "colorMainBackground": "#e6e6e6",
+          "colorMuted": "#7c7c7c",
+          "colorOffsetDark": 0.07,
+          "colorOffsetLight": 0.15,
+          "colorOrange": "#ff7900",
+          "colorOrangeDark": "#db6800",
+          "colorOrangeLight": "#ffa14d",
+          "colorOverlay": "rgba(0, 0, 0, .7)",
+          "colorPink": "#d91698",
+          "colorPinkDark": "#b91381",
+          "colorPinkLight": "#ed4eb8",
+          "colorPurple": "#9545e5",
+          "colorPurpleDark": "#b91381",
+          "colorPurpleLight": "#ed4eb8",
+          "colorRed": "#bd2527",
+          "colorRedDark": "#9f1f21",
+          "colorRedLight": "#dd5153",
+          "colorSmoke": "#f2f2f2",
+          "colorSuccess": "#68970f",
+          "colorTwitterBlue": "#00aced",
+          "colorWarning": "#fca520",
+          "colorWhite": "#fff",
+          "colorYellow": "#ffd24d",
+          "colorYellowDark": "#ffc929",
+          "colorYellowLight": "#ffe59a",
+          "disabledBackground": "#ededed",
+          "em": "1em",
+          "fontColor": "#333",
+          "fontColorHeadingCaption": "#888",
+          "fontFamily": "\\"Open Sans\\", Helvetica, Arial, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 400,
+          "fontWeightLight": 300,
+          "gradient": Object {
+            "eight": "linear-gradient(left, #85CBA8, #FFDB6F)",
+            "five": "linear-gradient(left, #8176B5, #F16975)",
+            "four": "linear-gradient(left, #8176B5, #BA77B1)",
+            "primary": "linear-gradient(left, #76C4E2, #85CBA8)",
+            "seven": "linear-gradient(left, #F69259, #FFDB6F)",
+            "six": "linear-gradient(left, #F16975, #F69259)",
+            "three": "linear-gradient(left, #8176B5, #76C4E2)",
+            "two": "linear-gradient(left, #8176B5, #85CBA8)",
+          },
+          "inputFontSize": "13px",
+          "inputLineHeight": 1.4,
+          "lineHeight": 1.5,
+          "rem": "1rem",
+          "weightBold": 700,
+          "weightLight": 300,
+          "weightNormal": 400,
+          "weightSemiBold": 600,
+          "zIndexMax": 1000,
+        }
+      }
+    >
+      <table>
+        <thead>
+          <tr>
+            <ThemedComponent>
+              <FelaComponent>
+                <TableHeadCellStyles
+                  _felaRule={[Function]}
+                  passThrough={Array []}
+                >
+                  <TableCellStyles
+                    _felaRule={[Function]}
+                    passThrough={Array []}
+                  >
+                    <TableCellStyles
+                      _felaRule={[Function]}
+                      passThrough={Array []}
+                    >
+                      <TableHeadCell
+                        className="6zfuo5"
+                        is="th"
+                      >
+                        <th
+                          className="6zfuo5"
+                        />
+                      </TableHeadCell>
+                    </TableCellStyles>
+                  </TableCellStyles>
+                </TableHeadCellStyles>
+              </FelaComponent>
+            </ThemedComponent>
+          </tr>
+        </thead>
+      </table>
+    </ThemeProvider>
+  </Provider>
+</StyleProvider>
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
@@ -3,14 +3,14 @@
 exports[`TableHeadCell should render 1`] = `
 Object {
   "component": <th
-    className="1u7kqkt"
+    className="cf-1u7kqkt"
 >
     TableHeadCell
 </th>,
-  "styles": ".1u7kqkt:first-letter {
+  "styles": ".cf-1u7kqkt:first-letter {
   text-transform: capitalize
 }
-.1u7kqkt {
+.cf-1u7kqkt {
   border-top: 1px solid #dedede;
   line-height: 1.5;
   padding: 0.73333333333rem;
@@ -23,7 +23,7 @@ Object {
   font-weight: 600
 }
 @media (max-width: 47.2em) {
-  .1u7kqkt {
+  .cf-1u7kqkt {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -31,7 +31,7 @@ Object {
   }
 }
 @media screen and (max-width: 47.2em) {
-  .1u7kqkt {
+  .cf-1u7kqkt {
     display: block;
     border: none;
     float: left;
@@ -53,7 +53,7 @@ exports[`createTableHeadCell should be able to render a div 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "1f998t1": true,
+          "cf-1f998t1": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -69,16 +69,16 @@ exports[`createTableHeadCell should be able to render a div 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".1f998t1 {
+          "(max-width: 47.2em)": ".cf-1f998t1 {
         display: block;
         width: 100%;
         box-sizing: border-box;
         border-top-width: 0px
       }",
-          "(min-width: 97.6em)": ".1f998t1 {
+          "(min-width: 97.6em)": ".cf-1f998t1 {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".1f998t1 {
+          "screen and (max-width: 47.2em)": ".cf-1f998t1 {
         display: block;
         border: none;
         float: left;
@@ -101,11 +101,11 @@ exports[`createTableHeadCell should be able to render a div 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".1f998t1:first-letter {
+        "rules": ".cf-1f998t1:first-letter {
         text-transform: capitalize
       }
       
-      .1f998t1 {
+      .cf-1f998t1 {
         display: inline-block;
         flex: auto;
         -webkit-flex: auto;
@@ -120,35 +120,35 @@ exports[`createTableHeadCell should be able to render a div 1`] = `
         text-align: left;
         font-weight: 600
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .1f998t1:first-letter { text-transform: capitalize } .1f998t1 { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede; text-align: left; font-weight: 600 }
+            .cf-1f998t1:first-letter { text-transform: capitalize } .cf-1f998t1 { display: inline-block; flex: auto; -webkit-flex: auto; border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede; text-align: left; font-weight: 600 }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .1f998t1 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+            .cf-1f998t1 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .1f998t1 { width: 1000px }
+            .cf-1f998t1 { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .1f998t1 { display: block; border: none; float: left; clear: left; padding: 0px }
+            .cf-1f998t1 { display: block; border: none; float: left; clear: left; padding: 0px }
       </style>,
         },
         "subscribe": [Function],
@@ -275,7 +275,7 @@ exports[`createTableHeadCell should be able to render a div 1`] = `
           is="div"
         >
           <div
-            className="1f998t1"
+            className="cf-1f998t1"
             is="div"
           />
         </FelaComponent>
@@ -296,7 +296,7 @@ exports[`createTableHeadCell should compose with styles overrides 1`] = `
         "_renderStyleToCache": [Function],
         "_renderStyleToClassNames": [Function],
         "cache": Object {
-          "6zfuo5": true,
+          "cf-6zfuo5": true,
         },
         "clear": [Function],
         "fontFaces": "",
@@ -312,16 +312,16 @@ exports[`createTableHeadCell should compose with styles overrides 1`] = `
         ],
         "mediaQueryOrder": Array [],
         "mediaRules": Object {
-          "(max-width: 47.2em)": ".6zfuo5 {
+          "(max-width: 47.2em)": ".cf-6zfuo5 {
         display: block;
         width: 100%;
         box-sizing: border-box;
         border-top-width: 0px
       }",
-          "(min-width: 97.6em)": ".6zfuo5 {
+          "(min-width: 97.6em)": ".cf-6zfuo5 {
         width: 1000px
       }",
-          "screen and (max-width: 47.2em)": ".6zfuo5 {
+          "screen and (max-width: 47.2em)": ".cf-6zfuo5 {
         display: block;
         border: none;
         float: left;
@@ -344,11 +344,11 @@ exports[`createTableHeadCell should compose with styles overrides 1`] = `
         "renderRule": [Function],
         "renderStatic": [Function],
         "renderToString": [Function],
-        "rules": ".6zfuo5:first-letter {
+        "rules": ".cf-6zfuo5:first-letter {
         text-transform: capitalize
       }
       
-      .6zfuo5 {
+      .cf-6zfuo5 {
         border-top: 1px solid #dedede;
         line-height: 1.5;
         padding: 0.73333333333rem;
@@ -360,35 +360,35 @@ exports[`createTableHeadCell should compose with styles overrides 1`] = `
         text-align: left;
         font-weight: 600
       }",
-        "selectorPrefix": "",
+        "selectorPrefix": "cf-",
         "statics": "",
         "styleNodes": Object {
           "RULE": <style
             data-fela-type="RULE"
             type="text/css"
       >
-            .6zfuo5:first-letter { text-transform: capitalize } .6zfuo5 { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede; text-align: left; font-weight: 600 }
+            .cf-6zfuo5:first-letter { text-transform: capitalize } .cf-6zfuo5 { border-top: 1px solid #dedede; line-height: 1.5; padding: 0.73333333333rem; vertical-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-color: #dedede; text-align: left; font-weight: 600 }
       </style>,
           "RULE(max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(max-width: 47.2em)"
       >
-            .6zfuo5 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
+            .cf-6zfuo5 { display: block; width: 100%; box-sizing: border-box; border-top-width: 0px }
       </style>,
           "RULE(min-width: 97.6em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="(min-width: 97.6em)"
       >
-            .6zfuo5 { width: 1000px }
+            .cf-6zfuo5 { width: 1000px }
       </style>,
           "RULEscreen and (max-width: 47.2em)": <style
             data-fela-type="RULE"
             type="text/css"
             media="screen and (max-width: 47.2em)"
       >
-            .6zfuo5 { display: block; border: none; float: left; clear: left; padding: 0px }
+            .cf-6zfuo5 { display: block; border: none; float: left; clear: left; padding: 0px }
       </style>,
         },
         "subscribe": [Function],
@@ -514,11 +514,11 @@ exports[`createTableHeadCell should compose with styles overrides 1`] = `
             <ThemedComponent>
               <FelaComponent>
                 <TableHeadCell
-                  className="6zfuo5"
+                  className="cf-6zfuo5"
                   is="th"
                 >
                   <th
-                    className="6zfuo5"
+                    className="cf-6zfuo5"
                   />
                 </TableHeadCell>
               </FelaComponent>

--- a/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
@@ -10,7 +10,6 @@ Object {
   "styles": ".1u7kqkt:first-letter {
   text-transform: capitalize
 }
-
 .1u7kqkt {
   border-top: 1px solid #dedede;
   line-height: 1.5;
@@ -22,18 +21,24 @@ Object {
   border-color: #dedede;
   text-align: left;
   font-weight: 600
-}@media (max-width: 47.2em){.1u7kqkt {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-width: 0px
-}}@media screen and (max-width: 47.2em){.1u7kqkt {
-  display: block;
-  border: none;
-  float: left;
-  clear: left;
-  padding: 0px
-}}",
+}
+@media (max-width: 47.2em) {
+  .1u7kqkt {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border-top-width: 0px
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .1u7kqkt {
+    display: block;
+    border: none;
+    float: left;
+    clear: left;
+    padding: 0px
+  }
+}",
 }
 `;
 

--- a/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableHeadCell.js.snap
@@ -269,28 +269,10 @@ exports[`createTableHeadCell should be able to render a div 1`] = `
         <FelaComponent
           is="div"
         >
-          <TableHeadCellStyles
-            _felaRule={[Function]}
+          <div
+            className="1f998t1"
             is="div"
-            passThrough={Array []}
-          >
-            <TableCellStyles
-              _felaRule={[Function]}
-              is="div"
-              passThrough={Array []}
-            >
-              <TableCellStyles
-                _felaRule={[Function]}
-                is="div"
-                passThrough={Array []}
-              >
-                <div
-                  className="1f998t1"
-                  is="div"
-                />
-              </TableCellStyles>
-            </TableCellStyles>
-          </TableHeadCellStyles>
+          />
         </FelaComponent>
       </ThemedComponent>
     </ThemeProvider>
@@ -526,29 +508,14 @@ exports[`createTableHeadCell should compose with styles overrides 1`] = `
           <tr>
             <ThemedComponent>
               <FelaComponent>
-                <TableHeadCellStyles
-                  _felaRule={[Function]}
-                  passThrough={Array []}
+                <TableHeadCell
+                  className="6zfuo5"
+                  is="th"
                 >
-                  <TableCellStyles
-                    _felaRule={[Function]}
-                    passThrough={Array []}
-                  >
-                    <TableCellStyles
-                      _felaRule={[Function]}
-                      passThrough={Array []}
-                    >
-                      <TableHeadCell
-                        className="6zfuo5"
-                        is="th"
-                      >
-                        <th
-                          className="6zfuo5"
-                        />
-                      </TableHeadCell>
-                    </TableCellStyles>
-                  </TableCellStyles>
-                </TableHeadCellStyles>
+                  <th
+                    className="6zfuo5"
+                  />
+                </TableHeadCell>
               </FelaComponent>
             </ThemedComponent>
           </tr>

--- a/packages/cf-component-table/test/__snapshots__/TableRow.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableRow.js.snap
@@ -121,3 +121,175 @@ Object {
 }}",
 }
 `;
+
+exports[`createTableRow should be able to render a div 1`] = `
+Object {
+  "component": <div
+    bare={undefined}
+    bordered={undefined}
+    className="1edt7t"
+    condensed={undefined}
+    hover={undefined}
+    is="div"
+    rowIndex={undefined}
+    striped={undefined}
+    tbodyIndex={undefined}
+    tfootIndex={undefined}
+    theadIndex={undefined}
+    type={undefined}
+>
+    <div
+        align={undefined}
+        bare={undefined}
+        bordered={undefined}
+        cellIndex={undefined}
+        className="kk9pov"
+        colSpan={undefined}
+        condensed={undefined}
+        headers={undefined}
+        hover={undefined}
+        is="div"
+        rowIndex={undefined}
+        rowSpan={undefined}
+        rowType={undefined}
+        striped={undefined}
+        tbodyIndex={undefined}
+        tfootIndex={undefined}
+        theadIndex={undefined}
+        width={undefined}
+    />
+</div>,
+  "styles": ".1edt7t {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  flex-wrap: nowrap;
+  -webkit-box-lines: nowrap;
+  -webkit-flex-wrap: nowrap;
+  justify-content: space-around;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-around;
+  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  border-color: #dedede;
+  vertical-align: right
+}
+
+
+    .kk9pov {
+  display: inline-block;
+  flex: auto;
+  -webkit-flex: auto;
+  border-top: 1px solid #dedede;
+  line-height: 1.5;
+  padding: 0.73333333333rem;
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-color: #dedede
+}@media (max-width: 47.2em){.1edt7t {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}
+
+
+    .kk9pov {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-width: 0px
+}}@media screen and (max-width: 47.2em){.1edt7t:after {
+  content: \\"\\";
+  display: table;
+  clear: both
+}
+
+.1edt7t {
+  display: block;
+  padding: 0.73333333333rem;
+  border-top: 1px solid #dedede;
+  background-color: #ccc
+}
+
+
+    .kk9pov {
+  display: block;
+  border: none;
+  float: left;
+  clear: left;
+  padding: 0px
+}}@media (min-width: 97.6em){.1edt7t {
+  width: 1000px
+}}",
+}
+`;
+
+exports[`createTableRow should compose with styles overrides 1`] = `
+Object {
+  "component": <tr
+    className="t744or"
+>
+    <td
+        className="1glop85"
+        colSpan={undefined}
+        rowSpan={undefined}
+    />
+</tr>,
+  "styles": "
+.t744or {
+  border-color: #dedede;
+  vertical-align: right
+}
+
+.1glop85 {
+  border-top: 1px solid #dedede;
+  line-height: 1.5;
+  padding: 0.73333333333rem;
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis
+}@media (max-width: 47.2em){
+    .t744or {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}
+
+.1glop85 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-width: 0px
+}}@media screen and (max-width: 47.2em){
+    .t744or:after {
+  content: \\"\\";
+  display: table;
+  clear: both
+}
+
+
+    .t744or {
+  display: block;
+  padding: 0.73333333333rem;
+  border-top: 1px solid #dedede;
+  background-color: #ccc
+}
+
+.1glop85 {
+  display: block;
+  border: none;
+  float: left;
+  clear: left;
+  padding: 0px
+}}@media (min-width: 97.6em){
+    .t744or {
+  width: 1000px
+}}",
+}
+`;

--- a/packages/cf-component-table/test/__snapshots__/TableRow.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableRow.js.snap
@@ -1,33 +1,123 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
-<tr
-  className="cf-table__row cf-table__row--default"
+exports[`TableRow should compose with styles overrides 1`] = `
+Object {
+  "component": <tr
+    className="t744or"
 >
-  TableRow
-</tr>
+    <td
+        className="1glop85"
+        colSpan={undefined}
+        rowSpan={undefined}
+    />
+</tr>,
+  "styles": "
+.t744or {
+  border-color: #dedede;
+  vertical-align: right
+}
+
+.1glop85 {
+  border-top: 1px solid #dedede;
+  line-height: 1.5;
+  padding: 0.73333333333rem;
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis
+}@media (max-width: 47.2em){
+    .t744or {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}
+
+.1glop85 {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border-top-width: 0px
+}}@media screen and (max-width: 47.2em){
+    .t744or:after {
+  content: \\"\\";
+  display: table;
+  clear: both
+}
+
+
+    .t744or {
+  display: block;
+  padding: 0.73333333333rem;
+  border-top: 1px solid #dedede;
+  background-color: #ccc
+}
+
+.1glop85 {
+  display: block;
+  border: none;
+  float: left;
+  clear: left;
+  padding: 0px
+}}@media (min-width: 97.6em){
+    .t744or {
+  width: 1000px
+}}",
+}
 `;
 
-exports[`should render extra class name 1`] = `
-<tr
-  className="cf-table__row cf-table__row--default extra"
+exports[`TableRow should render 1`] = `
+Object {
+  "component": <tr
+    className="1k2myrb"
 >
-  TableRow
-</tr>
+    TableRow
+</tr>,
+  "styles": ".1k2myrb {
+  border-color: #dedede
+}@media (max-width: 47.2em){.1k2myrb {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}}@media screen and (max-width: 47.2em){.1k2myrb:after {
+  content: \\"\\";
+  display: table;
+  clear: both
+}
+
+.1k2myrb {
+  display: block;
+  padding: 0.73333333333rem;
+  border-top: 1px solid #dedede;
+  background-color: #ccc
+}}",
+}
 `;
 
-exports[`should render with accent 1`] = `
-<tr
-  className="cf-table__row cf-table__row--default cf-table__row--accent-orange"
+exports[`TableRow should render with type 1`] = `
+Object {
+  "component": <tr
+    className="7q8ucp"
 >
-  TableRow
-</tr>
-`;
+    TableRow
+</tr>,
+  "styles": ".7q8ucp {
+  border-color: #d93c3e;
+  background-color: #dd5153
+}@media (max-width: 47.2em){.7q8ucp {
+  display: block;
+  width: 100%;
+  box-sizing: border-box
+}}@media screen and (max-width: 47.2em){.7q8ucp:after {
+  content: \\"\\";
+  display: table;
+  clear: both
+}
 
-exports[`should render with type 1`] = `
-<tr
-  className="cf-table__row cf-table__row--error"
->
-  TableRow
-</tr>
+.7q8ucp {
+  display: block;
+  padding: 0.73333333333rem;
+  border-top: 1px solid #dedede;
+  background-color: #ccc
+}}",
+}
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableRow.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableRow.js.snap
@@ -11,12 +11,10 @@ Object {
         rowSpan={undefined}
     />
 </tr>,
-  "styles": "
-.t744or {
+  "styles": ".t744or {
   border-color: #dedede;
   vertical-align: right
 }
-
 .1glop85 {
   border-top: 1px solid #dedede;
   line-height: 1.5;
@@ -25,43 +23,45 @@ Object {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis
-}@media (max-width: 47.2em){
-    .t744or {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
 }
-
-.1glop85 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-width: 0px
-}}@media screen and (max-width: 47.2em){
-    .t744or:after {
-  content: \\"\\";
-  display: table;
-  clear: both
+@media (max-width: 47.2em) {
+  .t744or {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+  .1glop85 {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border-top-width: 0px
+  }
 }
-
-
-    .t744or {
-  display: block;
-  padding: 0.73333333333rem;
-  border-top: 1px solid #dedede;
-  background-color: #ccc
+@media screen and (max-width: 47.2em) {
+  .t744or:after {
+    content: \\"\\";
+    display: table;
+    clear: both
+  }
+  .t744or {
+    display: block;
+    padding: 0.73333333333rem;
+    border-top: 1px solid #dedede;
+    background-color: #ccc
+  }
+  .1glop85 {
+    display: block;
+    border: none;
+    float: left;
+    clear: left;
+    padding: 0px
+  }
 }
-
-.1glop85 {
-  display: block;
-  border: none;
-  float: left;
-  clear: left;
-  padding: 0px
-}}@media (min-width: 97.6em){
-    .t744or {
-  width: 1000px
-}}",
+@media (min-width: 97.6em) {
+  .t744or {
+    width: 1000px
+  }
+}",
 }
 `;
 
@@ -74,22 +74,27 @@ Object {
 </tr>,
   "styles": ".1k2myrb {
   border-color: #dedede
-}@media (max-width: 47.2em){.1k2myrb {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
-}}@media screen and (max-width: 47.2em){.1k2myrb:after {
-  content: \\"\\";
-  display: table;
-  clear: both
 }
-
-.1k2myrb {
-  display: block;
-  padding: 0.73333333333rem;
-  border-top: 1px solid #dedede;
-  background-color: #ccc
-}}",
+@media (max-width: 47.2em) {
+  .1k2myrb {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .1k2myrb:after {
+    content: \\"\\";
+    display: table;
+    clear: both
+  }
+  .1k2myrb {
+    display: block;
+    padding: 0.73333333333rem;
+    border-top: 1px solid #dedede;
+    background-color: #ccc
+  }
+}",
 }
 `;
 
@@ -103,22 +108,27 @@ Object {
   "styles": ".7q8ucp {
   border-color: #d93c3e;
   background-color: #dd5153
-}@media (max-width: 47.2em){.7q8ucp {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
-}}@media screen and (max-width: 47.2em){.7q8ucp:after {
-  content: \\"\\";
-  display: table;
-  clear: both
 }
-
-.7q8ucp {
-  display: block;
-  padding: 0.73333333333rem;
-  border-top: 1px solid #dedede;
-  background-color: #ccc
-}}",
+@media (max-width: 47.2em) {
+  .7q8ucp {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+}
+@media screen and (max-width: 47.2em) {
+  .7q8ucp:after {
+    content: \\"\\";
+    display: table;
+    clear: both
+  }
+  .7q8ucp {
+    display: block;
+    padding: 0.73333333333rem;
+    border-top: 1px solid #dedede;
+    background-color: #ccc
+  }
+}",
 }
 `;
 
@@ -177,9 +187,7 @@ Object {
   border-color: #dedede;
   vertical-align: right
 }
-
-
-    .kk9pov {
+.kk9pov {
   display: inline-block;
   flex: auto;
   -webkit-flex: auto;
@@ -191,41 +199,45 @@ Object {
   overflow: hidden;
   text-overflow: ellipsis;
   border-color: #dedede
-}@media (max-width: 47.2em){.1edt7t {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
 }
-
-
-    .kk9pov {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-width: 0px
-}}@media screen and (max-width: 47.2em){.1edt7t:after {
-  content: \\"\\";
-  display: table;
-  clear: both
+@media (max-width: 47.2em) {
+  .1edt7t {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+  .kk9pov {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border-top-width: 0px
+  }
 }
-
-.1edt7t {
-  display: block;
-  padding: 0.73333333333rem;
-  border-top: 1px solid #dedede;
-  background-color: #ccc
+@media screen and (max-width: 47.2em) {
+  .1edt7t:after {
+    content: \\"\\";
+    display: table;
+    clear: both
+  }
+  .1edt7t {
+    display: block;
+    padding: 0.73333333333rem;
+    border-top: 1px solid #dedede;
+    background-color: #ccc
+  }
+  .kk9pov {
+    display: block;
+    border: none;
+    float: left;
+    clear: left;
+    padding: 0px
+  }
 }
-
-
-    .kk9pov {
-  display: block;
-  border: none;
-  float: left;
-  clear: left;
-  padding: 0px
-}}@media (min-width: 97.6em){.1edt7t {
-  width: 1000px
-}}",
+@media (min-width: 97.6em) {
+  .1edt7t {
+    width: 1000px
+  }
+}",
 }
 `;
 
@@ -240,12 +252,10 @@ Object {
         rowSpan={undefined}
     />
 </tr>,
-  "styles": "
-.t744or {
+  "styles": ".t744or {
   border-color: #dedede;
   vertical-align: right
 }
-
 .1glop85 {
   border-top: 1px solid #dedede;
   line-height: 1.5;
@@ -254,42 +264,44 @@ Object {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis
-}@media (max-width: 47.2em){
-    .t744or {
-  display: block;
-  width: 100%;
-  box-sizing: border-box
 }
-
-.1glop85 {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  border-top-width: 0px
-}}@media screen and (max-width: 47.2em){
-    .t744or:after {
-  content: \\"\\";
-  display: table;
-  clear: both
+@media (max-width: 47.2em) {
+  .t744or {
+    display: block;
+    width: 100%;
+    box-sizing: border-box
+  }
+  .1glop85 {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border-top-width: 0px
+  }
 }
-
-
-    .t744or {
-  display: block;
-  padding: 0.73333333333rem;
-  border-top: 1px solid #dedede;
-  background-color: #ccc
+@media screen and (max-width: 47.2em) {
+  .t744or:after {
+    content: \\"\\";
+    display: table;
+    clear: both
+  }
+  .t744or {
+    display: block;
+    padding: 0.73333333333rem;
+    border-top: 1px solid #dedede;
+    background-color: #ccc
+  }
+  .1glop85 {
+    display: block;
+    border: none;
+    float: left;
+    clear: left;
+    padding: 0px
+  }
 }
-
-.1glop85 {
-  display: block;
-  border: none;
-  float: left;
-  clear: left;
-  padding: 0px
-}}@media (min-width: 97.6em){
-    .t744or {
-  width: 1000px
-}}",
+@media (min-width: 97.6em) {
+  .t744or {
+    width: 1000px
+  }
+}",
 }
 `;

--- a/packages/cf-component-table/test/__snapshots__/TableRow.js.snap
+++ b/packages/cf-component-table/test/__snapshots__/TableRow.js.snap
@@ -3,19 +3,19 @@
 exports[`TableRow should compose with styles overrides 1`] = `
 Object {
   "component": <tr
-    className="t744or"
+    className="cf-t744or"
 >
     <td
-        className="1glop85"
+        className="cf-1glop85"
         colSpan={undefined}
         rowSpan={undefined}
     />
 </tr>,
-  "styles": ".t744or {
+  "styles": ".cf-t744or {
   border-color: #dedede;
   vertical-align: right
 }
-.1glop85 {
+.cf-1glop85 {
   border-top: 1px solid #dedede;
   line-height: 1.5;
   padding: 0.73333333333rem;
@@ -25,12 +25,12 @@ Object {
   text-overflow: ellipsis
 }
 @media (max-width: 47.2em) {
-  .t744or {
+  .cf-t744or {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
-  .1glop85 {
+  .cf-1glop85 {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -38,18 +38,18 @@ Object {
   }
 }
 @media screen and (max-width: 47.2em) {
-  .t744or:after {
+  .cf-t744or:after {
     content: \\"\\";
     display: table;
     clear: both
   }
-  .t744or {
+  .cf-t744or {
     display: block;
     padding: 0.73333333333rem;
     border-top: 1px solid #dedede;
     background-color: #ccc
   }
-  .1glop85 {
+  .cf-1glop85 {
     display: block;
     border: none;
     float: left;
@@ -58,7 +58,7 @@ Object {
   }
 }
 @media (min-width: 97.6em) {
-  .t744or {
+  .cf-t744or {
     width: 1000px
   }
 }",
@@ -68,27 +68,27 @@ Object {
 exports[`TableRow should render 1`] = `
 Object {
   "component": <tr
-    className="1k2myrb"
+    className="cf-1k2myrb"
 >
     TableRow
 </tr>,
-  "styles": ".1k2myrb {
+  "styles": ".cf-1k2myrb {
   border-color: #dedede
 }
 @media (max-width: 47.2em) {
-  .1k2myrb {
+  .cf-1k2myrb {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
 }
 @media screen and (max-width: 47.2em) {
-  .1k2myrb:after {
+  .cf-1k2myrb:after {
     content: \\"\\";
     display: table;
     clear: both
   }
-  .1k2myrb {
+  .cf-1k2myrb {
     display: block;
     padding: 0.73333333333rem;
     border-top: 1px solid #dedede;
@@ -101,28 +101,28 @@ Object {
 exports[`TableRow should render with type 1`] = `
 Object {
   "component": <tr
-    className="7q8ucp"
+    className="cf-7q8ucp"
 >
     TableRow
 </tr>,
-  "styles": ".7q8ucp {
+  "styles": ".cf-7q8ucp {
   border-color: #d93c3e;
   background-color: #dd5153
 }
 @media (max-width: 47.2em) {
-  .7q8ucp {
+  .cf-7q8ucp {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
 }
 @media screen and (max-width: 47.2em) {
-  .7q8ucp:after {
+  .cf-7q8ucp:after {
     content: \\"\\";
     display: table;
     clear: both
   }
-  .7q8ucp {
+  .cf-7q8ucp {
     display: block;
     padding: 0.73333333333rem;
     border-top: 1px solid #dedede;
@@ -137,7 +137,7 @@ Object {
   "component": <div
     bare={undefined}
     bordered={undefined}
-    className="1edt7t"
+    className="cf-1edt7t"
     condensed={undefined}
     hover={undefined}
     is="div"
@@ -153,7 +153,7 @@ Object {
         bare={undefined}
         bordered={undefined}
         cellIndex={undefined}
-        className="kk9pov"
+        className="cf-kk9pov"
         colSpan={undefined}
         condensed={undefined}
         headers={undefined}
@@ -169,7 +169,7 @@ Object {
         width={undefined}
     />
 </div>,
-  "styles": ".1edt7t {
+  "styles": ".cf-1edt7t {
   display: -webkit-box;
   display: -moz-box;
   display: -ms-flexbox;
@@ -187,7 +187,7 @@ Object {
   border-color: #dedede;
   vertical-align: right
 }
-.kk9pov {
+.cf-kk9pov {
   display: inline-block;
   flex: auto;
   -webkit-flex: auto;
@@ -201,12 +201,12 @@ Object {
   border-color: #dedede
 }
 @media (max-width: 47.2em) {
-  .1edt7t {
+  .cf-1edt7t {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
-  .kk9pov {
+  .cf-kk9pov {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -214,18 +214,18 @@ Object {
   }
 }
 @media screen and (max-width: 47.2em) {
-  .1edt7t:after {
+  .cf-1edt7t:after {
     content: \\"\\";
     display: table;
     clear: both
   }
-  .1edt7t {
+  .cf-1edt7t {
     display: block;
     padding: 0.73333333333rem;
     border-top: 1px solid #dedede;
     background-color: #ccc
   }
-  .kk9pov {
+  .cf-kk9pov {
     display: block;
     border: none;
     float: left;
@@ -234,7 +234,7 @@ Object {
   }
 }
 @media (min-width: 97.6em) {
-  .1edt7t {
+  .cf-1edt7t {
     width: 1000px
   }
 }",
@@ -244,19 +244,19 @@ Object {
 exports[`createTableRow should compose with styles overrides 1`] = `
 Object {
   "component": <tr
-    className="t744or"
+    className="cf-t744or"
 >
     <td
-        className="1glop85"
+        className="cf-1glop85"
         colSpan={undefined}
         rowSpan={undefined}
     />
 </tr>,
-  "styles": ".t744or {
+  "styles": ".cf-t744or {
   border-color: #dedede;
   vertical-align: right
 }
-.1glop85 {
+.cf-1glop85 {
   border-top: 1px solid #dedede;
   line-height: 1.5;
   padding: 0.73333333333rem;
@@ -266,12 +266,12 @@ Object {
   text-overflow: ellipsis
 }
 @media (max-width: 47.2em) {
-  .t744or {
+  .cf-t744or {
     display: block;
     width: 100%;
     box-sizing: border-box
   }
-  .1glop85 {
+  .cf-1glop85 {
     display: block;
     width: 100%;
     box-sizing: border-box;
@@ -279,18 +279,18 @@ Object {
   }
 }
 @media screen and (max-width: 47.2em) {
-  .t744or:after {
+  .cf-t744or:after {
     content: \\"\\";
     display: table;
     clear: both
   }
-  .t744or {
+  .cf-t744or {
     display: block;
     padding: 0.73333333333rem;
     border-top: 1px solid #dedede;
     background-color: #ccc
   }
-  .1glop85 {
+  .cf-1glop85 {
     display: block;
     border: none;
     float: left;
@@ -299,7 +299,7 @@ Object {
   }
 }
 @media (min-width: 97.6em) {
-  .t744or {
+  .cf-t744or {
     width: 1000px
   }
 }",

--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -15,6 +15,16 @@ const createComponent = (rule, type = 'div', passThroughProps = []) =>
       : passThroughProps
   );
 
+const connectStyles = (...styles) => type =>
+  styles.reduce(
+    (accum, style) =>
+      createComponent(typeof style === 'object' ? () => style : style, accum),
+    createComponent(
+      typeof styles[0] === 'object' ? () => styles[0] : styles[0],
+      type
+    )
+  );
+
 const mergeThemes = (baseTheme, ...themes) => ({
   theme: (themes &&
     themes.reduce((acc, theme) => {
@@ -52,6 +62,7 @@ const createComponentStyles = (styleFunctions, component) =>
 
 export {
   createComponent,
+  connectStyles,
   mergeThemes,
   applyTheme,
   ThemeProvider,

--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -16,13 +16,13 @@ const createComponent = (rule, type = 'div', passThroughProps = []) =>
   );
 
 const connectStyles = (...styles) => type =>
-  styles.reduce(
-    (accum, style) =>
-      createComponent(typeof style === 'object' ? () => style : style, accum),
-    createComponent(
-      typeof styles[0] === 'object' ? () => styles[0] : styles[0],
-      type
-    )
+  createComponent(
+    combineRules(
+      ...styles.map(
+        style => (typeof style === 'function' ? style : () => style)
+      )
+    ),
+    type
   );
 
 const mergeThemes = (baseTheme, ...themes) => ({

--- a/packages/cf-style-container/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-container/test/__snapshots__/index.js.snap
@@ -5,8 +5,7 @@ Object {
   "component": <div
     className="bd4m75"
 />,
-  "styles": "
-.bd4m75 {
+  "styles": ".bd4m75 {
   color: #fff
 }",
 }

--- a/packages/cf-style-container/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-container/test/__snapshots__/index.js.snap
@@ -3,9 +3,9 @@
 exports[`connectStyles should accept styles functions or objects 1`] = `
 Object {
   "component": <div
-    className="bd4m75"
+    className="cf-bd4m75"
 />,
-  "styles": ".bd4m75 {
+  "styles": ".cf-bd4m75 {
   color: #fff
 }",
 }
@@ -14,9 +14,9 @@ Object {
 exports[`connectStyles's return value should return a styled component when invoked 1`] = `
 Object {
   "component": <div
-    className="53ysj"
+    className="cf-53ysj"
 />,
-  "styles": ".53ysj {
+  "styles": ".cf-53ysj {
   color: black
 }",
 }

--- a/packages/cf-style-container/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-container/test/__snapshots__/index.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`connectStyles should accept styles functions or objects 1`] = `
+Object {
+  "component": <div
+    className="bd4m75"
+/>,
+  "styles": "
+.bd4m75 {
+  color: #fff
+}",
+}
+`;
+
+exports[`connectStyles's return value should return a styled component when invoked 1`] = `
+Object {
+  "component": <div
+    className="53ysj"
+/>,
+  "styles": ".53ysj {
+  color: black
+}",
+}
+`;
+
 exports[`createComponent creates empty component 1`] = `
 <div
   className=""

--- a/packages/cf-style-container/test/index.js
+++ b/packages/cf-style-container/test/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   createComponent,
   createComponentStyles,
+  connectStyles,
   mergeThemes,
   filterNone,
   filterStyle,
@@ -9,6 +10,24 @@ import {
 } from '../../cf-style-container/src/index';
 import { variables } from 'cf-style-const';
 import { felaSnapshot } from 'cf-style-provider';
+
+test('connectStyles should return a partial function that accepts a React element that returns a FelaComponent', () => {
+  const createElement = connectStyles({ color: 'blue' }, { color: 'black' });
+  expect(typeof createElement === 'function').toBe(true);
+  expect(createElement('div').displayName).toBe('FelaComponent');
+});
+
+test("connectStyles's return value should return a styled component when invoked", () => {
+  const Element = connectStyles({ color: 'blue' }, { color: 'black' })('div');
+  expect(felaSnapshot(<Element />)).toMatchSnapshot();
+});
+
+test('connectStyles should accept styles functions or objects', () => {
+  const Element = connectStyles({ color: 'blue' }, ({ theme }) => ({
+    color: theme.colorWhite
+  }))('div');
+  expect(felaSnapshot(<Element />)).toMatchSnapshot();
+});
 
 test('mergeThemes should return an immutable and deeply cloned object', () => {
   const themeA = () => ({ color: 'yellow' });
@@ -35,6 +54,10 @@ test('mergeThemes should return an immutable and deeply cloned object', () => {
   // To be or not to be. That is the question.
   // https://facebook.github.io/jest/docs/en/expect.html#tobevalue
   expect(props.theme.breakpoints).not.toBe(themeB.breakpoints);
+
+  expect(() => {
+    delete props.theme.color;
+  }).toThrow();
 });
 
 test('mergesThemes should accept functions themes', () => {


### PR DESCRIPTION
This PR migrates all of our existing SASS and PostCSS table styles to cf-component-table via Fela.

This migration slightly deviates from the pattern of currently migrated components in the following ways:

1. Despite the name, all of the those "Unstyled" components are actually unthemed, not unstyled. ~~This PR completely separates the styles from the components - component theme for minor customization, and style functions for replacing the styling completely.~~
~~2. Due to 1, the `className` prop remains open, in addition to `styles`. You should not abuse `className`. The relationship between them is either/or. You can either use a `className` automatically applied by `createComponent`, or the className that comes from the `styles` object given by `createComponentStyles`, but not both at the same time.~~
3. To achieve high fidelity to our existing selector-heavy styles, a number of creative ways to "emulate" CSS selectors had to be invented. The indices of allowed ancestors are passed all the way down to the cells, so we could simulate `:first-child`, `:last-child`, and `:nth-child` and so on. `:last-child` is signal by virtue of being an index that has a negative number. These indices are passed down by cloning the children and adding these "CSS query" props at every level. A number of helper functions were introduced into `cf-style-container` to help with is.
4. Separately, the inner logic of the `applyTheme` HOC had been extracted to ease testing. In addition, `applyTheme` can now take object themes instead of just function themes. This brings our wrapper layer back to feature parity with vanilla Fela's `<ThemeProvider>`. 
~~5. Arbitrary props value for the underlying DOM elements remain open, with the exception of the 
`style` attribute.~~

There are mainly 3 reasons to completely separate the styles from the structure of the components.
1. There will be new internal components introduced that rely on table structures while styled completely differently. Separating the style functions from the components allows this possibility.
2. Design is currently experimenting with a new design, so it's conceivable that we might have 2 separate styles living side-by-side. Decoupling the styles from the structure allows maximum room for progress on the new design.
3. It's often needed to use `createComponent`, `createComponentStyles` and `applyTheme` to create one off override to some style properties of presentational components.

I hope to promote this pattern in general because this pattern can drastically reduce stray `<div>`s generated by `<Box>`. Imagine instead of having to wrap every block you need to layout with a `<Box>`, you could import the style functions and themes separately, and compose in your overrides, and then apply to the blocks at issue.

# Note:
~~Since this package now requires direct parent/child relationship and runtime type detection among components to work, if you do need to mix in you custom table components with any components provided by this package, please make sure you ***inherit*** the one you intend to customize.~~


(I'll drop in some usage examples to explain this more tomorrow)