### PR TITLE
Replace merge-options with seamless-immutable

### DIFF
--- a/packages/cf-style-container/package.json
+++ b/packages/cf-style-container/package.json
@@ -15,6 +15,7 @@
     "merge-options": "^1.0.0",
     "prop-types": "^15.5.8",
     "react-fela": "^5.0.0",
+    "seamless-immutable": "^7.1.2",
     "underscore.string": "^3.3.4"
   },
   "peerDependencies": {

--- a/packages/cf-style-container/package.json
+++ b/packages/cf-style-container/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "fela": "^5.0.0",
-    "merge-options": "^1.0.0",
     "prop-types": "^15.5.8",
     "react-fela": "^5.0.0",
     "seamless-immutable": "^7.1.2",

--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -6,7 +6,7 @@ import {
   ThemeProvider,
   connect
 } from 'react-fela';
-import mergeOptions from 'merge-options';
+import { static as Immutable } from 'seamless-immutable';
 import { capitalize } from 'underscore.string';
 
 const createComponent = (rule, type = 'div', passThroughProps = []) =>
@@ -20,18 +20,17 @@ const createComponent = (rule, type = 'div', passThroughProps = []) =>
 
 const mergeThemes = (baseTheme, ...themes) => ({
   theme: (themes &&
-    themes.reduce(
-      (acc, theme) => {
-        if (typeof theme === 'function') {
-          return mergeOptions(acc, theme(baseTheme));
-        } else if (typeof theme === 'object') {
-          return mergeOptions(acc, theme);
-        }
-        throw new Error('theme must be either a function or an object');
-      },
-      { ...baseTheme }
-    )) ||
-    baseTheme
+    themes.reduce((acc, theme) => {
+      if (typeof theme === 'function') {
+        return Immutable.merge(acc, Immutable(theme(baseTheme)), {
+          deep: true
+        });
+      } else if (typeof theme === 'object') {
+        return Immutable.merge(acc, Immutable(theme), { deep: true });
+      }
+      throw new Error('theme must be either a function or an object');
+    }, Immutable(baseTheme))) ||
+    Immutable(baseTheme)
 });
 
 const applyTheme = (ComponentToWrap, ...themes) => {

--- a/packages/cf-style-container/test/index.js
+++ b/packages/cf-style-container/test/index.js
@@ -13,12 +13,28 @@ import felaTestContext from '../../../felaTestContext';
 
 test('mergeThemes should return an immutable and deeply cloned object', () => {
   const themeA = () => ({ color: 'yellow' });
-  const themeB = { color: 'blue', breakpoints: { desktop: '1em' } };
+  const themeB = {
+    color: 'blue',
+    breakpoints: {
+      desktop: '1em',
+      desktopLarge: '1em',
+      mobile: '1em',
+      mobileWide: '1em',
+      tablet: '1em'
+    }
+  };
   const props = mergeThemes(variables, themeA, themeB);
+
   expect(() => {
     props.theme.color = 'white';
   }).toThrow();
+
   expect(props.theme.color).toEqual('blue');
+
+  expect(props.theme.breakpoints).toEqual(themeB.breakpoints);
+
+  // To be or not to be. That is the question.
+  // https://facebook.github.io/jest/docs/en/expect.html#tobevalue
   expect(props.theme.breakpoints).not.toBe(themeB.breakpoints);
 });
 

--- a/packages/cf-style-container/test/index.js
+++ b/packages/cf-style-container/test/index.js
@@ -11,22 +11,33 @@ import { variables } from 'cf-style-const';
 import renderer from 'react-test-renderer';
 import felaTestContext from '../../../felaTestContext';
 
+test('mergeThemes should return an immutable and deeply cloned object', () => {
+  const themeA = () => ({ color: 'yellow' });
+  const themeB = { color: 'blue', breakpoints: { desktop: '1em' } };
+  const props = mergeThemes(variables, themeA, themeB);
+  expect(() => {
+    props.theme.color = 'white';
+  }).toThrow();
+  expect(props.theme.color).toEqual('blue');
+  expect(props.theme.breakpoints).not.toBe(themeB.breakpoints);
+});
+
 test('mergesThemes should accept functions themes', () => {
-  const theme = mergeThemes(variables, () => ({
+  const props = mergeThemes(variables, () => ({
     color: 'yellow'
   }));
-  expect(theme).toMatchSnapshot();
+  expect(props).toMatchSnapshot();
 });
 
 test('mergesThemes should accept object themes', () => {
-  const theme = mergeThemes(variables, {
+  const props = mergeThemes(variables, {
     color: 'yellow'
   });
-  expect(theme).toMatchSnapshot();
+  expect(props).toMatchSnapshot();
 });
 
 test('mergeThemes should override the baseTheme if more than one theme is provided', () => {
-  const theme = mergeThemes(
+  const props = mergeThemes(
     variables,
     () => ({
       color: 'yellow',
@@ -41,12 +52,12 @@ test('mergeThemes should override the baseTheme if more than one theme is provid
       }
     }
   );
-  expect(theme).toMatchSnapshot();
+  expect(props).toMatchSnapshot();
 });
 
 test('mergeThemes should return the baseTheme if no extra theme is provided', () => {
-  const theme = mergeThemes(variables);
-  expect(theme).toMatchSnapshot();
+  const props = mergeThemes(variables);
+  expect(props).toMatchSnapshot();
 });
 
 test('createComponent creates empty component', () => {


### PR DESCRIPTION
merge-options 1.0.0 has a package.json file that just assumes the environment will only be node, this PR swaps it out with seamless-immutable, so the themes merged now are immutable and deeply cloned.