### PR TITLE
fix(cf-component-form): remove missing background

### DIFF
--- a/packages/cf-component-form/src/Form.js
+++ b/packages/cf-component-form/src/Form.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { createComponent } from 'cf-style-container';
 
 const styles = ({ theme }) => ({
-  background: theme.background,
   border: theme.border,
   boxShadow: theme.boxShadow
 });


### PR DESCRIPTION
We removed the `background` property from the theme 46cbe7b but forgot
to remove it from the component as well.

I realized just as I hit merge on #272  😭 