### PR TITLE
Removing top padding from page

### DIFF
--- a/packages/cf-component-page/src/Page.js
+++ b/packages/cf-component-page/src/Page.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { createComponent } from 'cf-style-container';
 
 // Doesn't allow overrides atm
-const styles = () => ({
-  paddingTop: '2.5rem',
-  paddingBottom: '2.5rem',
+const styles = ({ theme }) => ({
+  paddingTop: theme.paddingTop,
+  paddingBottom: theme.paddingBottom,
   tablet: {
     paddingBottom: '1.3rem'
   }

--- a/packages/cf-component-page/src/PageTheme.js
+++ b/packages/cf-component-page/src/PageTheme.js
@@ -1,0 +1,4 @@
+export default () => ({
+  paddingTop: 0,
+  paddingBottom: 0
+});

--- a/packages/cf-component-page/src/index.js
+++ b/packages/cf-component-page/src/index.js
@@ -1,15 +1,17 @@
 import PageUnstyled from './Page';
 import PageHeaderUnstyled from './PageHeader';
 import PageContentUnstyled from './PageContent';
+import PageTheme from './PageTheme';
 
 import { applyTheme } from 'cf-style-container';
 
-const Page = applyTheme(PageUnstyled, {});
+const Page = applyTheme(PageUnstyled, PageTheme);
 const PageHeader = applyTheme(PageHeaderUnstyled, {});
 const PageContent = applyTheme(PageContentUnstyled, {});
 
 export {
   Page,
+  PageTheme,
   PageUnstyled,
   PageHeader,
   PageHeaderUnstyled,

--- a/packages/cf-component-page/test/__snapshots__/Page.js.snap
+++ b/packages/cf-component-page/test/__snapshots__/Page.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should render 1`] = `
 <article
-  className="flb8cdc"
+  className="fpl1olc"
 >
   Hello World
 </article>
@@ -10,13 +10,13 @@ exports[`should render 1`] = `
 
 exports[`should render 2`] = `
 "
-.flb8cdc {
-  padding-top: 2.5rem;
-  padding-bottom: 2.5rem
+.fpl1olc {
+  padding-top: 0px;
+  padding-bottom: 0px
 }
 
 @media (min-width: 47.2em) {
-  .flb8cdc {
+  .fpl1olc {
     padding-bottom: 1.3rem
   }
 }


### PR DESCRIPTION
There's already padding by way of zone-nav, so this adds way too much.
I'm whitelisting it and making it overridable via theme in case it
needs tweaking on some pages.