### PR TITLE
cf-style-provider update

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "isomorphic-fetch": "^2.2.1",
     "jest": "^20.0.3",
     "jest-fetch-mock": "^1.0.8",
+    "js-beautify": "^1.6.14",
     "jsdom": "^9.11.0",
     "lerna": "2.0.0-beta.38",
     "polished": "^1.2.1",

--- a/packages/cf-builder-pagination/test/PaginationBuilder.js
+++ b/packages/cf-builder-pagination/test/PaginationBuilder.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { PaginationBuilder } from '../../cf-builder-pagination/src/index';
 import { createStub } from '../../cf-test-stub/src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
-import felaTestContext from 'cf-style-provider/src/felaTestContext';
+import { felaSnapshot } from 'cf-style-provider';
+import { felaTestContext } from 'cf-style-provider';
 
 test('should render pagination', () => {
   const snapshot = felaSnapshot(

--- a/packages/cf-builder-pagination/test/__snapshots__/PaginationBuilder.js.snap
+++ b/packages/cf-builder-pagination/test/__snapshots__/PaginationBuilder.js.snap
@@ -2,20 +2,20 @@
 
 exports[`should render pagination 1`] = `
 <div
-  className="cf-1bek1ug"
+  className="f1bek1ug"
 >
   <ul
     aria-describedby={null}
-    className="cf-y1rhga"
+    className="fy1rhga"
     role="navigation"
   >
     <li
-      className="cf-mgj6am"
+      className="fmgj6am"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-109b087"
+        className="f109b087"
         href="#"
         onClick={[Function]}
       >
@@ -26,12 +26,12 @@ exports[`should render pagination 1`] = `
       </a>
     </li>
     <li
-      className="cf-1wi2cf1"
+      className="f1wi2cf1"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-109b087"
+        className="f109b087"
         href="#"
         onClick={[Function]}
       >
@@ -39,12 +39,12 @@ exports[`should render pagination 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -52,12 +52,12 @@ exports[`should render pagination 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -65,12 +65,12 @@ exports[`should render pagination 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -78,12 +78,12 @@ exports[`should render pagination 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -91,12 +91,12 @@ exports[`should render pagination 1`] = `
       </a>
     </li>
     <li
-      className="cf-hmei63"
+      className="fhmei63"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -111,12 +111,14 @@ exports[`should render pagination 1`] = `
 `;
 
 exports[`should render pagination 2`] = `
-".cf-y1rhga:after {
+"
+.fy1rhga:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-y1rhga {
+
+.fy1rhga {
   list-style: none;
   margin-top: 0px;
   margin-left: 0px;
@@ -130,12 +132,14 @@ exports[`should render pagination 2`] = `
   border-radius: 3px;
   box-shadow: none
 }
-.cf-1bek1ug:after {
+
+.f1bek1ug:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-mgj6am {
+
+.fmgj6am {
   float: left;
   position: relative;
   background-color: #ededed;
@@ -143,10 +147,12 @@ exports[`should render pagination 2`] = `
   cursor: default;
   border-radius: 3px
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -161,7 +167,8 @@ exports[`should render pagination 2`] = `
   color: inherit;
   cursor: default
 }
-.cf-1wi2cf1 {
+
+.f1wi2cf1 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -170,17 +177,20 @@ exports[`should render pagination 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-15spu1u {
+
+.f15spu1u {
   float: left;
   position: relative;
   background-color: #fff;
   color: #408BC9;
   cursor: pointer
 }
-.cf-32iz07:focus {
+
+.f32iz07:focus {
   z-index: 1
 }
-.cf-32iz07 {
+
+.f32iz07 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -195,32 +205,34 @@ exports[`should render pagination 2`] = `
   color: inherit;
   cursor: pointer
 }
-.cf-hmei63 {
+
+.fhmei63 {
   float: left;
   position: relative;
   background-color: #408BC9;
   color: #fff;
   cursor: pointer;
   border-radius: 3px
-}"
+}
+"
 `;
 
 exports[`should render pagination loading 1`] = `
 <div
-  className="cf-1bek1ug"
+  className="f1bek1ug"
 >
   <ul
     aria-describedby={null}
-    className="cf-y1rhga"
+    className="fy1rhga"
     role="navigation"
   >
     <li
-      className="cf-mgj6am"
+      className="fmgj6am"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-109b087"
+        className="f109b087"
         href="#"
         onClick={[Function]}
       >
@@ -231,12 +243,12 @@ exports[`should render pagination loading 1`] = `
       </a>
     </li>
     <li
-      className="cf-1wi2cf1"
+      className="f1wi2cf1"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-109b087"
+        className="f109b087"
         href="#"
         onClick={[Function]}
       >
@@ -247,12 +259,12 @@ exports[`should render pagination loading 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -260,12 +272,12 @@ exports[`should render pagination loading 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -273,12 +285,12 @@ exports[`should render pagination loading 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -286,12 +298,12 @@ exports[`should render pagination loading 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -299,12 +311,12 @@ exports[`should render pagination loading 1`] = `
       </a>
     </li>
     <li
-      className="cf-hmei63"
+      className="fhmei63"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -319,12 +331,14 @@ exports[`should render pagination loading 1`] = `
 `;
 
 exports[`should render pagination loading 2`] = `
-".cf-y1rhga:after {
+"
+.fy1rhga:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-y1rhga {
+
+.fy1rhga {
   list-style: none;
   margin-top: 0px;
   margin-left: 0px;
@@ -338,12 +352,14 @@ exports[`should render pagination loading 2`] = `
   border-radius: 3px;
   box-shadow: none
 }
-.cf-1bek1ug:after {
+
+.f1bek1ug:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-mgj6am {
+
+.fmgj6am {
   float: left;
   position: relative;
   background-color: #ededed;
@@ -351,10 +367,12 @@ exports[`should render pagination loading 2`] = `
   cursor: default;
   border-radius: 3px
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -369,7 +387,8 @@ exports[`should render pagination loading 2`] = `
   color: inherit;
   cursor: default
 }
-.cf-1wi2cf1 {
+
+.f1wi2cf1 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -378,17 +397,20 @@ exports[`should render pagination loading 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-15spu1u {
+
+.f15spu1u {
   float: left;
   position: relative;
   background-color: #fff;
   color: #408BC9;
   cursor: pointer
 }
-.cf-32iz07:focus {
+
+.f32iz07:focus {
   z-index: 1
 }
-.cf-32iz07 {
+
+.f32iz07 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -403,32 +425,34 @@ exports[`should render pagination loading 2`] = `
   color: inherit;
   cursor: pointer
 }
-.cf-hmei63 {
+
+.fhmei63 {
   float: left;
   position: relative;
   background-color: #408BC9;
   color: #fff;
   cursor: pointer;
   border-radius: 3px
-}"
+}
+"
 `;
 
 exports[`should render pagination with an infoFormatter 1`] = `
 <div
-  className="cf-1bek1ug"
+  className="f1bek1ug"
 >
   <ul
     aria-describedby={null}
-    className="cf-y1rhga"
+    className="fy1rhga"
     role="navigation"
   >
     <li
-      className="cf-hmei63"
+      className="fhmei63"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -439,12 +463,12 @@ exports[`should render pagination with an infoFormatter 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -452,12 +476,12 @@ exports[`should render pagination with an infoFormatter 1`] = `
       </a>
     </li>
     <li
-      className="cf-1wi2cf1"
+      className="f1wi2cf1"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-109b087"
+        className="f109b087"
         href="#"
         onClick={[Function]}
       >
@@ -465,12 +489,12 @@ exports[`should render pagination with an infoFormatter 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -478,12 +502,12 @@ exports[`should render pagination with an infoFormatter 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -491,12 +515,12 @@ exports[`should render pagination with an infoFormatter 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -504,12 +528,12 @@ exports[`should render pagination with an infoFormatter 1`] = `
       </a>
     </li>
     <li
-      className="cf-hmei63"
+      className="fhmei63"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -524,12 +548,14 @@ exports[`should render pagination with an infoFormatter 1`] = `
 `;
 
 exports[`should render pagination with an infoFormatter 2`] = `
-".cf-y1rhga:after {
+"
+.fy1rhga:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-y1rhga {
+
+.fy1rhga {
   list-style: none;
   margin-top: 0px;
   margin-left: 0px;
@@ -543,12 +569,14 @@ exports[`should render pagination with an infoFormatter 2`] = `
   border-radius: 3px;
   box-shadow: none
 }
-.cf-1bek1ug:after {
+
+.f1bek1ug:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-hmei63 {
+
+.fhmei63 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -556,10 +584,12 @@ exports[`should render pagination with an infoFormatter 2`] = `
   cursor: pointer;
   border-radius: 3px
 }
-.cf-32iz07:focus {
+
+.f32iz07:focus {
   z-index: 1
 }
-.cf-32iz07 {
+
+.f32iz07 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -574,14 +604,16 @@ exports[`should render pagination with an infoFormatter 2`] = `
   color: inherit;
   cursor: pointer
 }
-.cf-15spu1u {
+
+.f15spu1u {
   float: left;
   position: relative;
   background-color: #fff;
   color: #408BC9;
   cursor: pointer
 }
-.cf-1wi2cf1 {
+
+.f1wi2cf1 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -590,10 +622,12 @@ exports[`should render pagination with an infoFormatter 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -607,25 +641,26 @@ exports[`should render pagination with an infoFormatter 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;
 
 exports[`should render pagination with the last page active 1`] = `
 <div
-  className="cf-1bek1ug"
+  className="f1bek1ug"
 >
   <ul
     aria-describedby={null}
-    className="cf-y1rhga"
+    className="fy1rhga"
     role="navigation"
   >
     <li
-      className="cf-hmei63"
+      className="fhmei63"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -636,12 +671,12 @@ exports[`should render pagination with the last page active 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -649,12 +684,12 @@ exports[`should render pagination with the last page active 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -662,12 +697,12 @@ exports[`should render pagination with the last page active 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -675,12 +710,12 @@ exports[`should render pagination with the last page active 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -688,12 +723,12 @@ exports[`should render pagination with the last page active 1`] = `
       </a>
     </li>
     <li
-      className="cf-1wi2cf1"
+      className="f1wi2cf1"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-109b087"
+        className="f109b087"
         href="#"
         onClick={[Function]}
       >
@@ -701,12 +736,12 @@ exports[`should render pagination with the last page active 1`] = `
       </a>
     </li>
     <li
-      className="cf-mgj6am"
+      className="fmgj6am"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-109b087"
+        className="f109b087"
         href="#"
         onClick={[Function]}
       >
@@ -721,12 +756,14 @@ exports[`should render pagination with the last page active 1`] = `
 `;
 
 exports[`should render pagination with the last page active 2`] = `
-".cf-y1rhga:after {
+"
+.fy1rhga:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-y1rhga {
+
+.fy1rhga {
   list-style: none;
   margin-top: 0px;
   margin-left: 0px;
@@ -740,12 +777,14 @@ exports[`should render pagination with the last page active 2`] = `
   border-radius: 3px;
   box-shadow: none
 }
-.cf-1bek1ug:after {
+
+.f1bek1ug:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-hmei63 {
+
+.fhmei63 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -753,10 +792,12 @@ exports[`should render pagination with the last page active 2`] = `
   cursor: pointer;
   border-radius: 3px
 }
-.cf-32iz07:focus {
+
+.f32iz07:focus {
   z-index: 1
 }
-.cf-32iz07 {
+
+.f32iz07 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -771,14 +812,16 @@ exports[`should render pagination with the last page active 2`] = `
   color: inherit;
   cursor: pointer
 }
-.cf-15spu1u {
+
+.f15spu1u {
   float: left;
   position: relative;
   background-color: #fff;
   color: #408BC9;
   cursor: pointer
 }
-.cf-1wi2cf1 {
+
+.f1wi2cf1 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -787,10 +830,12 @@ exports[`should render pagination with the last page active 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -805,32 +850,34 @@ exports[`should render pagination with the last page active 2`] = `
   color: inherit;
   cursor: default
 }
-.cf-mgj6am {
+
+.fmgj6am {
   float: left;
   position: relative;
   background-color: #ededed;
   color: #666;
   cursor: default;
   border-radius: 3px
-}"
+}
+"
 `;
 
 exports[`should render with collapsed items 1`] = `
 <div
-  className="cf-1bek1ug"
+  className="f1bek1ug"
 >
   <ul
     aria-describedby={null}
-    className="cf-y1rhga"
+    className="fy1rhga"
     role="navigation"
   >
     <li
-      className="cf-hmei63"
+      className="fhmei63"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -841,12 +888,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -854,12 +901,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role="presentation"
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -869,12 +916,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -882,12 +929,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -895,12 +942,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-1wi2cf1"
+      className="f1wi2cf1"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-109b087"
+        className="f109b087"
         href="#"
         onClick={[Function]}
       >
@@ -908,12 +955,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -921,12 +968,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -934,12 +981,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role="presentation"
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -949,12 +996,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-15spu1u"
+      className="f15spu1u"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -962,12 +1009,12 @@ exports[`should render with collapsed items 1`] = `
       </a>
     </li>
     <li
-      className="cf-hmei63"
+      className="fhmei63"
       role={null}
     >
       <a
         aria-label={undefined}
-        className="cf-32iz07"
+        className="f32iz07"
         href="#"
         onClick={[Function]}
       >
@@ -982,12 +1029,14 @@ exports[`should render with collapsed items 1`] = `
 `;
 
 exports[`should render with collapsed items 2`] = `
-".cf-y1rhga:after {
+"
+.fy1rhga:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-y1rhga {
+
+.fy1rhga {
   list-style: none;
   margin-top: 0px;
   margin-left: 0px;
@@ -1001,12 +1050,14 @@ exports[`should render with collapsed items 2`] = `
   border-radius: 3px;
   box-shadow: none
 }
-.cf-1bek1ug:after {
+
+.f1bek1ug:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-hmei63 {
+
+.fhmei63 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -1014,10 +1065,12 @@ exports[`should render with collapsed items 2`] = `
   cursor: pointer;
   border-radius: 3px
 }
-.cf-32iz07:focus {
+
+.f32iz07:focus {
   z-index: 1
 }
-.cf-32iz07 {
+
+.f32iz07 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -1032,14 +1085,16 @@ exports[`should render with collapsed items 2`] = `
   color: inherit;
   cursor: pointer
 }
-.cf-15spu1u {
+
+.f15spu1u {
   float: left;
   position: relative;
   background-color: #fff;
   color: #408BC9;
   cursor: pointer
 }
-.cf-1wi2cf1 {
+
+.f1wi2cf1 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -1048,10 +1103,12 @@ exports[`should render with collapsed items 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -1065,5 +1122,6 @@ exports[`should render with collapsed items 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;

--- a/packages/cf-component-box/test/Box.js
+++ b/packages/cf-component-box/test/Box.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render all props as styles', () => {
   const snapshot = felaSnapshot(

--- a/packages/cf-component-box/test/__snapshots__/Box.js.snap
+++ b/packages/cf-component-box/test/__snapshots__/Box.js.snap
@@ -2,14 +2,15 @@
 
 exports[`should render all props as styles 1`] = `
 <div
-  className="cf-k8v3yj"
+  className="fk8v3yj"
 >
   Box
 </div>
 `;
 
 exports[`should render all props as styles 2`] = `
-".cf-k8v3yj {
+"
+.fk8v3yj {
   border-width: 1px;
   border-style: solid;
   border-color: black;
@@ -23,5 +24,6 @@ exports[`should render all props as styles 2`] = `
   width: 6.666666666666667rem;
   min-height: 6.666666666666667rem;
   height: 6.666666666666667rem
-}"
+}
+"
 `;

--- a/packages/cf-component-button/test/Button.js
+++ b/packages/cf-component-button/test/Button.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 import { Button } from '../../cf-component-button/src/index';
 
 test('should render with type', () => {

--- a/packages/cf-component-button/test/ButtonGroup.js
+++ b/packages/cf-component-button/test/ButtonGroup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 import { ButtonGroup, Button } from '../../cf-component-button/src/index';
 
 test('should render', () => {

--- a/packages/cf-component-button/test/__snapshots__/Button.js.snap
+++ b/packages/cf-component-button/test/__snapshots__/Button.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should render as submit 1`] = `
 <button
-  className="cf-12tyf0k"
+  className="f12tyf0k"
   disabled={undefined}
   onClick={[Function]}
   type="submit"
@@ -12,25 +12,30 @@ exports[`should render as submit 1`] = `
 `;
 
 exports[`should render as submit 2`] = `
-".cf-12tyf0k:hover {
+"
+.f12tyf0k:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-12tyf0k:active {
+
+.f12tyf0k:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-12tyf0k:focus {
+
+.f12tyf0k:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-12tyf0k[title] {
+
+.f12tyf0k[title] {
   pointer-events: none
 }
-.cf-12tyf0k {
+
+.f12tyf0k {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -40,7 +45,7 @@ exports[`should render as submit 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -66,12 +71,13 @@ exports[`should render as submit 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;
 
 exports[`should render with loading 1`] = `
 <button
-  className="cf-nubafe"
+  className="fnubafe"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -81,37 +87,44 @@ exports[`should render with loading 1`] = `
 `;
 
 exports[`should render with loading 2`] = `
-"@-webkit-keyframes k1 {
+"
+@-webkit-keyframes k1 {
   50% {
     opacity: 0
   }
 }
+
 @-moz-keyframes k1 {
   50% {
     opacity: 0
   }
 }
+
 @keyframes k1 {
   50% {
     opacity: 0
   }
 }
-.cf-nubafe:hover {
+
+.fnubafe:hover {
   background-color: #ededed;
   border-color: #dbdbdb;
   color: #ededed
 }
-.cf-nubafe:active {
+
+.fnubafe:active {
   background-color: #215685;
   border-color: #dbdbdb;
   color: #fff
 }
-.cf-nubafe:focus {
+
+.fnubafe:focus {
   color: #ededed;
   outline: none;
   border-color: #dbdbdb
 }
-.cf-nubafe::before {
+
+.fnubafe::before {
   content: \\"…\\";
   color: black;
   display: block;
@@ -129,10 +142,12 @@ exports[`should render with loading 2`] = `
   animation-timing-function: linear;
   -webkit-animation-timing-function: linear
 }
-.cf-nubafe[title] {
+
+.fnubafe[title] {
   pointer-events: none
 }
-.cf-nubafe {
+
+.fnubafe {
   background-color: #ededed;
   border-bottom: 1px solid;
   border-color: #dbdbdb;
@@ -142,7 +157,7 @@ exports[`should render with loading 2`] = `
   color: #ededed;
   cursor: default;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -168,12 +183,13 @@ exports[`should render with loading 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;
 
 exports[`should render with loading and disabled overridden 1`] = `
 <button
-  className="cf-nubafe"
+  className="fnubafe"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -183,37 +199,44 @@ exports[`should render with loading and disabled overridden 1`] = `
 `;
 
 exports[`should render with loading and disabled overridden 2`] = `
-"@-webkit-keyframes k1 {
+"
+@-webkit-keyframes k1 {
   50% {
     opacity: 0
   }
 }
+
 @-moz-keyframes k1 {
   50% {
     opacity: 0
   }
 }
+
 @keyframes k1 {
   50% {
     opacity: 0
   }
 }
-.cf-nubafe:hover {
+
+.fnubafe:hover {
   background-color: #ededed;
   border-color: #dbdbdb;
   color: #ededed
 }
-.cf-nubafe:active {
+
+.fnubafe:active {
   background-color: #215685;
   border-color: #dbdbdb;
   color: #fff
 }
-.cf-nubafe:focus {
+
+.fnubafe:focus {
   color: #ededed;
   outline: none;
   border-color: #dbdbdb
 }
-.cf-nubafe::before {
+
+.fnubafe::before {
   content: \\"…\\";
   color: black;
   display: block;
@@ -231,10 +254,12 @@ exports[`should render with loading and disabled overridden 2`] = `
   animation-timing-function: linear;
   -webkit-animation-timing-function: linear
 }
-.cf-nubafe[title] {
+
+.fnubafe[title] {
   pointer-events: none
 }
-.cf-nubafe {
+
+.fnubafe {
   background-color: #ededed;
   border-bottom: 1px solid;
   border-color: #dbdbdb;
@@ -244,7 +269,7 @@ exports[`should render with loading and disabled overridden 2`] = `
   color: #ededed;
   cursor: default;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -270,12 +295,13 @@ exports[`should render with loading and disabled overridden 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;
 
 exports[`should render with type 1`] = `
 <button
-  className="cf-12tyf0k"
+  className="f12tyf0k"
   disabled={undefined}
   onClick={[Function]}
   type="button"
@@ -285,25 +311,30 @@ exports[`should render with type 1`] = `
 `;
 
 exports[`should render with type 2`] = `
-".cf-12tyf0k:hover {
+"
+.f12tyf0k:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-12tyf0k:active {
+
+.f12tyf0k:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-12tyf0k:focus {
+
+.f12tyf0k:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-12tyf0k[title] {
+
+.f12tyf0k[title] {
   pointer-events: none
 }
-.cf-12tyf0k {
+
+.f12tyf0k {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -313,7 +344,7 @@ exports[`should render with type 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -339,12 +370,13 @@ exports[`should render with type 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;
 
 exports[`should render with type/disabled 1`] = `
 <button
-  className="cf-bare0q"
+  className="fbare0q"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -354,25 +386,30 @@ exports[`should render with type/disabled 1`] = `
 `;
 
 exports[`should render with type/disabled 2`] = `
-".cf-bare0q:hover {
+"
+.fbare0q:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-bare0q:active {
+
+.fbare0q:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-bare0q:focus {
+
+.fbare0q:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-bare0q[title] {
+
+.fbare0q[title] {
   pointer-events: auto
 }
-.cf-bare0q {
+
+.fbare0q {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -382,7 +419,7 @@ exports[`should render with type/disabled 2`] = `
   color: #fff;
   cursor: default;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -408,5 +445,6 @@ exports[`should render with type/disabled 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;

--- a/packages/cf-component-button/test/__snapshots__/ButtonGroup.js.snap
+++ b/packages/cf-component-button/test/__snapshots__/ButtonGroup.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should render 1`] = `
 <div
-  className="cf-cmkk1"
+  className="fcmkk1"
 >
   Hello
 </div>
@@ -10,10 +10,10 @@ exports[`should render 1`] = `
 
 exports[`should render 1 button 1`] = `
 <div
-  className="cf-cmkk1"
+  className="fcmkk1"
 >
   <button
-    className="cf-8n1gf0"
+    className="f8n1gf0"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -24,31 +24,37 @@ exports[`should render 1 button 1`] = `
 `;
 
 exports[`should render 1 button 2`] = `
-".cf-cmkk1 {
+"
+.fcmkk1 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   white-space: nowrap
 }
-.cf-8n1gf0:hover {
+
+.f8n1gf0:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-8n1gf0:active {
+
+.f8n1gf0:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-8n1gf0:focus {
+
+.f8n1gf0:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-8n1gf0[title] {
+
+.f8n1gf0[title] {
   pointer-events: none
 }
-.cf-8n1gf0 {
+
+.f8n1gf0 {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -58,7 +64,7 @@ exports[`should render 1 button 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -87,24 +93,27 @@ exports[`should render 1 button 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;
 
 exports[`should render 2`] = `
-".cf-cmkk1 {
+"
+.fcmkk1 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   white-space: nowrap
-}"
+}
+"
 `;
 
 exports[`should render 2 buttons 1`] = `
 <div
-  className="cf-cmkk1"
+  className="fcmkk1"
 >
   <button
-    className="cf-iwt3vg"
+    className="fiwt3vg"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -112,7 +121,7 @@ exports[`should render 2 buttons 1`] = `
     Button
   </button>
   <button
-    className="cf-8n1gf0"
+    className="f8n1gf0"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -123,31 +132,37 @@ exports[`should render 2 buttons 1`] = `
 `;
 
 exports[`should render 2 buttons 2`] = `
-".cf-cmkk1 {
+"
+.fcmkk1 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   white-space: nowrap
 }
-.cf-iwt3vg:hover {
+
+.fiwt3vg:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-iwt3vg:active {
+
+.fiwt3vg:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-iwt3vg:focus {
+
+.fiwt3vg:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-iwt3vg[title] {
+
+.fiwt3vg[title] {
   pointer-events: none
 }
-.cf-iwt3vg {
+
+.fiwt3vg {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -157,7 +172,7 @@ exports[`should render 2 buttons 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -187,25 +202,30 @@ exports[`should render 2 buttons 2`] = `
   float: none;
   max-width: initial
 }
-.cf-8n1gf0:hover {
+
+.f8n1gf0:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-8n1gf0:active {
+
+.f8n1gf0:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-8n1gf0:focus {
+
+.f8n1gf0:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-8n1gf0[title] {
+
+.f8n1gf0[title] {
   pointer-events: none
 }
-.cf-8n1gf0 {
+
+.f8n1gf0 {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -215,7 +235,7 @@ exports[`should render 2 buttons 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -244,15 +264,16 @@ exports[`should render 2 buttons 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;
 
 exports[`should render 3 buttons 1`] = `
 <div
-  className="cf-cmkk1"
+  className="fcmkk1"
 >
   <button
-    className="cf-iwt3vg"
+    className="fiwt3vg"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -260,7 +281,7 @@ exports[`should render 3 buttons 1`] = `
     Button
   </button>
   <button
-    className="cf-5141ss"
+    className="f5141ss"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -268,7 +289,7 @@ exports[`should render 3 buttons 1`] = `
     Button
   </button>
   <button
-    className="cf-8n1gf0"
+    className="f8n1gf0"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -279,31 +300,37 @@ exports[`should render 3 buttons 1`] = `
 `;
 
 exports[`should render 3 buttons 2`] = `
-".cf-cmkk1 {
+"
+.fcmkk1 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   white-space: nowrap
 }
-.cf-iwt3vg:hover {
+
+.fiwt3vg:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-iwt3vg:active {
+
+.fiwt3vg:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-iwt3vg:focus {
+
+.fiwt3vg:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-iwt3vg[title] {
+
+.fiwt3vg[title] {
   pointer-events: none
 }
-.cf-iwt3vg {
+
+.fiwt3vg {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -313,7 +340,7 @@ exports[`should render 3 buttons 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -343,25 +370,30 @@ exports[`should render 3 buttons 2`] = `
   float: none;
   max-width: initial
 }
-.cf-5141ss:hover {
+
+.f5141ss:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-5141ss:active {
+
+.f5141ss:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-5141ss:focus {
+
+.f5141ss:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-5141ss[title] {
+
+.f5141ss[title] {
   pointer-events: none
 }
-.cf-5141ss {
+
+.f5141ss {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -371,7 +403,7 @@ exports[`should render 3 buttons 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -401,25 +433,30 @@ exports[`should render 3 buttons 2`] = `
   float: none;
   max-width: initial
 }
-.cf-8n1gf0:hover {
+
+.f8n1gf0:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-8n1gf0:active {
+
+.f8n1gf0:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-8n1gf0:focus {
+
+.f8n1gf0:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-8n1gf0[title] {
+
+.f8n1gf0[title] {
   pointer-events: none
 }
-.cf-8n1gf0 {
+
+.f8n1gf0 {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -429,7 +466,7 @@ exports[`should render 3 buttons 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -458,15 +495,16 @@ exports[`should render 3 buttons 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;
 
 exports[`should render 3 buttons with spacing 1`] = `
 <div
-  className="cf-cmkk1"
+  className="fcmkk1"
 >
   <button
-    className="cf-12tyf0k"
+    className="f12tyf0k"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -474,7 +512,7 @@ exports[`should render 3 buttons with spacing 1`] = `
     Button
   </button>
   <button
-    className="cf-1n7ummk"
+    className="f1n7ummk"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -482,7 +520,7 @@ exports[`should render 3 buttons with spacing 1`] = `
     Button
   </button>
   <button
-    className="cf-1n7ummk"
+    className="f1n7ummk"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -493,31 +531,37 @@ exports[`should render 3 buttons with spacing 1`] = `
 `;
 
 exports[`should render 3 buttons with spacing 2`] = `
-".cf-cmkk1 {
+"
+.fcmkk1 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   white-space: nowrap
 }
-.cf-12tyf0k:hover {
+
+.f12tyf0k:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-12tyf0k:active {
+
+.f12tyf0k:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-12tyf0k:focus {
+
+.f12tyf0k:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-12tyf0k[title] {
+
+.f12tyf0k[title] {
   pointer-events: none
 }
-.cf-12tyf0k {
+
+.f12tyf0k {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -527,7 +571,7 @@ exports[`should render 3 buttons with spacing 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -554,25 +598,30 @@ exports[`should render 3 buttons with spacing 2`] = `
   float: none;
   max-width: initial
 }
-.cf-1n7ummk:hover {
+
+.f1n7ummk:hover {
   background-color: #2869a2;
   border-color: #215685;
   color: #fff
 }
-.cf-1n7ummk:active {
+
+.f1n7ummk:active {
   background-color: #215685;
   border-color: #1a4468;
   color: #fff
 }
-.cf-1n7ummk:focus {
+
+.f1n7ummk:focus {
   background-color: #2f7bbf;
   color: #fff;
   border-color: #2869a2
 }
-.cf-1n7ummk[title] {
+
+.f1n7ummk[title] {
   pointer-events: none
 }
-.cf-1n7ummk {
+
+.f1n7ummk {
   background-color: #2f7bbf;
   border-bottom: 1px solid;
   border-color: #2869a2;
@@ -582,7 +631,7 @@ exports[`should render 3 buttons with spacing 2`] = `
   color: #fff;
   cursor: pointer;
   display: inline-block;
-  font-family: \\"Open Sans\\",Helvetica,Arial,sans-serif;
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif;
   font-size: 0.9333333333333333rem;
   font-weight: 400;
   line-height: 1.2;
@@ -608,5 +657,6 @@ exports[`should render 3 buttons with spacing 2`] = `
   -ms-user-select: none;
   float: none;
   max-width: initial
-}"
+}
+"
 `;

--- a/packages/cf-component-form/test/Form.js
+++ b/packages/cf-component-form/test/Form.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Form } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render horizontal layout', () => {
   const snapshot = felaSnapshot(

--- a/packages/cf-component-form/test/FormFieldError.js
+++ b/packages/cf-component-form/test/FormFieldError.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { FormFieldError } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
-import felaTestContext from 'cf-style-provider/src/felaTestContext';
+import { felaSnapshot } from 'cf-style-provider';
+import { felaTestContext } from 'cf-style-provider';
 
 test('should render valid state', () => {
   expect(

--- a/packages/cf-component-form/test/FormFieldset.js
+++ b/packages/cf-component-form/test/FormFieldset.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormFieldset } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(

--- a/packages/cf-component-form/test/FormFooter.js
+++ b/packages/cf-component-form/test/FormFooter.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormFooter } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(<FormFooter>FormFooter</FormFooter>);

--- a/packages/cf-component-form/test/FormHeader.js
+++ b/packages/cf-component-form/test/FormHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormHeader } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(<FormHeader title="FormHeader" />);

--- a/packages/cf-component-form/test/FormLabel.js
+++ b/packages/cf-component-form/test/FormLabel.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormLabel } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(<FormLabel>FormLabel</FormLabel>);

--- a/packages/cf-component-form/test/__snapshots__/Form.js.snap
+++ b/packages/cf-component-form/test/__snapshots__/Form.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should render horizontal layout 1`] = `
 <form
-  className="cf-19lc4xi"
+  className="f19lc4xi"
   onSubmit={[Function]}
 >
   Form
@@ -10,15 +10,17 @@ exports[`should render horizontal layout 1`] = `
 `;
 
 exports[`should render horizontal layout 2`] = `
-".cf-19lc4xi {
+"
+.f19lc4xi {
   border: 1px solid #dedede;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05)
-}"
+}
+"
 `;
 
 exports[`should render vertical layout 1`] = `
 <form
-  className="cf-19lc4xi"
+  className="f19lc4xi"
   onSubmit={[Function]}
 >
   Form
@@ -26,8 +28,10 @@ exports[`should render vertical layout 1`] = `
 `;
 
 exports[`should render vertical layout 2`] = `
-".cf-19lc4xi {
+"
+.f19lc4xi {
   border: 1px solid #dedede;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05)
-}"
+}
+"
 `;

--- a/packages/cf-component-form/test/__snapshots__/FormFieldError.js.snap
+++ b/packages/cf-component-form/test/__snapshots__/FormFieldError.js.snap
@@ -2,12 +2,13 @@
 
 exports[`should render invalid state 1`] = `
 <div
-  className="cf-lzhvgp"
+  className="flzhvgp"
 />
 `;
 
 exports[`should render invalid state 2`] = `
-".cf-lzhvgp::before {
+"
+.flzhvgp::before {
   content: \\"\\";
   display: block;
   position: absolute;
@@ -18,7 +19,8 @@ exports[`should render invalid state 2`] = `
   border-width: 6px;
   border-bottom-color: #bd2527
 }
-.cf-lzhvgp::after {
+
+.flzhvgp::after {
   content: \\"\\";
   display: block;
   position: absolute;
@@ -29,18 +31,21 @@ exports[`should render invalid state 2`] = `
   border-width: 4px;
   border-bottom-color: #bd2527
 }
-.cf-lzhvgp p {
+
+.flzhvgp p {
   margin-top: 0px;
   margin-bottom: 0px
 }
-.cf-lzhvgp p + p {
+
+.flzhvgp p + p {
   margin-top: 0.5em
 }
-.cf-lzhvgp {
+
+.flzhvgp {
   position: relative;
   margin-top: -0.75em;
   padding: 0.5em 1em;
-  border: 1px solid #9f1f21;
+  border: 1px solid  #9f1f21;
   font-size: 0.8em;
   font-weight: 600;
   background: #bd2527;
@@ -48,12 +53,13 @@ exports[`should render invalid state 2`] = `
   border-radius: 2px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
   -webkit-font-smoothing: antialiased
-}"
+}
+"
 `;
 
 exports[`should render invalid state with validation errors 1`] = `
 <div
-  className="cf-lzhvgp"
+  className="flzhvgp"
 >
   <p>
     This is required
@@ -62,7 +68,8 @@ exports[`should render invalid state with validation errors 1`] = `
 `;
 
 exports[`should render invalid state with validation errors 2`] = `
-".cf-lzhvgp::before {
+"
+.flzhvgp::before {
   content: \\"\\";
   display: block;
   position: absolute;
@@ -73,7 +80,8 @@ exports[`should render invalid state with validation errors 2`] = `
   border-width: 6px;
   border-bottom-color: #bd2527
 }
-.cf-lzhvgp::after {
+
+.flzhvgp::after {
   content: \\"\\";
   display: block;
   position: absolute;
@@ -84,18 +92,21 @@ exports[`should render invalid state with validation errors 2`] = `
   border-width: 4px;
   border-bottom-color: #bd2527
 }
-.cf-lzhvgp p {
+
+.flzhvgp p {
   margin-top: 0px;
   margin-bottom: 0px
 }
-.cf-lzhvgp p + p {
+
+.flzhvgp p + p {
   margin-top: 0.5em
 }
-.cf-lzhvgp {
+
+.flzhvgp {
   position: relative;
   margin-top: -0.75em;
   padding: 0.5em 1em;
-  border: 1px solid #9f1f21;
+  border: 1px solid  #9f1f21;
   font-size: 0.8em;
   font-weight: 600;
   background: #bd2527;
@@ -103,5 +114,6 @@ exports[`should render invalid state with validation errors 2`] = `
   border-radius: 2px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
   -webkit-font-smoothing: antialiased
-}"
+}
+"
 `;

--- a/packages/cf-component-form/test/__snapshots__/FormFieldset.js.snap
+++ b/packages/cf-component-form/test/__snapshots__/FormFieldset.js.snap
@@ -2,15 +2,15 @@
 
 exports[`should render 1`] = `
 <fieldset
-  className="cf-1nadb32"
+  className="f1nadb32"
 >
   <legend
-    className="cf-1peqvck"
+    className="f1peqvck"
   >
     Legend
   </legend>
   <div
-    className="cf-1culcac"
+    className="f1culcac"
   >
     FormFieldset
   </div>
@@ -18,12 +18,14 @@ exports[`should render 1`] = `
 `;
 
 exports[`should render 2`] = `
-".cf-1nadb32::after {
+"
+.f1nadb32::after {
   clear: both;
   content: \\"\\";
   display: table
 }
-.cf-1nadb32 {
+
+.f1nadb32 {
   margin: 0px;
   padding: 0px;
   border-top: none;
@@ -31,30 +33,35 @@ exports[`should render 2`] = `
   border-right: none;
   border-bottom: 1px solid #dedede
 }
-.cf-1peqvck {
+
+.f1peqvck {
   padding: 1em;
   margin-bottom: 0px;
   border-bottom: none
 }
-.cf-1culcac {
+
+.f1culcac {
   padding: 1em;
   border: 0 solid #dedede;
   border-top-width: 1px;
   background: #eee
 }
+
 @media (min-width: 720px) {
-  .cf-1peqvck {
+  .f1peqvck {
     width: 30%;
     float: left;
     padding: 1.7em 1rem;
     color: #333;
     text-align: right
   }
-  .cf-1culcac {
+  
+  .f1culcac {
     width: 70%;
     float: left;
     border-top-width: 0px;
     border-left-width: 0px
   }
-}"
+}
+"
 `;

--- a/packages/cf-component-form/test/__snapshots__/FormFooter.js.snap
+++ b/packages/cf-component-form/test/__snapshots__/FormFooter.js.snap
@@ -2,16 +2,18 @@
 
 exports[`should render 1`] = `
 <div
-  className="cf-2idotc"
+  className="f2idotc"
 >
   FormFooter
 </div>
 `;
 
 exports[`should render 2`] = `
-".cf-2idotc {
+"
+.f2idotc {
   padding: 1em;
   border-top: 1px solid #dedede;
   text-align: right
-}"
+}
+"
 `;

--- a/packages/cf-component-form/test/__snapshots__/FormHeader.js.snap
+++ b/packages/cf-component-form/test/__snapshots__/FormHeader.js.snap
@@ -2,10 +2,10 @@
 
 exports[`should render 1`] = `
 <div
-  className="cf-1sgbk2q"
+  className="f1sgbk2q"
 >
   <h3
-    className="cf-oxs2bj"
+    className="foxs2bj"
   >
     FormHeader
   </h3>
@@ -13,11 +13,14 @@ exports[`should render 1`] = `
 `;
 
 exports[`should render 2`] = `
-".cf-1sgbk2q {
+"
+.f1sgbk2q {
   padding: 1em;
   border-bottom: 1px solid #dedede
 }
-.cf-oxs2bj {
+
+.foxs2bj {
   margin: 0px
-}"
+}
+"
 `;

--- a/packages/cf-component-form/test/__snapshots__/FormLabel.js.snap
+++ b/packages/cf-component-form/test/__snapshots__/FormLabel.js.snap
@@ -2,34 +2,38 @@
 
 exports[`should render 1`] = `
 <label
-  className="cf-1f9r163"
+  className="f1f9r163"
 >
   FormLabel
 </label>
 `;
 
 exports[`should render 2`] = `
-".cf-1f9r163 {
+"
+.f1f9r163 {
   font-size: 0.8666666666666667em;
   display: block;
   margin-bottom: 0.2em;
   color: #333
-}"
+}
+"
 `;
 
 exports[`should render hidden 1`] = `
 <label
-  className="cf-1f1cr8o"
+  className="f1f1cr8o"
 >
   FormLabel
 </label>
 `;
 
 exports[`should render hidden 2`] = `
-".cf-1f1cr8o {
+"
+.f1f1cr8o {
   font-size: 0.8666666666666667em;
   display: none;
   margin-bottom: 0.2em;
   color: #333
-}"
+}
+"
 `;

--- a/packages/cf-component-heading/test/Heading.js
+++ b/packages/cf-component-heading/test/Heading.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Heading } from '../../cf-component-heading/src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render size', () => {
   const snapshot = felaSnapshot(<Heading size={2}>Heading</Heading>);

--- a/packages/cf-component-heading/test/HeadingCaption.js
+++ b/packages/cf-component-heading/test/HeadingCaption.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { HeadingCaption } from '../../cf-component-heading/src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(

--- a/packages/cf-component-heading/test/__snapshots__/Heading.js.snap
+++ b/packages/cf-component-heading/test/__snapshots__/Heading.js.snap
@@ -2,19 +2,21 @@
 
 exports[`should render size 1`] = `
 <h2
-  className="cf-1y93kqw"
+  className="f1y93kqw"
 >
   Heading
 </h2>
 `;
 
 exports[`should render size 2`] = `
-".cf-1y93kqw {
+"
+.f1y93kqw {
   font-size: 1.6rem;
   line-height: 1.3;
   padding-top: 0px;
   padding-bottom: 0px;
   padding-left: 0px;
   padding-right: 0px
-}"
+}
+"
 `;

--- a/packages/cf-component-heading/test/__snapshots__/HeadingCaption.js.snap
+++ b/packages/cf-component-heading/test/__snapshots__/HeadingCaption.js.snap
@@ -2,17 +2,19 @@
 
 exports[`should render 1`] = `
 <small
-  className="cf-1d38fhm"
+  className="f1d38fhm"
 >
   Heading Caption
 </small>
 `;
 
 exports[`should render 2`] = `
-".cf-1d38fhm {
+"
+.f1d38fhm {
   color: #7c7c7c;
   font-color: #333;
   font-weight: 400;
   margin-left: .5em
-}"
+}
+"
 `;

--- a/packages/cf-component-label/test/Label.js
+++ b/packages/cf-component-label/test/Label.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 import { Label } from '../../cf-component-label/src/index';
 
 test('should render', () => {

--- a/packages/cf-component-label/test/__snapshots__/Label.js.snap
+++ b/packages/cf-component-label/test/__snapshots__/Label.js.snap
@@ -2,14 +2,15 @@
 
 exports[`should render 1`] = `
 <span
-  className="cf-1gcgiur"
+  className="f1gcgiur"
 >
   A Label
 </span>
 `;
 
 exports[`should render 2`] = `
-".cf-1gcgiur {
+"
+.f1gcgiur {
   border-radius: 2px;
   color: #fff;
   display: inline-block;
@@ -29,5 +30,6 @@ exports[`should render 2`] = `
   -webkit-text-stroke: 0px;
   white-space: nowrap;
   background-color: #7D7D7D
-}"
+}
+"
 `;

--- a/packages/cf-component-modal/test/ModalTitle.js
+++ b/packages/cf-component-modal/test/ModalTitle.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ModalTitle } from '../../cf-component-modal/src/index';
 import { Heading } from '../../cf-component-heading/src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(<ModalTitle>ModalTitle</ModalTitle>);

--- a/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
+++ b/packages/cf-component-modal/test/__snapshots__/ModalTitle.js.snap
@@ -12,4 +12,8 @@ exports[`should render 1`] = `
 </div>
 `;
 
-exports[`should render 2`] = `""`;
+exports[`should render 2`] = `
+"
+
+"
+`;

--- a/packages/cf-component-page/test/Page.js
+++ b/packages/cf-component-page/test/Page.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { Page } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(<Page>Hello World</Page>);

--- a/packages/cf-component-page/test/PageContent.js
+++ b/packages/cf-component-page/test/PageContent.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { PageContent } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(<PageContent>Hello World</PageContent>);

--- a/packages/cf-component-page/test/PageHeader.js
+++ b/packages/cf-component-page/test/PageHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { PageHeader } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render title', () => {
   const snapshot = felaSnapshot(<PageHeader title="Title" />);

--- a/packages/cf-component-page/test/__snapshots__/Page.js.snap
+++ b/packages/cf-component-page/test/__snapshots__/Page.js.snap
@@ -2,20 +2,23 @@
 
 exports[`should render 1`] = `
 <article
-  className="cf-lb8cdc"
+  className="flb8cdc"
 >
   Hello World
 </article>
 `;
 
 exports[`should render 2`] = `
-".cf-lb8cdc {
+"
+.flb8cdc {
   padding-top: 2.5rem;
   padding-bottom: 2.5rem
 }
+
 @media (min-width: 47.2em) {
-  .cf-lb8cdc {
+  .flb8cdc {
     padding-bottom: 1.3rem
   }
-}"
+}
+"
 `;

--- a/packages/cf-component-page/test/__snapshots__/PageContent.js.snap
+++ b/packages/cf-component-page/test/__snapshots__/PageContent.js.snap
@@ -2,40 +2,47 @@
 
 exports[`should render 1`] = `
 <div
-  className="cf-10xznom"
+  className="f10xznom"
 >
   Hello World
 </div>
 `;
 
 exports[`should render 2`] = `
-".cf-10xznom {
+"
+.f10xznom {
   margin-left: auto;
   margin-right: auto
 }
+
 @media (min-width: 13.6em) {
-  .cf-10xznom {
+  .f10xznom {
     width: 13.6em
   }
 }
+
 @media (min-width: 30.4em) {
-  .cf-10xznom {
+  .f10xznom {
     width: 30.4em
   }
 }
+
 @media (min-width: 47.2em) {
-  .cf-10xznom {
+  .f10xznom {
     width: 47.2em
   }
 }
+
 @media (min-width: 64em) {
-  .cf-10xznom {
+  .f10xznom {
     width: 64em
   }
 }
+
 @media (min-width: 97.6em) {
-  .cf-10xznom {
+  .f10xznom {
     width: 97.6em
   }
-}"
+}
+"
 `;

--- a/packages/cf-component-page/test/__snapshots__/PageHeader.js.snap
+++ b/packages/cf-component-page/test/__snapshots__/PageHeader.js.snap
@@ -5,7 +5,7 @@ exports[`should render title 1`] = `
   className=""
 >
   <h1
-    className="cf-10h3ujg"
+    className="f10h3ujg"
   >
     Title
   </h1>
@@ -13,11 +13,13 @@ exports[`should render title 1`] = `
 `;
 
 exports[`should render title 2`] = `
-".cf-10h3ujg {
+"
+.f10h3ujg {
   font-size: 2rem;
   line-height: 1.2;
   font-weight: 400
-}"
+}
+"
 `;
 
 exports[`should render title/subtitle 1`] = `
@@ -25,12 +27,12 @@ exports[`should render title/subtitle 1`] = `
   className=""
 >
   <h1
-    className="cf-10h3ujg"
+    className="f10h3ujg"
   >
     Title
   </h1>
   <h2
-    className="cf-jjd3ph"
+    className="fjjd3ph"
   >
     Subtitle
   </h2>
@@ -38,13 +40,16 @@ exports[`should render title/subtitle 1`] = `
 `;
 
 exports[`should render title/subtitle 2`] = `
-".cf-10h3ujg {
+"
+.f10h3ujg {
   font-size: 2rem;
   line-height: 1.2;
   font-weight: 400
 }
-.cf-jjd3ph {
+
+.fjjd3ph {
   color: #7c7c7c;
   font-weight: 300
-}"
+}
+"
 `;

--- a/packages/cf-component-pagination/test/Pagination.js
+++ b/packages/cf-component-pagination/test/Pagination.js
@@ -3,7 +3,7 @@ import {
   Pagination,
   PaginationRoot
 } from '../../cf-component-pagination/src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(

--- a/packages/cf-component-pagination/test/PaginationItem.js
+++ b/packages/cf-component-pagination/test/PaginationItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PaginationItem } from '../../cf-component-pagination/src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render', () => {
   const snapshot = felaSnapshot(

--- a/packages/cf-component-pagination/test/__snapshots__/Pagination.js.snap
+++ b/packages/cf-component-pagination/test/__snapshots__/Pagination.js.snap
@@ -2,11 +2,11 @@
 
 exports[`should render 1`] = `
 <div
-  className="cf-1bek1ug"
+  className="f1bek1ug"
 >
   <ul
     aria-describedby={null}
-    className="cf-y1rhga"
+    className="fy1rhga"
     role="navigation"
   >
     Pagination
@@ -15,12 +15,14 @@ exports[`should render 1`] = `
 `;
 
 exports[`should render 2`] = `
-".cf-y1rhga:after {
+"
+.fy1rhga:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-y1rhga {
+
+.fy1rhga {
   list-style: none;
   margin-top: 0px;
   margin-left: 0px;
@@ -34,20 +36,22 @@ exports[`should render 2`] = `
   border-radius: 3px;
   box-shadow: none
 }
-.cf-1bek1ug:after {
+
+.f1bek1ug:after {
   content: \\"\\";
   display: table;
   clear: both
-}"
+}
+"
 `;
 
 exports[`should render with info 1`] = `
 <div
-  className="cf-1bek1ug"
+  className="f1bek1ug"
 >
   <ul
     aria-describedby="cf-pagination-1"
-    className="cf-y1rhga"
+    className="fy1rhga"
     role="navigation"
   >
     Pagination
@@ -61,12 +65,14 @@ exports[`should render with info 1`] = `
 `;
 
 exports[`should render with info 2`] = `
-".cf-y1rhga:after {
+"
+.fy1rhga:after {
   content: \\"\\";
   display: table;
   clear: both
 }
-.cf-y1rhga {
+
+.fy1rhga {
   list-style: none;
   margin-top: 0px;
   margin-left: 0px;
@@ -80,9 +86,11 @@ exports[`should render with info 2`] = `
   border-radius: 3px;
   box-shadow: none
 }
-.cf-1bek1ug:after {
+
+.f1bek1ug:after {
   content: \\"\\";
   display: table;
   clear: both
-}"
+}
+"
 `;

--- a/packages/cf-component-pagination/test/__snapshots__/PaginationItem.js.snap
+++ b/packages/cf-component-pagination/test/__snapshots__/PaginationItem.js.snap
@@ -2,12 +2,12 @@
 
 exports[`should render 1`] = `
 <li
-  className="cf-15spu1u"
+  className="f15spu1u"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-32iz07"
+    className="f32iz07"
     href="#"
     onClick={[Function]}
   >
@@ -17,17 +17,20 @@ exports[`should render 1`] = `
 `;
 
 exports[`should render 2`] = `
-".cf-15spu1u {
+"
+.f15spu1u {
   float: left;
   position: relative;
   background-color: #fff;
   color: #408BC9;
   cursor: pointer
 }
-.cf-32iz07:focus {
+
+.f32iz07:focus {
   z-index: 1
 }
-.cf-32iz07 {
+
+.f32iz07 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -41,17 +44,18 @@ exports[`should render 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: pointer
-}"
+}
+"
 `;
 
 exports[`should render active 1`] = `
 <li
-  className="cf-1wi2cf1"
+  className="f1wi2cf1"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-109b087"
+    className="f109b087"
     href="#"
     onClick={[Function]}
   >
@@ -61,7 +65,8 @@ exports[`should render active 1`] = `
 `;
 
 exports[`should render active 2`] = `
-".cf-1wi2cf1 {
+"
+.f1wi2cf1 {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -70,10 +75,12 @@ exports[`should render active 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -87,17 +94,18 @@ exports[`should render active 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;
 
 exports[`should render active dot 1`] = `
 <li
-  className="cf-1xpv85q"
+  className="f1xpv85q"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-109b087"
+    className="f109b087"
     href="#"
     onClick={[Function]}
   >
@@ -107,7 +115,8 @@ exports[`should render active dot 1`] = `
 `;
 
 exports[`should render active dot 2`] = `
-".cf-1xpv85q {
+"
+.f1xpv85q {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -121,10 +130,12 @@ exports[`should render active dot 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -138,17 +149,18 @@ exports[`should render active dot 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;
 
 exports[`should render active next 1`] = `
 <li
-  className="cf-1ezx84k"
+  className="f1ezx84k"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-109b087"
+    className="f109b087"
     href="#"
     onClick={[Function]}
   >
@@ -158,7 +170,8 @@ exports[`should render active next 1`] = `
 `;
 
 exports[`should render active next 2`] = `
-".cf-1ezx84k {
+"
+.f1ezx84k {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -168,10 +181,12 @@ exports[`should render active next 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -185,17 +200,18 @@ exports[`should render active next 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;
 
 exports[`should render active prev 1`] = `
 <li
-  className="cf-1ezx84k"
+  className="f1ezx84k"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-109b087"
+    className="f109b087"
     href="#"
     onClick={[Function]}
   >
@@ -205,7 +221,8 @@ exports[`should render active prev 1`] = `
 `;
 
 exports[`should render active prev 2`] = `
-".cf-1ezx84k {
+"
+.f1ezx84k {
   float: left;
   position: relative;
   background-color: #408BC9;
@@ -215,10 +232,12 @@ exports[`should render active prev 2`] = `
   border-color: #62a1d8;
   z-index: 1
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -232,17 +251,18 @@ exports[`should render active prev 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;
 
 exports[`should render disabled 1`] = `
 <li
-  className="cf-yr93k7"
+  className="fyr93k7"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-109b087"
+    className="f109b087"
     href="#"
     onClick={[Function]}
   >
@@ -252,17 +272,20 @@ exports[`should render disabled 1`] = `
 `;
 
 exports[`should render disabled 2`] = `
-".cf-yr93k7 {
+"
+.fyr93k7 {
   float: left;
   position: relative;
   background-color: #ededed;
   color: #666;
   cursor: default
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -276,17 +299,18 @@ exports[`should render disabled 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;
 
 exports[`should render disabled dot 1`] = `
 <li
-  className="cf-18awel0"
+  className="f18awel0"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-109b087"
+    className="f109b087"
     href="#"
     onClick={[Function]}
   >
@@ -296,7 +320,8 @@ exports[`should render disabled dot 1`] = `
 `;
 
 exports[`should render disabled dot 2`] = `
-".cf-18awel0 {
+"
+.f18awel0 {
   float: left;
   position: relative;
   background-color: #ededed;
@@ -308,10 +333,12 @@ exports[`should render disabled dot 2`] = `
   margin: 1em;
   border-radius: 50%
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -325,17 +352,18 @@ exports[`should render disabled dot 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;
 
 exports[`should render disabled next 1`] = `
 <li
-  className="cf-mgj6am"
+  className="fmgj6am"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-109b087"
+    className="f109b087"
     href="#"
     onClick={[Function]}
   >
@@ -345,7 +373,8 @@ exports[`should render disabled next 1`] = `
 `;
 
 exports[`should render disabled next 2`] = `
-".cf-mgj6am {
+"
+.fmgj6am {
   float: left;
   position: relative;
   background-color: #ededed;
@@ -353,10 +382,12 @@ exports[`should render disabled next 2`] = `
   cursor: default;
   border-radius: 3px
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -370,17 +401,18 @@ exports[`should render disabled next 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;
 
 exports[`should render disabled prev 1`] = `
 <li
-  className="cf-mgj6am"
+  className="fmgj6am"
   role={null}
 >
   <a
     aria-label={undefined}
-    className="cf-109b087"
+    className="f109b087"
     href="#"
     onClick={[Function]}
   >
@@ -390,7 +422,8 @@ exports[`should render disabled prev 1`] = `
 `;
 
 exports[`should render disabled prev 2`] = `
-".cf-mgj6am {
+"
+.fmgj6am {
   float: left;
   position: relative;
   background-color: #ededed;
@@ -398,10 +431,12 @@ exports[`should render disabled prev 2`] = `
   cursor: default;
   border-radius: 3px
 }
-.cf-109b087:focus {
+
+.f109b087:focus {
   z-index: 1
 }
-.cf-109b087 {
+
+.f109b087 {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -415,5 +450,6 @@ exports[`should render disabled prev 2`] = `
   text-decoration: none;
   color: inherit;
   cursor: default
-}"
+}
+"
 `;

--- a/packages/cf-component-text/test/Text.js
+++ b/packages/cf-component-text/test/Text.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, TextUnstyled } from '../../cf-component-text/src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 import { applyTheme } from 'cf-style-container';
 
 test('should render normal size', () => {

--- a/packages/cf-component-text/test/__snapshots__/Text.js.snap
+++ b/packages/cf-component-text/test/__snapshots__/Text.js.snap
@@ -2,115 +2,131 @@
 
 exports[`should render align 1`] = `
 <div
-  className="cf-12kp2av"
+  className="f12kp2av"
 >
   Hello
 </div>
 `;
 
 exports[`should render align 2`] = `
-".cf-12kp2av {
+"
+.f12kp2av {
   text-align: center
-}"
+}
+"
 `;
 
 exports[`should render bold size 1`] = `
 <div
-  className="cf-e0qi9f"
+  className="fe0qi9f"
 >
   Hello
 </div>
 `;
 
 exports[`should render bold size 2`] = `
-".cf-e0qi9f {
+"
+.fe0qi9f {
   font-size: 1rem;
   font-weight: 700
-}"
+}
+"
 `;
 
 exports[`should render lowercase 1`] = `
 <div
-  className="cf-1ez8i2i"
+  className="f1ez8i2i"
 >
   Hello
 </div>
 `;
 
 exports[`should render lowercase 2`] = `
-".cf-1ez8i2i {
+"
+.f1ez8i2i {
   text-transform: lowercase
-}"
+}
+"
 `;
 
 exports[`should render normal size 1`] = `
 <div
-  className="cf-jgz5pd"
+  className="fjgz5pd"
 >
   Hello
 </div>
 `;
 
 exports[`should render normal size 2`] = `
-".cf-jgz5pd {
+"
+.fjgz5pd {
   font-size: 1rem
-}"
+}
+"
 `;
 
 exports[`should render semi-bold size 1`] = `
 <div
-  className="cf-z310y"
+  className="fz310y"
 >
   Hello
 </div>
 `;
 
 exports[`should render semi-bold size 2`] = `
-".cf-z310y {
+"
+.fz310y {
   font-size: 1rem;
   font-weight: 600
-}"
+}
+"
 `;
 
 exports[`should render small size 1`] = `
 <div
-  className="cf-xk5sq7"
+  className="fxk5sq7"
 >
   Hello
 </div>
 `;
 
 exports[`should render small size 2`] = `
-".cf-xk5sq7 {
+"
+.fxk5sq7 {
   line-height: 1.3;
   font-size: 0.8em
-}"
+}
+"
 `;
 
 exports[`should render titlecase case 1`] = `
 <div
-  className="cf-w04jx1"
+  className="fw04jx1"
 >
   Hello
 </div>
 `;
 
 exports[`should render titlecase case 2`] = `
-".cf-w04jx1:first-letter {
+"
+.fw04jx1:first-letter {
   text-transform: capitalize
-}"
+}
+"
 `;
 
 exports[`should render type 1`] = `
 <div
-  className="cf-1vjexbg"
+  className="f1vjexbg"
 >
   Hello
 </div>
 `;
 
 exports[`should render type 2`] = `
-".cf-1vjexbg {
+"
+.f1vjexbg {
   color: #434148
-}"
+}
+"
 `;

--- a/packages/cf-style-container/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-container/test/__snapshots__/index.js.snap
@@ -6,25 +6,32 @@ exports[`createComponent creates empty component 1`] = `
 />
 `;
 
-exports[`createComponent creates empty component 2`] = `""`;
+exports[`createComponent creates empty component 2`] = `
+"
+
+"
+`;
 
 exports[`createComponentStyles creates a component 1`] = `
 <div
-  className="cf-dxtwdx"
+  className="fdxtwdx"
 >
   <i
-    className="cf-18oup6l"
+    className="f18oup6l"
   />
 </div>
 `;
 
 exports[`createComponentStyles creates a component 2`] = `
-".cf-dxtwdx {
+"
+.fdxtwdx {
   padding: 5px
 }
-.cf-18oup6l {
+
+.f18oup6l {
   margin: 2px
-}"
+}
+"
 `;
 
 exports[`mergeThemes should override the baseTheme if more than one theme is provided 1`] = `

--- a/packages/cf-style-container/test/index.js
+++ b/packages/cf-style-container/test/index.js
@@ -8,7 +8,7 @@ import {
   mapChildren
 } from '../../cf-style-container/src/index';
 import { variables } from 'cf-style-const';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('mergeThemes should return an immutable and deeply cloned object', () => {
   const themeA = () => ({ color: 'yellow' });

--- a/packages/cf-style-provider/README.md
+++ b/packages/cf-style-provider/README.md
@@ -65,7 +65,7 @@ deep path to acccess it.
 
 ```js
 import { mount } from 'enzyme';
-import felaTestContext from 'cf-style-provider/src/felaTestContext';
+import { felaTestContext } from 'cf-style-provider';
 
 test('should call onPageChange when clicking another page', () => {
   const onPageChange = createStub();
@@ -97,7 +97,7 @@ path to acccess it.
 ```js
 import React from 'react';
 import { Form } from '../src/index';
-import felaSnapshot from 'cf-style-provider/src/felaSnapshot';
+import { felaSnapshot } from 'cf-style-provider';
 
 test('should render horizontal layout', () => {
   const snapshot = felaSnapshot(

--- a/packages/cf-style-provider/package.json
+++ b/packages/cf-style-provider/package.json
@@ -13,11 +13,9 @@
   "dependencies": {
     "cf-style-const": "^1.6.2",
     "cf-style-container": "^1.3.2",
-    "clean-css": "^4.1.4",
-    "cssbeautify": "^0.3.1",
     "fela": "^5.0.0",
     "fela-beautifier": "^5.0.0",
-    "fela-monolithic": "^5.0.0",
+    "fela-monolithic": "^5.0.2",
     "fela-plugin-embedded": "^5.0.0",
     "fela-plugin-fallback-value": "^5.0.0",
     "fela-plugin-lvha": "^5.0.0",
@@ -26,7 +24,6 @@
     "fela-plugin-unit": "^5.0.0",
     "fela-plugin-validator": "^5.0.0",
     "inline-style-prefixer": "^3.0.5",
-    "js-beautify": "^1.6.14",
     "prop-types": "^15.5.8",
     "react-fela": "^5.0.0",
     "react-test-renderer": "^15.6.1"

--- a/packages/cf-style-provider/src/createRenderer.js
+++ b/packages/cf-style-provider/src/createRenderer.js
@@ -11,7 +11,6 @@ import namedMediaQuery from 'fela-plugin-named-media-query';
 import { variables } from 'cf-style-const';
 
 const defaultOpts = {
-  selectorPrefix: 'cf-',
   dev: false
 };
 
@@ -41,8 +40,7 @@ const createRenderer = opts => {
 
   return createFelaRenderer({
     plugins,
-    enhancers,
-    selectorPrefix: usedOpts.selectorPrefix
+    enhancers
   });
 };
 

--- a/packages/cf-style-provider/src/felaSnapshot.js
+++ b/packages/cf-style-provider/src/felaSnapshot.js
@@ -1,20 +1,29 @@
 import renderer from 'react-test-renderer';
-import { html as beautify } from 'js-beautify';
-import CleanCSS from 'clean-css';
+import perfectionist from 'perfectionist';
 import felaTestContext from './felaTestContext';
 import createRenderer from './createRenderer';
-
-const cssCleaner = new CleanCSS({ format: 'beautify', level: 0 });
 
 export default component => {
   const felaRenderer = createRenderer({
     dev: true
   });
 
+  const prettifyFelaString = str =>
+    str
+      // adds extra lines before @media
+      .replace(/\@media/g, '\n\n@media')
+      // adds extra lines between keyframes and following selectors
+      .replace(/\}\.([a-zA-Z])/g, '}\n\n.$1')
+      // adds extra indentation and lines to nested selectors
+      .replace(
+        /\)\{(\.[\s\S]+?\})(\})/g,
+        (match, p1) => `) {\n  ${p1.replace(/\n/g, '\n  ')}\n}`
+      );
+
   return {
     component: renderer
       .create(felaTestContext(component, felaRenderer))
       .toJSON(),
-    styles: cssCleaner.minify(felaRenderer.renderToString()).styles
+    styles: `\n${prettifyFelaString(felaRenderer.renderToString())}\n`
   };
 };

--- a/packages/cf-style-provider/src/felaSnapshot.js
+++ b/packages/cf-style-provider/src/felaSnapshot.js
@@ -1,5 +1,4 @@
 import renderer from 'react-test-renderer';
-import perfectionist from 'perfectionist';
 import felaTestContext from './felaTestContext';
 import createRenderer from './createRenderer';
 

--- a/packages/cf-style-provider/src/index.js
+++ b/packages/cf-style-provider/src/index.js
@@ -1,4 +1,6 @@
 import createRenderer from './createRenderer';
 import StyleProvider from './StyleProvider';
+import felaTestContext from './felaTestContext';
+import felaSnapshot from './felaSnapshot';
 
-export { createRenderer, StyleProvider };
+export { createRenderer, StyleProvider, felaTestContext, felaSnapshot };

--- a/packages/cf-style-provider/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-provider/test/__snapshots__/index.js.snap
@@ -7,16 +7,16 @@ exports[`StyleProvider should render styles 1`] = `
 
 <head>
   <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
-    .cf-a {
+    .a {
       margin: 10px
     }
 
-    .cf-b {
+    .b {
       color: red
     }
   </style>
   <style data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 64em)\\">
-    .cf-c {
+    .c {
       font-size: 1px
     }
   </style>
@@ -24,7 +24,7 @@ exports[`StyleProvider should render styles 1`] = `
 
 <body>
   <div>
-    <div data-reactroot=\\"\\" class=\\"cf-a cf-b cf-c\\"></div>
+    <div data-reactroot=\\"\\" class=\\"a b c\\"></div>
   </div>
 </body>
 
@@ -34,10 +34,12 @@ exports[`StyleProvider should render styles 1`] = `
 exports[`felaSnapshot should return a formatted snapshot object 1`] = `
 Object {
   "component": <div
-    className="cf-53ysj"
+    className="f53ysj"
 />,
-  "styles": ".cf-53ysj {
+  "styles": "
+.f53ysj {
   color: black
-}",
+}
+",
 }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -802,6 +802,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@^3.0.5:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -1055,7 +1059,7 @@ command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
 
-commander@^2.8.1:
+commander@^2.8.1, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1083,6 +1087,13 @@ concat-stream@^1.5.2:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+config-chain@~1.1.5:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -1455,6 +1466,15 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+editorconfig@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.2.tgz#8e57926d9ee69ab6cb999f027c2171467acceb35"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    sigmund "^1.0.1"
 
 electron-to-chromium@^1.2.7:
   version "1.3.3"
@@ -2185,7 +2205,7 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@^1.3.2, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
@@ -2757,6 +2777,15 @@ js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
+js-beautify@^1.6.14:
+  version "1.6.14"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.6.14.tgz#d3b8f7322d02b9277d58bd238264c327e58044cd"
+  dependencies:
+    config-chain "~1.1.5"
+    editorconfig "^0.13.2"
+    mkdirp "~0.5.0"
+    nopt "~3.0.1"
+
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
@@ -3028,6 +3057,12 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
+
 lru-cache@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
@@ -3180,6 +3215,12 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@~3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
   version "2.3.6"
@@ -3524,6 +3565,10 @@ prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, 
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
     fbjs "^0.8.9"
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -3910,6 +3955,10 @@ shelljs@^0.7.5:
 shellwords@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
+
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
- remove selectorPrefix (again) since it's been fixed in Fela
- replace `clean-css` dep by a regexp
- export felaTestContext and felaSnapshot out of cf-style-provider (again) since it works
- move js-beautify dep to root package.json since we don't need it in cf-style-provider deps

I've tested it in cf-www-next and both dev and prod builds are ok.