### PR TITLE
Stop passing rule functions downstream

### DIFF
--- a/packages/cf-builder-pagination/test/PaginationBuilder.js
+++ b/packages/cf-builder-pagination/test/PaginationBuilder.js
@@ -94,17 +94,17 @@ test('should call onPageChange when clicking another page', () => {
   );
 
   const items = wrapper.find('li');
-  items.at(2).find('a').simulate('click');
+  items.at(2).find('a').at(0).simulate('click');
   expect(onPageChange.called).toBeTruthy();
   expect(onPageChange.calls[0].args[0]).toBe(2);
 
   wrapper.setProps({ page: 2 });
-  items.at(0).find('a').simulate('click');
+  items.at(0).find('a').at(0).simulate('click');
   expect(onPageChange.called).toBeTruthy;
   expect(onPageChange.calls[1].args[0]).toBe(1);
 
   wrapper.setProps({ page: 1 });
-  items.at(items.length - 1).find('a').simulate('click');
+  items.at(items.length - 1).find('a').at(0).simulate('click');
   expect(onPageChange.called).toBeTruthy;
   expect(onPageChange.calls[2].args[0]).toBe(2);
 });

--- a/packages/cf-style-container/package.json
+++ b/packages/cf-style-container/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "fela": "^5.0.0",
+    "fela-utils": "^5.0.2",
     "prop-types": "^15.5.8",
     "react-fela": "^5.0.0",
     "seamless-immutable": "^7.1.2",

--- a/packages/cf-style-container/src/createComponent.js
+++ b/packages/cf-style-container/src/createComponent.js
@@ -1,0 +1,72 @@
+import { extractPassThroughProps, resolvePassThrough } from 'fela-utils';
+import { createElement } from 'react';
+import PropTypes from 'prop-types';
+
+function createComponentFactory(createElement, contextTypes) {
+  return function createComponent(rule, type, passThroughProps) {
+    const displayName = rule.name ? rule.name : 'FelaComponent';
+
+    const FelaComponent = ({ children, ...ruleProps }, { renderer, theme }) => {
+      if (!renderer) {
+        throw new Error(
+          "createComponent() can't render styles without the renderer in the context. Missing react-fela's <Provider /> at the app root?"
+        );
+      }
+
+      const componentName = typeof type === 'string'
+        ? type
+        : type.displayName || type.name || '';
+
+      // compose passThrough props from arrays or functions
+      const resolvedPassThrough = [
+        ...resolvePassThrough(passThroughProps, ruleProps)
+      ];
+
+      if (ruleProps.className) {
+        console.warn(`You cannot restyle Fela component ${componentName}`);
+      }
+
+      const componentProps = extractPassThroughProps(
+        resolvedPassThrough,
+        ruleProps
+      );
+
+      ruleProps.theme = theme || {};
+
+      if (ruleProps.style) {
+        componentProps.style = ruleProps.style;
+      }
+
+      if (ruleProps.className) {
+      }
+
+      componentProps.className = renderer.renderRule(rule, ruleProps);
+
+      if (ruleProps.id) {
+        componentProps.id = ruleProps.id;
+      }
+
+      if (ruleProps.innerRef) {
+        componentProps.ref = ruleProps.innerRef;
+      }
+
+      const customType = ruleProps.is || type;
+      return createElement(customType, componentProps, children);
+    };
+
+    if (contextTypes) {
+      FelaComponent.contextTypes = contextTypes;
+    }
+
+    // use the rule name as display name to better debug with react inspector
+    FelaComponent.displayName = displayName;
+    FelaComponent._isFelaComponent = true;
+
+    return FelaComponent;
+  };
+}
+
+export default createComponentFactory(createElement, {
+  renderer: PropTypes.object,
+  theme: PropTypes.object
+});

--- a/packages/cf-style-container/src/createComponent.js
+++ b/packages/cf-style-container/src/createComponent.js
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types';
 
 function createComponentFactory(createElement, contextTypes) {
   return function createComponent(rule, type, passThroughProps) {
-    const displayName = rule.name || 'FelaComponent';
+    const componentName = typeof type === 'string'
+      ? type
+      : type.displayName || type.name || '';
 
     const FelaComponent = ({ children, ...ruleProps }, { renderer, theme }) => {
       if (!renderer) {
@@ -18,10 +20,6 @@ function createComponentFactory(createElement, contextTypes) {
           "createComponent() can't render styles without the theme in the context. Wrap the root of your app with <StyleProvider />."
         );
       }
-
-      const componentName = typeof type === 'string'
-        ? type
-        : type.displayName || type.name || '';
 
       // compose passThrough props from arrays or functions
       const resolvedPassThrough = [
@@ -54,15 +52,21 @@ function createComponentFactory(createElement, contextTypes) {
       }
 
       const customType = ruleProps.is || type;
+
       return createElement(customType, componentProps, children);
     };
+
+    if (type.propTypes) {
+      FelaComponent.propTypes = type.propTypes;
+      FelaComponent.propTypes.className = PropTypes.string;
+    }
 
     if (contextTypes) {
       FelaComponent.contextTypes = contextTypes;
     }
 
     // use the rule name as display name to better debug with react inspector
-    FelaComponent.displayName = displayName;
+    FelaComponent.displayName = componentName;
     FelaComponent._isFelaComponent = true;
 
     return FelaComponent;

--- a/packages/cf-style-container/src/createComponent.js
+++ b/packages/cf-style-container/src/createComponent.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 function createComponentFactory(createElement, contextTypes) {
   return function createComponent(rule, type, passThroughProps) {
-    const displayName = rule.name ? rule.name : 'FelaComponent';
+    const displayName = rule.name || 'FelaComponent';
 
     const FelaComponent = ({ children, ...ruleProps }, { renderer, theme }) => {
       if (!renderer) {
@@ -35,9 +35,6 @@ function createComponentFactory(createElement, contextTypes) {
 
       if (ruleProps.style) {
         componentProps.style = ruleProps.style;
-      }
-
-      if (ruleProps.className) {
       }
 
       componentProps.className = renderer.renderRule(rule, ruleProps);

--- a/packages/cf-style-container/src/createComponent.js
+++ b/packages/cf-style-container/src/createComponent.js
@@ -9,7 +9,13 @@ function createComponentFactory(createElement, contextTypes) {
     const FelaComponent = ({ children, ...ruleProps }, { renderer, theme }) => {
       if (!renderer) {
         throw new Error(
-          "createComponent() can't render styles without the renderer in the context. Missing react-fela's <Provider /> at the app root?"
+          "createComponent() can't render styles without the renderer in the context. Wrap the root of your app with <StyleProvider />."
+        );
+      }
+
+      if (!theme) {
+        throw new Error(
+          "createComponent() can't render styles without the theme in the context. Wrap the root of your app with <StyleProvider />."
         );
       }
 

--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -1,13 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { combineRules } from 'fela';
-import {
-  createComponent as createFelaComponent,
-  ThemeProvider,
-  connect
-} from 'react-fela';
+import { ThemeProvider, connect } from 'react-fela';
 import { static as Immutable } from 'seamless-immutable';
 import { capitalize } from 'underscore.string';
+import createFelaComponent from './createComponent';
 
 const createComponent = (rule, type = 'div', passThroughProps = []) =>
   createFelaComponent(


### PR DESCRIPTION
This prevents to append custom classNames to components styled by Fela.

It gives a warning: 

```
You cannot restyle Fela component ${componentName}
```