### PR TITLE
feat(cf-component-toggle): rewrite in `fela`

### DIFF
--- a/packages/cf-component-toggle/src/Toggle.js
+++ b/packages/cf-component-toggle/src/Toggle.js
@@ -1,6 +1,115 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import { createComponent } from 'cf-style-container';
+
+const styles = ({ theme, disabled }) => {
+  return {
+    display: 'block',
+    position: 'relative',
+    margin: 0,
+    height: theme.height,
+    width: theme.width,
+    borderRadius: theme.borderRadius,
+    borderWidth: theme.borderWidth,
+    borderStyle: theme.borderStyle,
+    borderColor: disabled ? theme.colorGray : theme.borderColor,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontSize: theme.fontSize,
+    marginBottom: theme.marginBottom,
+    minHeight: theme.minHeight,
+
+    '&::before': {
+      display: 'block',
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      width: '50%',
+      lineHeight: theme['&::before'].lineHeight,
+      textAlign: 'center',
+      content: "'On'",
+      left: 0,
+      background: disabled ? theme.colorGray : theme['&::before'].background,
+      color: disabled ? theme.colorGrayLight : theme['&::before'].color
+    },
+    '&::after': {
+      display: 'block',
+      position: 'absolute',
+      content: "'Off'",
+      top: 0,
+      bottom: 0,
+      right: 0,
+      textAlign: 'center',
+      width: '50%',
+      lineHeight: theme['&::after'].lineHeight,
+      background: theme['&::after'].background,
+      color: disabled ? theme.colorGrayLight : theme['&::after'].color
+    }
+  };
+};
+
+const Handle = createComponent(
+  ({ theme, active }) => ({
+    display: 'block',
+    position: 'absolute',
+    zIndex: 1,
+    top: 0,
+    bottom: 0,
+    left: active ? '50%' : 0,
+    width: '50%',
+
+    border: 'inherit',
+    borderWidth: 0,
+    borderRightWidth: active ? 0 : 'inherit',
+    borderLeftWidth: active ? 'inherit' : 0,
+
+    background: theme.colorWhite,
+    transition: 'left 100ms ease',
+
+    '&::before': {
+      border: '4px solid transparent',
+      content: "''",
+      display: 'block',
+      height: 0,
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      marginTop: '-3px',
+      width: 0,
+      borderLeftColor: 'transparent',
+      borderRightColor: 'inherit',
+      marginLeft: '-10px'
+    },
+    '&::after': {
+      border: '4px solid transparent',
+      borderLeftColor: 'inherit',
+      content: "''",
+      display: 'block',
+      height: 0,
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      marginLeft: '2px',
+      marginTop: '-3px',
+      width: 0
+    }
+  }),
+  'span',
+  ['active']
+);
+
+const A11yLabel = createComponent(
+  () => ({
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    border: 0
+  }),
+  'span'
+);
 
 class Toggle extends React.Component {
   constructor(props) {
@@ -15,20 +124,11 @@ class Toggle extends React.Component {
   }
 
   render() {
-    let className = 'cf-toggle';
-
-    if (this.props.value) {
-      className += ' cf-toggle--active';
-    }
-
-    if (this.props.disabled) {
-      className += ' cf-toggle--disabled';
-    }
+    const { className } = this.props;
 
     return (
       <label htmlFor={this.props.name} className={className}>
         <input
-          className="cf-toggle__checkbox"
           type="checkbox"
           disabled={this.props.disabled}
           id={this.props.name}
@@ -38,10 +138,8 @@ class Toggle extends React.Component {
           onFocus={this.props.onFocus}
           onBlur={this.props.onBlur}
         />
-        <span className="cf-toggle__label">
-          {this.props.label}
-        </span>
-        <span className="cf-toggle__handle" />
+        <A11yLabel>{this.props.label}</A11yLabel>
+        <Handle active={this.props.value} />
       </label>
     );
   }
@@ -55,7 +153,8 @@ Toggle.propTypes = {
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  className: PropTypes.string
 };
 
-export default Toggle;
+export default createComponent(styles, Toggle);

--- a/packages/cf-component-toggle/src/ToggleTheme.js
+++ b/packages/cf-component-toggle/src/ToggleTheme.js
@@ -1,0 +1,46 @@
+export default baseTheme => ({
+  display: 'block',
+  position: 'relative',
+  margin: 0,
+  height: '2.26667rem',
+  width: '5.334rem',
+  borderRadius: '2px',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: '#aaa',
+  cursor: 'pointer',
+  colorGray: baseTheme.colorGray,
+  colorGrayLight: baseTheme.colorGrayLight,
+
+  fontSize: '0.86667rem',
+  marginBottom: '0.38333em',
+  minHeight: '1.22em',
+
+  '&::before': {
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    width: '50%',
+    lineHeight: '2.26667rem',
+    textAlign: 'center',
+    content: 'On',
+    left: 0,
+    background: baseTheme.colorGreen,
+    color: baseTheme.colorWhite
+  },
+
+  '&::after': {
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    width: '50%',
+    lineHeight: '2.26667rem',
+    textAlign: 'center',
+    content: 'Off',
+    right: 0,
+    background: baseTheme.colorGray,
+    color: baseTheme.colorWhite
+  }
+});

--- a/packages/cf-component-toggle/src/index.js
+++ b/packages/cf-component-toggle/src/index.js
@@ -1,3 +1,8 @@
-import Toggle from './Toggle';
+import { applyTheme } from 'cf-style-container';
 
-export default Toggle;
+import ToggleUnstyled from './Toggle';
+import ToggleTheme from './ToggleTheme';
+
+const Toggle = applyTheme(ToggleUnstyled, ToggleTheme);
+
+export { Toggle as default, ToggleUnstyled, ToggleTheme };

--- a/packages/cf-component-toggle/test/Toggle.js
+++ b/packages/cf-component-toggle/test/Toggle.js
@@ -1,22 +1,25 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { felaSnapshot } from 'cf-style-provider';
 import Toggle from '../../cf-component-toggle/src/index';
 
 test('should render', () => {
-  const component = renderer.create(<Toggle label="Test Toggle" name="test" />);
-  expect(component.toJSON()).toMatchSnapshot();
+  const snapshot = felaSnapshot(<Toggle label="Test Toggle" name="test" />);
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render checked', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Toggle label="Test Toggle" name="test" value={true} />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render disabled', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Toggle disabled label="Test Toggle" name="test" value={true} />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });

--- a/packages/cf-component-toggle/test/__snapshots__/Toggle.js.snap
+++ b/packages/cf-component-toggle/test/__snapshots__/Toggle.js.snap
@@ -2,12 +2,11 @@
 
 exports[`should render 1`] = `
 <label
-  className="cf-toggle"
+  className="f17lho90"
   htmlFor="test"
 >
   <input
     checked={undefined}
-    className="cf-toggle__checkbox"
     disabled={undefined}
     id="test"
     name="test"
@@ -17,24 +16,130 @@ exports[`should render 1`] = `
     type="checkbox"
   />
   <span
-    className="cf-toggle__label"
+    className="f15elc4i"
   >
     Test Toggle
   </span>
   <span
-    className="cf-toggle__handle"
+    active={undefined}
+    className="fopa0cz"
   />
 </label>
+`;
+
+exports[`should render 2`] = `
+"
+.f17lho90::before {
+  display: block;
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  width: 50%;
+  line-height: 2.26667rem;
+  text-align: center;
+  content: 'On';
+  left: 0px;
+  background: #9bca3e;
+  color: #fff
+}
+
+.f17lho90::after {
+  display: block;
+  position: absolute;
+  content: 'Off';
+  top: 0px;
+  bottom: 0px;
+  right: 0px;
+  text-align: center;
+  width: 50%;
+  line-height: 2.26667rem;
+  background: #7c7c7c;
+  color: #fff
+}
+
+.f17lho90 {
+  display: block;
+  position: relative;
+  margin: 0px;
+  height: 2.26667rem;
+  width: 5.334rem;
+  border-radius: 2px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #aaa;
+  cursor: pointer;
+  font-size: 0.86667rem;
+  margin-bottom: 0.38333em;
+  min-height: 1.22em
+}
+
+.f15elc4i {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0px
+}
+
+.fopa0cz::before {
+  border: 4px solid transparent;
+  content: '';
+  display: block;
+  height: 0px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-top: -3px;
+  width: 0px;
+  border-left-color: transparent;
+  border-right-color: inherit;
+  margin-left: -10px
+}
+
+.fopa0cz::after {
+  border: 4px solid transparent;
+  border-left-color: inherit;
+  content: '';
+  display: block;
+  height: 0px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-left: 2px;
+  margin-top: -3px;
+  width: 0px
+}
+
+.fopa0cz {
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  width: 50%;
+  border: inherit;
+  border-width: 0px;
+  border-right-width: inherit;
+  border-left-width: 0px;
+  background: #fff;
+  transition: left 100ms ease;
+  -webkit-transition: left 100ms ease;
+  -moz-transition: left 100ms ease
+}
+"
 `;
 
 exports[`should render checked 1`] = `
 <label
-  className="cf-toggle cf-toggle--active"
+  className="f17lho90"
   htmlFor="test"
 >
   <input
     checked={true}
-    className="cf-toggle__checkbox"
     disabled={undefined}
     id="test"
     name="test"
@@ -44,24 +149,130 @@ exports[`should render checked 1`] = `
     type="checkbox"
   />
   <span
-    className="cf-toggle__label"
+    className="f15elc4i"
   >
     Test Toggle
   </span>
   <span
-    className="cf-toggle__handle"
+    active={true}
+    className="firytjf"
   />
 </label>
 `;
 
+exports[`should render checked 2`] = `
+"
+.f17lho90::before {
+  display: block;
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  width: 50%;
+  line-height: 2.26667rem;
+  text-align: center;
+  content: 'On';
+  left: 0px;
+  background: #9bca3e;
+  color: #fff
+}
+
+.f17lho90::after {
+  display: block;
+  position: absolute;
+  content: 'Off';
+  top: 0px;
+  bottom: 0px;
+  right: 0px;
+  text-align: center;
+  width: 50%;
+  line-height: 2.26667rem;
+  background: #7c7c7c;
+  color: #fff
+}
+
+.f17lho90 {
+  display: block;
+  position: relative;
+  margin: 0px;
+  height: 2.26667rem;
+  width: 5.334rem;
+  border-radius: 2px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #aaa;
+  cursor: pointer;
+  font-size: 0.86667rem;
+  margin-bottom: 0.38333em;
+  min-height: 1.22em
+}
+
+.f15elc4i {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0px
+}
+
+.firytjf::before {
+  border: 4px solid transparent;
+  content: '';
+  display: block;
+  height: 0px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-top: -3px;
+  width: 0px;
+  border-left-color: transparent;
+  border-right-color: inherit;
+  margin-left: -10px
+}
+
+.firytjf::after {
+  border: 4px solid transparent;
+  border-left-color: inherit;
+  content: '';
+  display: block;
+  height: 0px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-left: 2px;
+  margin-top: -3px;
+  width: 0px
+}
+
+.firytjf {
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0px;
+  bottom: 0px;
+  left: 50%;
+  width: 50%;
+  border: inherit;
+  border-width: 0px;
+  border-right-width: 0px;
+  border-left-width: inherit;
+  background: #fff;
+  transition: left 100ms ease;
+  -webkit-transition: left 100ms ease;
+  -moz-transition: left 100ms ease
+}
+"
+`;
+
 exports[`should render disabled 1`] = `
 <label
-  className="cf-toggle cf-toggle--active cf-toggle--disabled"
+  className="f1t9hd5d"
   htmlFor="test"
 >
   <input
     checked={true}
-    className="cf-toggle__checkbox"
     disabled={true}
     id="test"
     name="test"
@@ -71,12 +282,119 @@ exports[`should render disabled 1`] = `
     type="checkbox"
   />
   <span
-    className="cf-toggle__label"
+    className="f15elc4i"
   >
     Test Toggle
   </span>
   <span
-    className="cf-toggle__handle"
+    active={true}
+    className="firytjf"
   />
 </label>
+`;
+
+exports[`should render disabled 2`] = `
+"
+.f1t9hd5d::before {
+  display: block;
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  width: 50%;
+  line-height: 2.26667rem;
+  text-align: center;
+  content: 'On';
+  left: 0px;
+  background: #7c7c7c;
+  color: #dedede
+}
+
+.f1t9hd5d::after {
+  display: block;
+  position: absolute;
+  content: 'Off';
+  top: 0px;
+  bottom: 0px;
+  right: 0px;
+  text-align: center;
+  width: 50%;
+  line-height: 2.26667rem;
+  background: #7c7c7c;
+  color: #dedede
+}
+
+.f1t9hd5d {
+  display: block;
+  position: relative;
+  margin: 0px;
+  height: 2.26667rem;
+  width: 5.334rem;
+  border-radius: 2px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #7c7c7c;
+  cursor: not-allowed;
+  font-size: 0.86667rem;
+  margin-bottom: 0.38333em;
+  min-height: 1.22em
+}
+
+.f15elc4i {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0px
+}
+
+.firytjf::before {
+  border: 4px solid transparent;
+  content: '';
+  display: block;
+  height: 0px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-top: -3px;
+  width: 0px;
+  border-left-color: transparent;
+  border-right-color: inherit;
+  margin-left: -10px
+}
+
+.firytjf::after {
+  border: 4px solid transparent;
+  border-left-color: inherit;
+  content: '';
+  display: block;
+  height: 0px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-left: 2px;
+  margin-top: -3px;
+  width: 0px
+}
+
+.firytjf {
+  display: block;
+  position: absolute;
+  z-index: 1;
+  top: 0px;
+  bottom: 0px;
+  left: 50%;
+  width: 50%;
+  border: inherit;
+  border-width: 0px;
+  border-right-width: 0px;
+  border-left-width: inherit;
+  background: #fff;
+  transition: left 100ms ease;
+  -webkit-transition: left 100ms ease;
+  -moz-transition: left 100ms ease
+}
+"
 `;


### PR DESCRIPTION
Now `cf-component-toggle` uses `fela` to apply styles defined in JS to
the components rather than relying on outside CSS to provide styles.

BREAKING CHANGE: `className` prop is no longer applied to the component.

Closes: #228