### PR TITLE
feat(cf-component-link): rewrite styling in fela

### DIFF
--- a/packages/cf-component-card/src/CardToolbarLink.js
+++ b/packages/cf-component-card/src/CardToolbarLink.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Link from 'cf-component-link';
+import { Link } from 'cf-component-link';
 
 class CardToolbarLink extends React.Component {
   constructor(props) {

--- a/packages/cf-component-dropdown/src/DropdownLink.js
+++ b/packages/cf-component-dropdown/src/DropdownLink.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Link from 'cf-component-link';
+import { Link } from 'cf-component-link';
 import DropdownRegistry from './DropdownRegistry';
 
 class DropdownLink extends React.Component {

--- a/packages/cf-component-link/README.md
+++ b/packages/cf-component-link/README.md
@@ -12,7 +12,7 @@ $ npm install cf-component-link
 
 ```jsx
 import React from 'react';
-import Link from 'cf-component-link';
+import { Link } from 'cf-component-link';
 
 class LinkComponent extends React.Component {
   handleClick() {

--- a/packages/cf-component-link/example/basic/component.js
+++ b/packages/cf-component-link/example/basic/component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Link from 'cf-component-link';
+import { Link } from 'cf-component-link';
 
 class LinkComponent extends React.Component {
   handleClick() {
@@ -15,11 +15,6 @@ class LinkComponent extends React.Component {
         <p>Alternatively you can pass an <code>onClick</code> handler:</p>
         <Link onClick={this.handleClick.bind(this)}>Link to something</Link>
         <p>Note: This will give it a <code>role="button"</code></p>
-
-        <p>
-          All additional props will be added to the <code>Link</code> element:
-        </p>
-        <Link to="/foo" className="special-link">Link to /foo</Link>
 
         <p>You can even specify <code>tagName</code>:</p>
         <Link to="/bar" tagName="button">Link to /bar</Link>

--- a/packages/cf-component-link/src/Link.js
+++ b/packages/cf-component-link/src/Link.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { routeTo } from 'cf-util-route-handler';
+import { createComponent } from 'cf-style-container';
 
 class Link extends React.Component {
   constructor(props, context) {
@@ -47,22 +48,43 @@ class Link extends React.Component {
       }
     }
 
-    props.className = 'cf-link';
-
     if (disabled) {
-      props.className += ' cf-link--disabled';
       props.disabled = true;
-    }
-
-    if (className) {
-      props.className += ' ' + className;
     }
 
     props.onClick = this.handleClick;
 
     props.ref = node => this.link = node;
 
-    return React.createElement(tagName, props, children);
+    const Link = createComponent(
+      ({ theme, disabled }) => ({
+        color: disabled ? theme.disabledColor : theme.color,
+        outline: theme.outline,
+        textDecoration: theme.textDecoration,
+        transition: theme.transition,
+        cursor: disabled ? theme.disabledCursor : theme.cursor,
+
+        '&:hover': {
+          color: disabled
+            ? theme['&:hover'].disabledColor
+            : theme['&:hover'].color
+        },
+
+        '&:focus': {
+          color: theme['&:focus'].color,
+          outline: theme['&:focus'].outline,
+          outlineOffset: theme['&:focus'].outlineOffset
+        },
+
+        '&:active': {
+          color: theme['&:active'].color,
+          outline: theme['&:active'].outline
+        }
+      }),
+      tagName,
+      ['disabled', 'href', 'role']
+    );
+    return <Link {...props}>{children}</Link>;
   }
 }
 

--- a/packages/cf-component-link/src/LinkTheme.js
+++ b/packages/cf-component-link/src/LinkTheme.js
@@ -1,0 +1,25 @@
+export default baseTheme => ({
+  color: theme.color.marine,
+  disabledColor: theme.colorGray,
+  outline: 'none',
+  textDecoration: 'none',
+  transition: 'all 150ms ease',
+  cursor: 'pointer',
+  disabledCursor: 'default',
+
+  '&:hover': {
+    color: theme.color.tangerine,
+    disabledColor: theme.colorGray
+  },
+
+  '&:focus': {
+    color: theme.color.sky,
+    outline: '5px auto -webkit-focus-ring-color',
+    outlineOffset: '-1px'
+  },
+
+  '&:active': {
+    color: theme.color.sunrise,
+    outline: 'none'
+  }
+});

--- a/packages/cf-component-link/src/index.js
+++ b/packages/cf-component-link/src/index.js
@@ -1,3 +1,11 @@
-import Link from './Link';
+import LinkUnstyled from './Link';
+import LinkTheme from './LinkTheme';
+import { applyTheme } from 'cf-style-container';
 
-export default Link;
+const Link = applyTheme(LinkUnstyled, LinkTheme);
+
+export default {
+  Link,
+  LinkUnstyled,
+  LinkTheme
+};

--- a/packages/cf-component-link/test/Link.js
+++ b/packages/cf-component-link/test/Link.js
@@ -1,43 +1,45 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import Link from '../../cf-component-link/src/index';
+import { felaSnapshot } from 'cf-style-provider';
+import { Link } from '../../cf-component-link/src/index';
 
 test('should render', () => {
-  const component = renderer.create(<Link to="/route">Hello World</Link>);
-  expect(component.toJSON()).toMatchSnapshot();
+  const snapshot = felaSnapshot(<Link to="/route">Hello World</Link>);
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with onClick', () => {
-  const component = renderer.create(
-    <Link onClick={() => {}}>Hello World</Link>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
+  const snapshot = felaSnapshot(<Link onClick={() => {}}>Hello World</Link>);
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with tagName', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Link to="/route" tagName="button">Hello World</Link>
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with className', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Link to="/route" className="special-link">Hello World</Link>
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with role', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Link to="/route" role="button" tagName="div">Hello World</Link>
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with disabled', () => {
-  const component = renderer.create(
-    <Link to="/route" disabled>Hello World</Link>
-  );
-  expect(component.toJSON()).toMatchSnapshot();
+  const snapshot = felaSnapshot(<Link to="/route" disabled>Hello World</Link>);
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });

--- a/packages/cf-component-progress/src/Progress.js
+++ b/packages/cf-component-progress/src/Progress.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Link from 'cf-component-link';
+import { Link } from 'cf-component-link';
 
 class Progress extends React.Component {
   constructor(props) {

--- a/packages/cf-component-progress/test/Progress.js
+++ b/packages/cf-component-progress/test/Progress.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Progress from '../../cf-component-progress/src/index';
-import Link from '../../cf-component-link/src/index';
+import { Link } from '../../cf-component-link/src/index';
 
 test('should render', () => {
   const component = renderer.create(


### PR DESCRIPTION
BREAKING CHANGE: The `className` is now the one that is passed down from
the `fela` higher order component and any `className` prop that is
passed to `Link` will be ignored.

Closes: #287