### PR TITLE
feat(cf-component-input): rewrite styling in fela

### DIFF
--- a/packages/cf-component-form/README.md
+++ b/packages/cf-component-form/README.md
@@ -21,7 +21,7 @@ import {
   FormFieldError
 } from 'cf-component-form';
 import { Flex, FlexItem } from 'cf-component-flex';
-import Input from 'cf-component-input';
+import { Input } from 'cf-component-input';
 import Select from 'cf-component-select';
 import Textarea from 'cf-component-textarea';
 import { Button } from 'cf-component-button';

--- a/packages/cf-component-form/example/basic/component.js
+++ b/packages/cf-component-form/example/basic/component.js
@@ -8,7 +8,7 @@ import {
   FormFieldError
 } from 'cf-component-form';
 import { Flex, FlexItem } from 'cf-component-flex';
-import Input from 'cf-component-input';
+import { Input } from 'cf-component-input';
 import Select from 'cf-component-select';
 import Textarea from 'cf-component-textarea';
 import { Button } from 'cf-component-button';

--- a/packages/cf-component-input/example/basic/component.js
+++ b/packages/cf-component-input/example/basic/component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Input from 'cf-component-input';
+import { Input } from 'cf-component-input';
 
 class InputComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-input/src/Input.js
+++ b/packages/cf-component-input/src/Input.js
@@ -1,22 +1,59 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import { createComponent } from 'cf-style-container';
+
+const styles = ({ theme }) => ({
+  zIndex: theme.zIndex,
+  width: theme.width,
+  margin: theme.margin,
+  padding: theme.padding,
+  border: theme.border,
+  borderRadius: theme.borderRadius,
+
+  verticalAlign: theme.verticalAlign,
+  fontFamily: theme.fontFamily,
+  fontSize: theme.fontSize,
+
+  background: theme.background,
+  color: theme.color,
+  outline: theme.outline,
+
+  transition: theme.transition,
+
+  '&:hover': {
+    borderColor: theme['&:hover'].borderColor
+  },
+
+  '&:focus': {
+    outline: theme['&:hover'].outline,
+    outlineOffset: theme['&:hover'].outlineOffset
+  }
+});
 
 class Input extends React.Component {
   render() {
-    let { className, type, invalid, ...props } = this.props;
-
-    let _className = 'cf-input cf-input--' + type;
-
-    if (invalid) {
-      _className += ' cf-input--invalid';
-    }
-
-    if (className) {
-      _className += ' ' + className;
-    }
-
-    return <input className={_className} type={type} {...props} />;
+    const {
+      type,
+      name,
+      value,
+      onChange,
+      placeholder,
+      autoComplete,
+      invalid,
+      className
+    } = this.props;
+    return (
+      <input
+        type={type}
+        name={name}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        invalid={invalid}
+        className={className}
+      />
+    );
   }
 }
 
@@ -35,4 +72,4 @@ Input.defaultProps = {
   type: 'text'
 };
 
-export default Input;
+export default createComponent(styles, Input);

--- a/packages/cf-component-input/src/InputTheme.js
+++ b/packages/cf-component-input/src/InputTheme.js
@@ -1,0 +1,27 @@
+export default baseTheme => ({
+  zIndex: 0,
+  width: '100%',
+  margin: '0 0 0.75rem',
+  padding: '0.45em 0.75em',
+  border: `1px solid ${baseTheme.color.hail}`,
+  borderRadius: baseTheme.borderRadius,
+
+  verticalAlign: 'middle',
+  fontFamily: baseTheme.fontFamily,
+  fontSize: '0.86667rem',
+
+  background: baseTheme.colorWhite,
+  color: baseTheme.color.charcoal,
+  outline: 'none',
+
+  transition: 'border-color 0.2s ease',
+
+  '&:hover': {
+    borderColor: '#256298'
+  },
+
+  '&:focus': {
+    outline: '5px auto -webkit-focus-ring-color',
+    outlineOffset: '-1px'
+  }
+});

--- a/packages/cf-component-input/src/index.js
+++ b/packages/cf-component-input/src/index.js
@@ -1,3 +1,7 @@
-import Input from './Input';
+import InputUnstyled from './Input';
+import InputTheme from './InputTheme';
+import { applyTheme } from 'cf-style-container';
 
-export default Input;
+const Input = applyTheme(InputUnstyled, InputTheme);
+
+export { Input, InputUnstyled, InputTheme };

--- a/packages/cf-component-input/test/Input.js
+++ b/packages/cf-component-input/test/Input.js
@@ -1,30 +1,33 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import Input from '../../cf-component-input/src/index';
+import { felaSnapshot } from 'cf-style-provider';
+import { Input } from '../../cf-component-input/src/index';
 
 test('should render', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Input name="example" value="content" onChange={() => {}} />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with type', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Input type="search" name="example" value="content" onChange={() => {}} />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with error', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Input name="example" value="" invalid onChange={() => {}} />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with placeholder', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Input
       name="example"
       value=""
@@ -32,18 +35,20 @@ test('should render with placeholder', () => {
       onChange={() => {}}
     />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with autocomplete', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Input name="example" value="" autoComplete="off" onChange={() => {}} />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should pass all props down to the inner input and merge classnames', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Input
       className="klass"
       name="example"
@@ -56,5 +61,6 @@ test('should pass all props down to the inner input and merge classnames', () =>
       min={3}
     />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });

--- a/packages/cf-component-input/test/__snapshots__/Input.js.snap
+++ b/packages/cf-component-input/test/__snapshots__/Input.js.snap
@@ -2,51 +2,309 @@
 
 exports[`should pass all props down to the inner input and merge classnames 1`] = `
 <input
-  className="cf-input cf-input--number cf-input--invalid klass"
-  data-shadowed={true}
-  disabled={true}
-  min={3}
+  autoComplete={undefined}
+  className="a b c d e f g h i j k l m n"
+  invalid={true}
   name="example"
   onChange={[Function]}
+  placeholder={undefined}
   type="number"
   value=""
 />
 `;
 
+exports[`should pass all props down to the inner input and merge classnames 2`] = `
+"
+.a {
+  z-index: 0
+}
+
+.b {
+  width: 100%
+}
+
+.c {
+  margin: 0 0 0.75rem
+}
+
+.d {
+  padding: 0.45em 0.75em
+}
+
+.e {
+  border: 1px solid #BCBEC0
+}
+
+.f {
+  border-radius: 2px
+}
+
+.g {
+  vertical-align: middle
+}
+
+.h {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.i {
+  font-size: 0.86667rem
+}
+
+.j {
+  background: #fff
+}
+
+.k {
+  color: #333333
+}
+
+.l {
+  outline: none
+}
+
+.m {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.n:hover {
+  border-color: #256298
+}
+"
+`;
+
 exports[`should render 1`] = `
 <input
-  className="cf-input cf-input--text"
+  autoComplete={undefined}
+  className="a b c d e f g h i j k l m n"
+  invalid={undefined}
   name="example"
   onChange={[Function]}
+  placeholder={undefined}
   type="text"
   value="content"
 />
 `;
 
+exports[`should render 2`] = `
+"
+.a {
+  z-index: 0
+}
+
+.b {
+  width: 100%
+}
+
+.c {
+  margin: 0 0 0.75rem
+}
+
+.d {
+  padding: 0.45em 0.75em
+}
+
+.e {
+  border: 1px solid #BCBEC0
+}
+
+.f {
+  border-radius: 2px
+}
+
+.g {
+  vertical-align: middle
+}
+
+.h {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.i {
+  font-size: 0.86667rem
+}
+
+.j {
+  background: #fff
+}
+
+.k {
+  color: #333333
+}
+
+.l {
+  outline: none
+}
+
+.m {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.n:hover {
+  border-color: #256298
+}
+"
+`;
+
 exports[`should render with autocomplete 1`] = `
 <input
   autoComplete="off"
-  className="cf-input cf-input--text"
+  className="a b c d e f g h i j k l m n"
+  invalid={undefined}
   name="example"
   onChange={[Function]}
+  placeholder={undefined}
   type="text"
   value=""
 />
+`;
+
+exports[`should render with autocomplete 2`] = `
+"
+.a {
+  z-index: 0
+}
+
+.b {
+  width: 100%
+}
+
+.c {
+  margin: 0 0 0.75rem
+}
+
+.d {
+  padding: 0.45em 0.75em
+}
+
+.e {
+  border: 1px solid #BCBEC0
+}
+
+.f {
+  border-radius: 2px
+}
+
+.g {
+  vertical-align: middle
+}
+
+.h {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.i {
+  font-size: 0.86667rem
+}
+
+.j {
+  background: #fff
+}
+
+.k {
+  color: #333333
+}
+
+.l {
+  outline: none
+}
+
+.m {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.n:hover {
+  border-color: #256298
+}
+"
 `;
 
 exports[`should render with error 1`] = `
 <input
-  className="cf-input cf-input--text cf-input--invalid"
+  autoComplete={undefined}
+  className="a b c d e f g h i j k l m n"
+  invalid={true}
   name="example"
   onChange={[Function]}
+  placeholder={undefined}
   type="text"
   value=""
 />
 `;
 
+exports[`should render with error 2`] = `
+"
+.a {
+  z-index: 0
+}
+
+.b {
+  width: 100%
+}
+
+.c {
+  margin: 0 0 0.75rem
+}
+
+.d {
+  padding: 0.45em 0.75em
+}
+
+.e {
+  border: 1px solid #BCBEC0
+}
+
+.f {
+  border-radius: 2px
+}
+
+.g {
+  vertical-align: middle
+}
+
+.h {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.i {
+  font-size: 0.86667rem
+}
+
+.j {
+  background: #fff
+}
+
+.k {
+  color: #333333
+}
+
+.l {
+  outline: none
+}
+
+.m {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.n:hover {
+  border-color: #256298
+}
+"
+`;
+
 exports[`should render with placeholder 1`] = `
 <input
-  className="cf-input cf-input--text"
+  autoComplete={undefined}
+  className="a b c d e f g h i j k l m n"
+  invalid={undefined}
   name="example"
   onChange={[Function]}
   placeholder="placeholder"
@@ -55,12 +313,139 @@ exports[`should render with placeholder 1`] = `
 />
 `;
 
+exports[`should render with placeholder 2`] = `
+"
+.a {
+  z-index: 0
+}
+
+.b {
+  width: 100%
+}
+
+.c {
+  margin: 0 0 0.75rem
+}
+
+.d {
+  padding: 0.45em 0.75em
+}
+
+.e {
+  border: 1px solid #BCBEC0
+}
+
+.f {
+  border-radius: 2px
+}
+
+.g {
+  vertical-align: middle
+}
+
+.h {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.i {
+  font-size: 0.86667rem
+}
+
+.j {
+  background: #fff
+}
+
+.k {
+  color: #333333
+}
+
+.l {
+  outline: none
+}
+
+.m {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.n:hover {
+  border-color: #256298
+}
+"
+`;
+
 exports[`should render with type 1`] = `
 <input
-  className="cf-input cf-input--search"
+  autoComplete={undefined}
+  className="a b c d e f g h i j k l m n"
+  invalid={undefined}
   name="example"
   onChange={[Function]}
+  placeholder={undefined}
   type="search"
   value="content"
 />
+`;
+
+exports[`should render with type 2`] = `
+"
+.a {
+  z-index: 0
+}
+
+.b {
+  width: 100%
+}
+
+.c {
+  margin: 0 0 0.75rem
+}
+
+.d {
+  padding: 0.45em 0.75em
+}
+
+.e {
+  border: 1px solid #BCBEC0
+}
+
+.f {
+  border-radius: 2px
+}
+
+.g {
+  vertical-align: middle
+}
+
+.h {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.i {
+  font-size: 0.86667rem
+}
+
+.j {
+  background: #fff
+}
+
+.k {
+  color: #333333
+}
+
+.l {
+  outline: none
+}
+
+.m {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.n:hover {
+  border-color: #256298
+}
+"
 `;


### PR DESCRIPTION
BREAKING CHANGE: There is no default export in `cf-component-input`
anymore, the previously exported default is now exported as `Input`.

Additionally the `className` prop is now ignored.

Closes: #226