### PR TITLE
Sort Media Queries and whitelist them

### DIFF
--- a/packages/cf-component-form/src/FormFieldset.js
+++ b/packages/cf-component-form/src/FormFieldset.js
@@ -17,7 +17,7 @@ const legendStyles = ({ theme, layout }) => ({
   padding: theme.legend.padding,
   marginBottom: theme.legend.marginBottom,
   borderBottom: theme.legend.borderBottom,
-  '@media (min-width: 720px)': layout === 'horizontal'
+  tablet: layout === 'horizontal'
     ? {
         width: '30%',
         float: 'left',
@@ -33,7 +33,7 @@ const contentStyles = ({ theme, layout }) => ({
   border: theme.content.border,
   borderTopWidth: theme.content.borderTopWidth,
   background: theme.content.background,
-  '@media (min-width: 720px)': layout === 'horizontal'
+  tablet: layout === 'horizontal'
     ? {
         width: '70%',
         float: 'left',

--- a/packages/cf-component-form/test/__snapshots__/FormFieldset.js.snap
+++ b/packages/cf-component-form/test/__snapshots__/FormFieldset.js.snap
@@ -5,12 +5,12 @@ exports[`should render 1`] = `
   className="f1nadb32"
 >
   <legend
-    className="f1peqvck"
+    className="f15bygxq"
   >
     Legend
   </legend>
   <div
-    className="f1culcac"
+    className="f13cnhwe"
   >
     FormFieldset
   </div>
@@ -34,21 +34,21 @@ exports[`should render 2`] = `
   border-bottom: 1px solid #dedede
 }
 
-.f1peqvck {
+.f15bygxq {
   padding: 1em;
   margin-bottom: 0px;
   border-bottom: none
 }
 
-.f1culcac {
+.f13cnhwe {
   padding: 1em;
   border: 0 solid #dedede;
   border-top-width: 1px;
   background: #eee
 }
 
-@media (min-width: 720px) {
-  .f1peqvck {
+@media (min-width: 47.2em) {
+  .f15bygxq {
     width: 30%;
     float: left;
     padding: 1.7em 1rem;
@@ -56,7 +56,7 @@ exports[`should render 2`] = `
     text-align: right
   }
   
-  .f1culcac {
+  .f13cnhwe {
     width: 70%;
     float: left;
     border-top-width: 0px;

--- a/packages/cf-style-provider/README.md
+++ b/packages/cf-style-provider/README.md
@@ -119,8 +119,44 @@ We use multiple fela plugins that extend typical CSS-in-JS syntax. Check them ou
 - [unit](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-unit)
 - [embedded](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-embedded)
 - [named-media-query](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-named-media-query)
-  - mobile
-  - mobileWide
-  - tablet
-  - desktop
-  - desktopLarge
+
+### named-media-query
+
+We have a set of configured media queries. Please, use them!
+
+```
+mobile: @media (min-width: 13.6em)
+mobileWide: @media (min-width: 30.4em)
+tablet: @media (min-width: 47.2em)
+desktop: @media (min-width: 64em)
+desktopLarge: @media (min-width: 97.6em)
+```
+
+**Input:** 
+
+```js
+const Column = createComponent(() => ({
+  color: 'black',
+  desktop: {
+    color: 'white'
+  }
+}))
+```
+
+**Output:**
+
+```html
+<style data-fela-type="RULE" type="text/css">
+  .a {
+    color: black
+  }
+</style>
+
+<style data-fela-type="RULE" type="text/css" media="(min-width: 64em)">
+  .b {
+    color: white
+  }
+</style>
+
+<div class="a b"></div>
+```

--- a/packages/cf-style-provider/src/createRenderer.js
+++ b/packages/cf-style-provider/src/createRenderer.js
@@ -14,6 +14,16 @@ const defaultOpts = {
   dev: false
 };
 
+const mediaQueries = {
+  mobile: `@media (min-width: ${variables.breakpoints.mobile})`,
+  mobileWide: `@media (min-width: ${variables.breakpoints.mobileWide})`,
+  tablet: `@media (min-width: ${variables.breakpoints.tablet})`,
+  desktop: `@media (min-width: ${variables.breakpoints.desktop})`,
+  desktopLarge: `@media (min-width: ${variables.breakpoints.desktopLarge})`
+};
+
+const removePrefix = query => query.replace('@media ', '');
+
 const createRenderer = opts => {
   const usedOpts = Object.assign({}, defaultOpts, opts);
   const plugins = [
@@ -22,13 +32,7 @@ const createRenderer = opts => {
     unit(),
     lvha(),
     embedded(),
-    namedMediaQuery({
-      mobile: `@media (min-width: ${variables.breakpoints.mobile})`,
-      mobileWide: `@media (min-width: ${variables.breakpoints.mobileWide})`,
-      tablet: `@media (min-width: ${variables.breakpoints.tablet})`,
-      desktop: `@media (min-width: ${variables.breakpoints.desktop})`,
-      desktopLarge: `@media (min-width: ${variables.breakpoints.desktopLarge})`
-    })
+    namedMediaQuery(mediaQueries)
   ];
   const enhancers = [];
 
@@ -38,9 +42,18 @@ const createRenderer = opts => {
     enhancers.push(monolithic());
   }
 
+  console.log(removePrefix(mediaQueries.mobile));
+
   return createFelaRenderer({
     plugins,
-    enhancers
+    enhancers,
+    mediaQueryOrder: [
+      removePrefix(mediaQueries.mobile),
+      removePrefix(mediaQueries.mobileWide),
+      removePrefix(mediaQueries.tablet),
+      removePrefix(mediaQueries.desktop),
+      removePrefix(mediaQueries.desktopLarge)
+    ]
   });
 };
 

--- a/packages/cf-style-provider/src/createRenderer.js
+++ b/packages/cf-style-provider/src/createRenderer.js
@@ -8,6 +8,7 @@ import embedded from 'fela-plugin-embedded';
 import beautifier from 'fela-beautifier';
 import monolithic from 'fela-monolithic';
 import namedMediaQuery from 'fela-plugin-named-media-query';
+import whitelistMediaQuery from './whitelistMediaQuery';
 import { variables } from 'cf-style-const';
 
 const defaultOpts = {
@@ -38,11 +39,10 @@ const createRenderer = opts => {
 
   if (usedOpts.dev === true) {
     plugins.push(validator());
+    plugins.push(whitelistMediaQuery(mediaQueries));
     enhancers.push(beautifier());
     enhancers.push(monolithic());
   }
-
-  console.log(removePrefix(mediaQueries.mobile));
 
   return createFelaRenderer({
     plugins,

--- a/packages/cf-style-provider/src/whitelistMediaQuery.js
+++ b/packages/cf-style-provider/src/whitelistMediaQuery.js
@@ -1,0 +1,33 @@
+const isObject = value => typeof value === 'object' && !Array.isArray(value);
+
+const flipKeysAndValues = input =>
+  Object.keys(input).reduce((obj, key) => ({ ...obj, [input[key]]: key }), {});
+
+function checkMediaQuery(style, mediaQueryMap, aliases) {
+  for (const property in style) {
+    const value = style[property];
+
+    if (isObject(value)) {
+      checkMediaQuery(value, mediaQueryMap, aliases);
+      if (
+        property.substring(0, 6) === '@media' &&
+        !mediaQueryMap.hasOwnProperty(property)
+      ) {
+        console.warn(
+          `Please don't use "${property}". Use one of the aliases: ${aliases.join(', ')}.
+More info: https://github.com/cloudflare/cf-ui/tree/master/packages/cf-style-provider#named-media-query`
+        );
+      }
+    }
+  }
+  return style;
+}
+
+export default function whitelistMediaQuery(mediaQueryMap) {
+  return style =>
+    checkMediaQuery(
+      style,
+      flipKeysAndValues(mediaQueryMap),
+      Object.keys(mediaQueryMap)
+    );
+}


### PR DESCRIPTION
By default, Fela doesn't preserve order of anything but it's important for media queries. This PR adds sorting for media queries. Also, we need to limit ourselves to use only specific set of them so the sorting is possible and the result can be deterministic. Once you start mix min-width, max-width or even both, things get crazy fast. Therefore, you should always use one of the predefined aliased min-width breakpoints:

```
mobile: @media (min-width: 13.6em)
mobileWide: @media (min-width: 30.4em)
tablet: @media (min-width: 47.2em)
desktop: @media (min-width: 64em)
desktopLarge: @media (min-width: 97.6em)
```

use it as: 

```js
createComponent(() => ({
  desktop: {
  }
});

```


and never write something as:

```js
createComponent(() => ({
  '@media ....' : {
  }
});
```
again. 

All our media queries are using `min-width` only since it better plays with the mobile-first design.

To enforce this, I've added a new plugin that `console.warn` you in the dev mode with this message:

> Please don't use "@media... ". Use one of the aliases: mobile, mobileWide, tablet, desktop, desktopLarge. More info: https://github.com/cloudflare/cf-ui/tree/master/packages/cf-style-provider#named-media-query


