### PR TITLE
feat(cf-component-dropdown): CSS to `fela`

### DIFF
--- a/packages/cf-component-dropdown/src/Dropdown.js
+++ b/packages/cf-component-dropdown/src/Dropdown.js
@@ -1,7 +1,57 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import DropdownRegistry from './DropdownRegistry';
 import { canUseDOM } from 'exenv';
+import { createComponent } from 'cf-style-container';
+
+import DropdownRegistry from './DropdownRegistry';
+
+const styles = ({ theme, align }) => ({
+  position: 'absolute',
+  zIndex: 1,
+  minWidth: '10.66667rem',
+  margin: '0.5em 0 0',
+  padding: '0.33333rem 0',
+  listStyle: 'none',
+  background: theme.colorWhite,
+  border: `1px solid ${theme.colorGrayLight}`,
+  borderRadius: theme.borderRadius,
+  boxShadow: '0 3px 10px rgba(0, 0, 0, 0.2)',
+
+  left: align === 'left' ? 0 : 'initial',
+  right: align === 'right' ? 0 : 'initial',
+
+  animationName: {
+    '0%': {
+      display: 'none',
+      opacity: 0
+    },
+    '1%': {
+      display: 'block',
+      opacity: 0,
+      top: '80%'
+    },
+    '100%': {
+      display: 'none',
+      opacity: 1,
+      top: '102%'
+    }
+  },
+  animationDuration: '150ms',
+  animationTimingFunction: 'ease-out',
+
+  '&::before': {
+    content: "''",
+    display: 'block',
+    position: 'absolute',
+    bottom: '100%',
+    border: 'solid transparent',
+    borderWidth: '10px',
+    borderTopWidth: 0,
+    borderBottomColor: theme.colorWhite,
+    left: align === 'left' ? '10px' : 'initial',
+    right: align === 'right' ? '10px' : 'initial'
+  }
+});
 
 class Dropdown extends React.Component {
   getChildContext() {
@@ -57,10 +107,7 @@ class Dropdown extends React.Component {
 
   render() {
     return (
-      <ul
-        role="menu"
-        className={`cf-dropdown cf-dropdown--${this.props.align}`}
-      >
+      <ul className={this.props.className} role="menu">
         {this.props.children}
       </ul>
     );
@@ -81,4 +128,4 @@ Dropdown.childContextTypes = {
   dropdownRegistry: PropTypes.instanceOf(DropdownRegistry).isRequired
 };
 
-export default Dropdown;
+export default createComponent(styles, Dropdown);

--- a/packages/cf-component-dropdown/src/DropdownLink.js
+++ b/packages/cf-component-dropdown/src/DropdownLink.js
@@ -1,7 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'cf-component-link';
+import { createComponent } from 'cf-style-container';
+
 import DropdownRegistry from './DropdownRegistry';
+
+const styled = ({ theme }) => ({
+  position: 'relative',
+  zIndex: 1,
+
+  '&:first-child': {
+    borderTopWidth: 0
+  },
+
+  '& > a': {
+    display: 'block',
+    padding: '0.2rem 1.06667rem',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+
+    '&:hover': {
+      color: theme.colorWhite,
+      background: theme.color.marine
+    },
+
+    '&:focus': {
+      color: theme.colorWhite,
+      background: theme.color.sky,
+      outline: '5px auto -webkit-focus-ring-color',
+      outlineOffset: '-1px'
+    },
+
+    '&:active': {
+      color: theme.colorWhite,
+      background: theme.color.rain
+    }
+  }
+});
 
 class DropdownLink extends React.Component {
   constructor(props, context) {
@@ -41,7 +76,7 @@ class DropdownLink extends React.Component {
 
   render() {
     return (
-      <li className="cf-dropdown__link" role="menuitem">
+      <li className={this.props.className} role="menuitem">
         <Link
           ref={node => this.link = node}
           to={this.props.to}
@@ -66,4 +101,4 @@ DropdownLink.contextTypes = {
   dropdownRegistry: PropTypes.instanceOf(DropdownRegistry).isRequired
 };
 
-export default DropdownLink;
+export default createComponent(styled, DropdownLink);

--- a/packages/cf-component-dropdown/src/DropdownLinkTheme.js
+++ b/packages/cf-component-dropdown/src/DropdownLinkTheme.js
@@ -1,0 +1,1 @@
+export default baseTheme => ({});

--- a/packages/cf-component-dropdown/src/DropdownSeparator.js
+++ b/packages/cf-component-dropdown/src/DropdownSeparator.js
@@ -1,7 +1,13 @@
 import React from 'react';
+import { createComponent } from 'cf-style-container';
 
-const DropdownSeparator = () => (
-  <div className="cf-dropdown__separator" role="separator" />
+const styles = ({ theme }) => ({
+  margin: '0.53333rem 0',
+  borderTop: `1px solid ${theme.colorGrayLight}`
+});
+
+const DropdownSeparator = ({ className }) => (
+  <div className={className} role="separator" />
 );
 
-export default DropdownSeparator;
+export default createComponent(styles, DropdownSeparator);

--- a/packages/cf-component-dropdown/src/DropdownSeparatorTheme.js
+++ b/packages/cf-component-dropdown/src/DropdownSeparatorTheme.js
@@ -1,0 +1,1 @@
+export default baseTheme => ({});

--- a/packages/cf-component-dropdown/src/DropdownTheme.js
+++ b/packages/cf-component-dropdown/src/DropdownTheme.js
@@ -1,0 +1,1 @@
+export default baseTheme => ({});

--- a/packages/cf-component-dropdown/src/index.js
+++ b/packages/cf-component-dropdown/src/index.js
@@ -1,5 +1,27 @@
-import Dropdown from './Dropdown';
-import DropdownLink from './DropdownLink';
-import DropdownSeparator from './DropdownSeparator';
+import { applyTheme } from 'cf-style-container';
 
-export { Dropdown, DropdownLink, DropdownSeparator };
+import DropdownUnstyled from './Dropdown';
+import DropdownTheme from './DropdownTheme';
+import DropdownLinkUnstyled from './DropdownLink';
+import DropdownLinkTheme from './DropdownLinkTheme';
+import DropdownSeparatorUnstyled from './DropdownSeparator';
+import DropdownSeparatorTheme from './DropdownTheme';
+
+const Dropdown = applyTheme(DropdownUnstyled, DropdownTheme);
+const DropdownLink = applyTheme(DropdownLinkUnstyled, DropdownLinkTheme);
+const DropdownSeparator = applyTheme(
+  DropdownSeparatorUnstyled,
+  DropdownSeparatorTheme
+);
+
+export {
+  Dropdown,
+  DropdownTheme,
+  DropdownUnstyled,
+  DropdownLink,
+  DropdownLinkTheme,
+  DropdownLinkUnstyled,
+  DropdownSeparator,
+  DropdownSeparatorTheme,
+  DropdownSeparatorUnstyled
+};

--- a/packages/cf-component-dropdown/test/DropdownLink.js
+++ b/packages/cf-component-dropdown/test/DropdownLink.js
@@ -1,21 +1,23 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { felaSnapshot } from 'cf-style-provider';
 import { Dropdown, DropdownLink } from '../../cf-component-dropdown/src/index';
 
 test('should render with to', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Dropdown onClose={() => {}}>
       <DropdownLink to="/foo">Route to /foo</DropdownLink>
     </Dropdown>
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render with onClick', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Dropdown onClose={() => {}}>
       <DropdownLink onClick={() => {}}>onClick handler</DropdownLink>
     </Dropdown>
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });

--- a/packages/cf-component-dropdown/test/DropdownSeparator.js
+++ b/packages/cf-component-dropdown/test/DropdownSeparator.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { felaSnapshot } from 'cf-style-provider';
 import { DropdownSeparator } from '../../cf-component-dropdown/src/index';
 
 test('should render with to', () => {
-  const component = renderer.create(<DropdownSeparator />);
-  expect(component.toJSON()).toMatchSnapshot();
+  const snapshot = felaSnapshot(<DropdownSeparator />);
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });

--- a/packages/cf-component-dropdown/test/__snapshots__/Dropdown.js.snap
+++ b/packages/cf-component-dropdown/test/__snapshots__/Dropdown.js.snap
@@ -2,9 +2,344 @@
 
 exports[`should render 1`] = `
 <ul
-  className="cf-dropdown cf-dropdown--left"
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y"
   role="menu"
 >
   Dropdown
 </ul>
+`;
+
+exports[`should render 2`] = `
+"
+@-webkit-keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+@-moz-keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+@keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+.a {
+  position: absolute
+}
+
+.b {
+  z-index: 1
+}
+
+.c {
+  min-width: 10.66667rem
+}
+
+.d {
+  margin: 0.5em 0 0
+}
+
+.e {
+  padding: 0.33333rem 0
+}
+
+.f {
+  list-style: none
+}
+
+.g {
+  background: #fff
+}
+
+.h {
+  border: 1px solid #dedede
+}
+
+.i {
+  border-radius: 2px
+}
+
+.j {
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2)
+}
+
+.k {
+  left: initial
+}
+
+.l {
+  right: initial
+}
+
+.m {
+  animation-name: k1
+}
+
+.n {
+  animation-duration: 150ms;
+  -webkit-animation-duration: 150ms
+}
+
+.o {
+  animation-timing-function: ease-out;
+  -webkit-animation-timing-function: ease-out
+}
+
+.p::before {
+  content: ''
+}
+
+.q::before {
+  display: block
+}
+
+.r::before {
+  position: absolute
+}
+
+.s::before {
+  bottom: 100%
+}
+
+.t::before {
+  border: solid transparent
+}
+
+.u::before {
+  border-width: 10px
+}
+
+.v::before {
+  border-top-width: 0px
+}
+
+.w::before {
+  border-bottom-color: #fff
+}
+
+.x::before {
+  left: initial
+}
+
+.y::before {
+  right: initial
+}
+"
+`;
+
+exports[`should render with align 1`] = `
+<ul
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y"
+  role="menu"
+>
+  Dropdown
+</ul>
+`;
+
+exports[`should render with align 2`] = `
+"
+@-webkit-keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+@-moz-keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+@keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+.a {
+  position: absolute
+}
+
+.b {
+  z-index: 1
+}
+
+.c {
+  min-width: 10.66667rem
+}
+
+.d {
+  margin: 0.5em 0 0
+}
+
+.e {
+  padding: 0.33333rem 0
+}
+
+.f {
+  list-style: none
+}
+
+.g {
+  background: #fff
+}
+
+.h {
+  border: 1px solid #dedede
+}
+
+.i {
+  border-radius: 2px
+}
+
+.j {
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2)
+}
+
+.k {
+  left: initial
+}
+
+.l {
+  right: 0px
+}
+
+.m {
+  animation-name: k1
+}
+
+.n {
+  animation-duration: 150ms;
+  -webkit-animation-duration: 150ms
+}
+
+.o {
+  animation-timing-function: ease-out;
+  -webkit-animation-timing-function: ease-out
+}
+
+.p::before {
+  content: ''
+}
+
+.q::before {
+  display: block
+}
+
+.r::before {
+  position: absolute
+}
+
+.s::before {
+  bottom: 100%
+}
+
+.t::before {
+  border: solid transparent
+}
+
+.u::before {
+  border-width: 10px
+}
+
+.v::before {
+  border-top-width: 0px
+}
+
+.w::before {
+  border-bottom-color: #fff
+}
+
+.x::before {
+  left: initial
+}
+
+.y::before {
+  right: 10px
+}
+"
 `;

--- a/packages/cf-component-dropdown/test/__snapshots__/DropdownLink.js.snap
+++ b/packages/cf-component-dropdown/test/__snapshots__/DropdownLink.js.snap
@@ -2,11 +2,11 @@
 
 exports[`should render with onClick 1`] = `
 <ul
-  className="cf-dropdown cf-dropdown--left"
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y"
   role="menu"
 >
   <li
-    className="cf-dropdown__link"
+    className="z b ab ac ad ae af ag ah ai aj ak al am an"
     role="menuitem"
   >
     <a
@@ -23,13 +23,232 @@ exports[`should render with onClick 1`] = `
 </ul>
 `;
 
+exports[`should render with onClick 2`] = `
+"
+@-webkit-keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+@-moz-keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+@keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+.a {
+  position: absolute
+}
+
+.b {
+  z-index: 1
+}
+
+.c {
+  min-width: 10.66667rem
+}
+
+.d {
+  margin: 0.5em 0 0
+}
+
+.e {
+  padding: 0.33333rem 0
+}
+
+.f {
+  list-style: none
+}
+
+.g {
+  background: #fff
+}
+
+.h {
+  border: 1px solid #dedede
+}
+
+.i {
+  border-radius: 2px
+}
+
+.j {
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2)
+}
+
+.k {
+  left: initial
+}
+
+.l {
+  right: initial
+}
+
+.m {
+  animation-name: k1
+}
+
+.n {
+  animation-duration: 150ms;
+  -webkit-animation-duration: 150ms
+}
+
+.o {
+  animation-timing-function: ease-out;
+  -webkit-animation-timing-function: ease-out
+}
+
+.p::before {
+  content: ''
+}
+
+.q::before {
+  display: block
+}
+
+.r::before {
+  position: absolute
+}
+
+.s::before {
+  bottom: 100%
+}
+
+.t::before {
+  border: solid transparent
+}
+
+.u::before {
+  border-width: 10px
+}
+
+.v::before {
+  border-top-width: 0px
+}
+
+.w::before {
+  border-bottom-color: #fff
+}
+
+.x::before {
+  left: initial
+}
+
+.y::before {
+  right: initial
+}
+
+.z {
+  position: relative
+}
+
+.ab:first-child {
+  border-top-width: 0px
+}
+
+.ac > a {
+  display: block
+}
+
+.ad > a {
+  padding: 0.2rem 1.06667rem
+}
+
+.ae > a {
+  cursor: pointer
+}
+
+.af > a {
+  white-space: nowrap
+}
+
+.ag > a:hover {
+  color: #fff
+}
+
+.ah > a:hover {
+  background: #2F7BBF
+}
+
+.ai > a:focus {
+  color: #fff
+}
+
+.aj > a:focus {
+  background: #76C4E2
+}
+
+.ak > a:focus {
+  outline: 5px auto -webkit-focus-ring-color
+}
+
+.al > a:focus {
+  outline-offset: -1px
+}
+
+.am > a:active {
+  color: #fff
+}
+
+.an > a:active {
+  background: #408BC9
+}
+"
+`;
+
 exports[`should render with to 1`] = `
 <ul
-  className="cf-dropdown cf-dropdown--left"
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y"
   role="menu"
 >
   <li
-    className="cf-dropdown__link"
+    className="z b ab ac ad ae af ag ah ai aj ak al am an"
     role="menuitem"
   >
     <a
@@ -43,4 +262,223 @@ exports[`should render with to 1`] = `
     </a>
   </li>
 </ul>
+`;
+
+exports[`should render with to 2`] = `
+"
+@-webkit-keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+@-moz-keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+@keyframes k1 {
+  0% {
+    display: none;
+    opacity: 0
+  }
+
+  1% {
+    display: block;
+    opacity: 0;
+    top: 80%
+  }
+
+  100% {
+    display: none;
+    opacity: 1;
+    top: 102%
+  }
+}
+
+.a {
+  position: absolute
+}
+
+.b {
+  z-index: 1
+}
+
+.c {
+  min-width: 10.66667rem
+}
+
+.d {
+  margin: 0.5em 0 0
+}
+
+.e {
+  padding: 0.33333rem 0
+}
+
+.f {
+  list-style: none
+}
+
+.g {
+  background: #fff
+}
+
+.h {
+  border: 1px solid #dedede
+}
+
+.i {
+  border-radius: 2px
+}
+
+.j {
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2)
+}
+
+.k {
+  left: initial
+}
+
+.l {
+  right: initial
+}
+
+.m {
+  animation-name: k1
+}
+
+.n {
+  animation-duration: 150ms;
+  -webkit-animation-duration: 150ms
+}
+
+.o {
+  animation-timing-function: ease-out;
+  -webkit-animation-timing-function: ease-out
+}
+
+.p::before {
+  content: ''
+}
+
+.q::before {
+  display: block
+}
+
+.r::before {
+  position: absolute
+}
+
+.s::before {
+  bottom: 100%
+}
+
+.t::before {
+  border: solid transparent
+}
+
+.u::before {
+  border-width: 10px
+}
+
+.v::before {
+  border-top-width: 0px
+}
+
+.w::before {
+  border-bottom-color: #fff
+}
+
+.x::before {
+  left: initial
+}
+
+.y::before {
+  right: initial
+}
+
+.z {
+  position: relative
+}
+
+.ab:first-child {
+  border-top-width: 0px
+}
+
+.ac > a {
+  display: block
+}
+
+.ad > a {
+  padding: 0.2rem 1.06667rem
+}
+
+.ae > a {
+  cursor: pointer
+}
+
+.af > a {
+  white-space: nowrap
+}
+
+.ag > a:hover {
+  color: #fff
+}
+
+.ah > a:hover {
+  background: #2F7BBF
+}
+
+.ai > a:focus {
+  color: #fff
+}
+
+.aj > a:focus {
+  background: #76C4E2
+}
+
+.ak > a:focus {
+  outline: 5px auto -webkit-focus-ring-color
+}
+
+.al > a:focus {
+  outline-offset: -1px
+}
+
+.am > a:active {
+  color: #fff
+}
+
+.an > a:active {
+  background: #408BC9
+}
+"
 `;

--- a/packages/cf-component-dropdown/test/__snapshots__/DropdownSeparator.js.snap
+++ b/packages/cf-component-dropdown/test/__snapshots__/DropdownSeparator.js.snap
@@ -2,7 +2,19 @@
 
 exports[`should render with to 1`] = `
 <div
-  className="cf-dropdown__separator"
+  className="a b"
   role="separator"
 />
+`;
+
+exports[`should render with to 2`] = `
+"
+.a {
+  margin: 0.53333rem 0
+}
+
+.b {
+  border-top: 1px solid #dedede
+}
+"
 `;


### PR DESCRIPTION
BREAKING CHANGE: Major migration of styles from plain old CSS class
names to the CSS-in-JS framework `fela`.

Closes: #210