### PR TITLE
fix(cf-component-toggle): add missing dependency

### DIFF
--- a/packages/cf-component-toggle/package.json
+++ b/packages/cf-component-toggle/package.json
@@ -11,6 +11,7 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
+    "cf-style-container": "^1.3.3",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
`cf-style-container` was missing from the dependency list