### PR TITLE
fix(cf-style-container): Change fela wrapper names

### DIFF
--- a/packages/cf-style-container/src/createComponent.js
+++ b/packages/cf-style-container/src/createComponent.js
@@ -66,7 +66,7 @@ function createComponentFactory(createElement, contextTypes) {
     }
 
     // use the rule name as display name to better debug with react inspector
-    FelaComponent.displayName = componentName;
+    FelaComponent.displayName = `${componentName}FelaWrapper`;
     FelaComponent._isFelaComponent = true;
 
     return FelaComponent;


### PR DESCRIPTION
Change the component display name for fela higher order components so
that the actual components can be targeted by their display names in
tests or otherwise.

BREAKING CHANGE: If you are targeting components in your tests you are
going to need to make some changes. Previously others have selected the
second one in the node list after querying for the display name.