### PR TITLE
fix(cf-component-callout): get all rules in theme

### DIFF
--- a/packages/cf-component-callout/src/Callout.js
+++ b/packages/cf-component-callout/src/Callout.js
@@ -4,9 +4,9 @@ import { createComponent } from 'cf-style-container';
 
 const styles = ({ theme, type = 'default' }) => {
   return {
-    margin: '1rem',
-    padding: '1rem',
-    border: '1px solid transparent',
+    margin: theme.margin,
+    padding: theme.padding,
+    border: theme.border,
     borderRadius: theme.borderRadius,
     color: theme.color,
 

--- a/packages/cf-component-callout/src/CalloutTheme.js
+++ b/packages/cf-component-callout/src/CalloutTheme.js
@@ -1,4 +1,8 @@
 export default baseTheme => ({
+  margin: '1rem',
+  padding: '1rem',
+  border: '1px solid transparent',
+
   borderRadius: baseTheme.borderRadius,
   color: baseTheme.colorWhite,
   default: {


### PR DESCRIPTION
Remove hard-coded values in the component `cf-component-callout` and move into the default theme so that they can be overwritten.