### PR TITLE
fix(cf-component-progress): media query fix

### DIFF
--- a/packages/cf-component-progress/example/basic/component.js
+++ b/packages/cf-component-progress/example/basic/component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Progress from 'cf-component-progress';
+import { Progress } from 'cf-component-progress';
 
 class ProgressComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-progress/src/Progress.js
+++ b/packages/cf-component-progress/src/Progress.js
@@ -55,8 +55,8 @@ const Item = createComponent(
     }
 
     return {
-      width,
-      float: 'left',
+      width: 'auto',
+      float: 'none',
       height: 'auto',
       padding: 0,
       paddingTop: '7.5px',
@@ -66,15 +66,16 @@ const Item = createComponent(
 
       textAlign: 'center',
       cursor: disabled ? 'default' : 'pointer',
+      display: active ? 'list-item' : 'none',
 
       '&::before': {
         content: 'none'
       },
 
       tablet: {
-        display: active ? 'block' : 'none',
-        width: 'auto !important',
-        float: 'none'
+        width,
+        float: 'left',
+        display: 'list-item'
       },
 
       '& > .cf-link': {

--- a/packages/cf-component-progress/test/__snapshots__/Progress.js.snap
+++ b/packages/cf-component-progress/test/__snapshots__/Progress.js.snap
@@ -14,7 +14,7 @@ exports[`should render 1`] = `
   >
     <li
       active={true}
-      className="r s t q u v w x y z ab ac ad ae af ag"
+      className="r s t q u v w x y z ab ac ad ae af ag ah"
       disabled={false}
       width="33.3333%"
     >
@@ -29,7 +29,7 @@ exports[`should render 1`] = `
     </li>
     <li
       active={false}
-      className="r s t q u ah w x y z ab ac ad ai af ag"
+      className="r s t q u ai w x y aj ab ac ad ae af ag ah"
       disabled={false}
       width="33.3333%"
     >
@@ -44,7 +44,7 @@ exports[`should render 1`] = `
     </li>
     <li
       active={false}
-      className="r s t q u aj w x ak z ab ac ad ai af ag"
+      className="r s t q u ak w x al aj ab ac ad ae af ag ah"
       disabled={true}
       width="33.3333%"
     >
@@ -137,11 +137,11 @@ exports[`should render 2`] = `
 }
 
 .r {
-  width: 33.3333%
+  width: auto
 }
 
 .s {
-  float: left
+  float: none
 }
 
 .t {
@@ -168,49 +168,53 @@ exports[`should render 2`] = `
   cursor: pointer
 }
 
-.z::before {
+.z {
+  display: list-item
+}
+
+.ab::before {
   content: none
 }
 
-.ab > .cf-link {
+.ac > .cf-link {
   display: block
 }
 
-.ac > .cf-link {
+.ad > .cf-link {
   color: inherit
 }
 
-.ad > .cf-link {
+.ae > .cf-link {
   cursor: pointer
 }
 
-.ah {
+.ai {
   color: #7c7c7c
 }
 
 .aj {
-  color: #dedede
+  display: none
 }
 
 .ak {
+  color: #dedede
+}
+
+.al {
   cursor: default
 }
 
 @media (min-width: 47.2em) {
-  .ae {
-    display: block
-  }
-  
   .af {
-    width: auto !important
+    width: 33.3333%
   }
   
   .ag {
-    float: none
+    float: left
   }
   
-  .ai {
-    display: none
+  .ah {
+    display: list-item
   }
 }
 "


### PR DESCRIPTION
Media queries in `cf-ui` are reversed to the ones in the legacy CSS
styles resulting in mobile styles being applied when the browser width
is larger than a average mobile device and the desktop styles being
applied when smaller than the average mobile device.

This PR reversed the styles along the media query "axis". So the correct
device styles are applies for the Progress component.