### PR TITLE
fix(cf-style-container): set themed component name

### DIFF
--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -42,6 +42,7 @@ const applyTheme = (ComponentToWrap, ...themes) => {
     }
   }
 
+  ThemedComponent.displayName = `Themed${ComponentToWrap.displayName}`;
   ThemedComponent.childContextTypes = { theme: PropTypes.object };
   ThemedComponent.contextTypes = { theme: PropTypes.object };
   return ThemedComponent;

--- a/packages/cf-style-container/test/index.js
+++ b/packages/cf-style-container/test/index.js
@@ -5,10 +5,12 @@ import {
   mergeThemes,
   filterNone,
   filterStyle,
-  mapChildren
+  mapChildren,
+  applyTheme
 } from '../../cf-style-container/src/index';
 import { variables } from 'cf-style-const';
 import { felaSnapshot } from 'cf-style-provider';
+import { shallow } from 'enzyme';
 
 test('mergeThemes should return an immutable and deeply cloned object', () => {
   const themeA = () => ({ color: 'yellow' });
@@ -118,4 +120,15 @@ test('mapChildren will call a function for each child, passing its index and the
     return child;
   });
   expect(result).toHaveLength(1);
+});
+
+describe('applyTheme', () => {
+  test('will set the display name to the same display name as the wrapped component with a "Themed" prefix', () => {
+    const SomeComponent = () => <div>foo</div>;
+    SomeComponent.displayName = 'SomeComponent';
+    const ThemedComponent = applyTheme(SomeComponent, {});
+
+    const wrapper = shallow(<ThemedComponent />);
+    expect(ThemedComponent.displayName).toBe('ThemedSomeComponent');
+  });
 });


### PR DESCRIPTION
Sets the `displayName` property of themed components to
`Themed[Component name]` rather than the `ThemedComponent` it is set to
now.

This change will make it possible to select these components in
`enzyme` tests by their display names.

BREAKING CHANGE: The display name of themed components now have a
`Themed` prefix to their display names. So if you had a themed component
that has the name `Button` it will now be `ThemedButton` instead of
`ThemedComponent`.

Related-to: #300