### PR TITLE
fix(cf-component-form): FormFieldset invalid propTypes

### DIFF
--- a/packages/cf-component-form/src/FormFieldset.js
+++ b/packages/cf-component-form/src/FormFieldset.js
@@ -60,10 +60,14 @@ class FormFieldset extends React.Component {
 }
 
 FormFieldset.propTypes = {
-  layout: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
+  layout: PropTypes.oneOf(['horizontal', 'vertical']),
   styles: PropTypes.object.isRequired,
   legend: PropTypes.string.isRequired,
   children: PropTypes.node
+};
+
+FormFieldset.defaultProps = {
+  layout: 'vertical'
 };
 
 export default createComponentStyles(


### PR DESCRIPTION
I saw that in our example, this component was failing validation since this prop was missing (and it's specified as required). However, it's not _really_ required. The component defaults to `vertical`. Well, that's not exactly true. All input that isn't `horizontal` is treated as `vertical`.