### PR TITLE
fix(cf-component-input): spread input props

### DIFF
--- a/packages/cf-component-input/src/Input.js
+++ b/packages/cf-component-input/src/Input.js
@@ -32,28 +32,7 @@ const styles = ({ theme }) => ({
 
 class Input extends React.Component {
   render() {
-    const {
-      type,
-      name,
-      value,
-      onChange,
-      placeholder,
-      autoComplete,
-      invalid,
-      className
-    } = this.props;
-    return (
-      <input
-        type={type}
-        name={name}
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        autoComplete={autoComplete}
-        invalid={invalid}
-        className={className}
-      />
-    );
+    return <input {...this.props} />;
   }
 }
 


### PR DESCRIPTION
Instead of maintaning a 1-to-1 list of props that HTMLInputElement can accept we should just spread the ones we get from the parent on the `<input />` component.