### PR TITLE
Allow passing selectorPrefix into cf-style-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "./scripts/build.sh",
     "lint": "eslint packages/*/src/**/*.js packages/*/example/**/*.js packages/*/test/**/*.js",
-    "test": "cross-env BABEL_ENV=commonjs jest",
+    "test": "cross-env BABEL_ENV=commonjs jest --no-cache",
     "updated": "lerna updated --only-explicit-updates",
     "prettier": "node prettier.js",
     "clean": "lerna clean --yes && rimraf .jest packages/**/es packages/**/lib packages/**/dist",

--- a/packages/cf-style-provider/src/createRenderer.js
+++ b/packages/cf-style-provider/src/createRenderer.js
@@ -45,6 +45,7 @@ const createRenderer = opts => {
   return createFelaRenderer({
     plugins,
     enhancers,
+    selectorPrefix: usedOpts.selectorPrefix,
     mediaQueryOrder: [
       removePrefix(mediaQueries.mobile),
       removePrefix(mediaQueries.mobileWide),


### PR DESCRIPTION
Default value will be empty so no changes to the current behavior. We allow passing value through input parameter in case we need to use prefix (in case of class name collision)