### PR TITLE
feat(cf-component-checkbox): migrate css to fela

### DIFF
--- a/packages/cf-component-checkbox/example/basic/component.js
+++ b/packages/cf-component-checkbox/example/basic/component.js
@@ -1,5 +1,23 @@
 import React from 'react';
-import { Checkbox, CheckboxGroup } from 'cf-component-checkbox';
+import {
+  Checkbox,
+  CheckboxUnstyled,
+  CheckboxTheme,
+  CheckboxGroup
+} from 'cf-component-checkbox';
+import { applyTheme } from 'cf-style-container';
+
+const CheckboxGroupItem = applyTheme(
+  CheckboxUnstyled,
+  CheckboxTheme,
+  theme => ({
+    marginTop: '1em',
+
+    '&:first-child': {
+      marginTop: 0
+    }
+  })
+);
 
 class CheckboxComponent extends React.Component {
   constructor(props) {
@@ -21,14 +39,16 @@ class CheckboxComponent extends React.Component {
   render() {
     return (
       <div>
-        <p>You can create them individually with <code>Checkbox</code></p>
+        <p>
+          You can create them individually with <code>Checkbox</code>
+        </p>
 
         <Checkbox
           label="Checkbox 1"
           name="checkbox-1"
           value="checkbox1"
           checked={this.state.checkbox1}
-          onChange={checked => this.setState({ checkbox1: checked })}
+          onChange={event => this.setState({ checkbox1: event.target.checked })}
         />
 
         <Checkbox
@@ -36,19 +56,28 @@ class CheckboxComponent extends React.Component {
           name="checkbox-2"
           value="checkbox2"
           checked={this.state.checkbox2}
-          onChange={checked => this.setState({ checkbox2: checked })}
+          onChange={event => this.setState({ checkbox2: event.target.checked })}
         />
 
-        <p>Or as a group with <code>CheckboxGroup</code></p>
+        <p>
+          Or as a group with <code>CheckboxGroup</code>
+        </p>
 
         <CheckboxGroup
           values={this.state.checkboxValues}
           onChange={this.onCheckboxGroupChange}
-          options={[
-            { label: 'Option 1', name: 'group-option-1', value: 'option1' },
-            { label: 'Option 2', name: 'group-option-2', value: 'option2' }
-          ]}
-        />
+        >
+          <CheckboxGroupItem
+            label="Option 1"
+            name="group-option-1"
+            value="option1"
+          />
+          <CheckboxGroupItem
+            label="Option 2"
+            name="group-option-2"
+            value="option2"
+          />
+        </CheckboxGroup>
 
         <p>
           You can also disable a label by passing <code>false</code> explicitly
@@ -59,7 +88,7 @@ class CheckboxComponent extends React.Component {
           name="checkbox-1-no-label"
           value="checkbox1"
           checked={this.state.checkbox1}
-          onChange={checked => this.setState({ checkbox1: checked })}
+          onChange={event => this.setState({ checkbox1: event.target.checked })}
         />
       </div>
     );

--- a/packages/cf-component-checkbox/src/Checkbox.js
+++ b/packages/cf-component-checkbox/src/Checkbox.js
@@ -1,20 +1,81 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
+import { createComponent } from 'cf-style-container';
+
+const styles = ({ theme, checked }) => ({
+  cursor: 'pointer',
+  display: 'block',
+  minHeight: '1em',
+  paddingLeft: '2em'
+});
+
+const Input = createComponent(
+  ({ theme, checked }) => ({
+    zIndex: 0,
+    border: '1px solid #bdbdbd',
+    borderRadius: theme.borderRadius,
+
+    verticalAlign: 'middle',
+    fontFamily: theme.fontFamily,
+    fontSize: '0.86667rem',
+
+    background: theme.colorWhite,
+    color: theme.color.charcoal,
+    outline: 'none',
+
+    transition: 'border-color 0.2s ease',
+    position: 'relative',
+    height: '15px',
+    width: '15px',
+    margin: '1px 0 0',
+    padding: 0,
+    lineHeight: 'normal',
+    appearance: 'none',
+    top: '-1px',
+
+    '&:hover': {
+      borderColor: '#256298'
+    },
+
+    '&:focus': {
+      outline: '5px auto -webkit-focus-ring-color',
+      outlineOffset: '-1px'
+    },
+
+    '&::before': {
+      color: checked ? theme.color.charcoal : 'transparent',
+      position: 'absolute',
+      backgroundColor: 'transparent',
+      '-webkit-text-stroke': 0,
+      transition: 'all 150ms ease-out',
+      content: "'\\f009'",
+      fontFamily: 'cloudflare-font',
+      fontSize: '15px',
+      left: '-1px',
+      top: '-1px'
+    }
+  }),
+  'input',
+  ['type', 'id', 'name', 'value', 'checked', 'onChange']
+);
+
+const Label = createComponent(
+  () => ({
+    display: 'inline',
+    fontSize: '0.86667rem',
+    marginBottom: '0.38333em',
+    marginLeft: '1em',
+    minHeight: '1.22em'
+  }),
+  'span'
+);
 
 class Checkbox extends React.Component {
   render() {
-    let className = 'cf-checkbox';
-
-    if (this.props.checked) {
-      className += ' cf-checkbox--checked';
-    }
-
     return (
-      <label htmlFor={this.props.name} className={className}>
-        <input
+      <label htmlFor={this.props.name} className={this.props.className}>
+        <Input
           type="checkbox"
-          className="cf-checkbox__input"
           id={this.props.name}
           name={this.props.name}
           value={this.props.value}
@@ -22,9 +83,9 @@ class Checkbox extends React.Component {
           onChange={this.props.onChange}
         />
         {this.props.label &&
-          <span className="cf-checkbox__label">
+          <Label>
             {this.props.label}
-          </span>}
+          </Label>}
       </label>
     );
   }
@@ -39,4 +100,4 @@ Checkbox.propTypes = {
   onChange: PropTypes.func.isRequired
 };
 
-export default Checkbox;
+export default createComponent(styles, Checkbox);

--- a/packages/cf-component-checkbox/src/CheckboxGroup.js
+++ b/packages/cf-component-checkbox/src/CheckboxGroup.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Checkbox from './Checkbox';
 import includes from 'lodash/includes';
 
 class CheckboxGroup extends React.Component {
@@ -10,16 +9,16 @@ class CheckboxGroup extends React.Component {
   }
 
   handleChange(value, checked) {
-    const values = this.props.options
+    const values = this.props.children
       .filter(option => {
-        if (option.value === value) {
+        if (option.props.value === value) {
           return checked;
         }
 
-        return includes(this.props.values, option.value);
+        return includes(this.props.values, option.props.value);
       })
       .map(option => {
-        return option.value;
+        return option.props.value;
       });
 
     this.props.onChange(values);
@@ -27,19 +26,15 @@ class CheckboxGroup extends React.Component {
 
   render() {
     return (
-      <div className="cf-checkbox__group">
-        {this.props.options.map(option => {
-          return (
-            <Checkbox
-              key={option.name}
-              label={option.label}
-              name={option.name}
-              value={option.value}
-              checked={includes(this.props.values, option.value)}
-              onChange={e => this.handleChange(option.value, e.target.checked)}
-            />
-          );
-        })}
+      <div>
+        {React.Children.map(this.props.children, Checkbox =>
+          React.cloneElement(Checkbox, {
+            key: Checkbox.props.name,
+            checked: includes(this.props.values, Checkbox.props.value),
+            onChange: event =>
+              this.handleChange(Checkbox.props.value, event.target.checked)
+          })
+        )}
       </div>
     );
   }

--- a/packages/cf-component-checkbox/src/CheckboxTheme.js
+++ b/packages/cf-component-checkbox/src/CheckboxTheme.js
@@ -1,0 +1,1 @@
+export default baseTheme => ({});

--- a/packages/cf-component-checkbox/src/index.js
+++ b/packages/cf-component-checkbox/src/index.js
@@ -1,4 +1,8 @@
-import Checkbox from './Checkbox';
+import { applyTheme } from 'cf-style-container';
+import CheckboxUnstyled from './Checkbox';
+import CheckboxTheme from './CheckboxTheme';
 import CheckboxGroup from './CheckboxGroup';
 
-export { Checkbox, CheckboxGroup };
+const Checkbox = applyTheme(CheckboxUnstyled, CheckboxTheme);
+
+export { Checkbox, CheckboxUnstyled, CheckboxTheme, CheckboxGroup };

--- a/packages/cf-component-checkbox/test/Checkbox.js
+++ b/packages/cf-component-checkbox/test/Checkbox.js
@@ -1,25 +1,28 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import { Checkbox } from '../../cf-component-checkbox/src/index';
 import { shallow } from 'enzyme';
+import { felaTestContext, felaSnapshot } from 'cf-style-provider';
+
+import { Checkbox } from '../../cf-component-checkbox/src/index';
 
 test('should handle onChange', () => {
   let called = false;
   const wrapper = shallow(
-    <Checkbox
-      label="Option 1"
-      name="checkbox-option-1"
-      value="option1"
-      checked={false}
-      onChange={() => called = true}
-    />
+    felaTestContext(
+      <Checkbox
+        label="Option 1"
+        name="checkbox-option-1"
+        value="option1"
+        checked={false}
+        onChange={() => called = true}
+      />
+    )
   );
-  wrapper.find('input').simulate('change');
+  wrapper.find('ThemedCheckboxFelaWrapper').simulate('change');
   expect(called).toBeTruthy();
 });
 
 test('should render', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Checkbox
       label="Option 1"
       name="checkbox-option-1"
@@ -28,11 +31,12 @@ test('should render', () => {
       onChange={() => {}}
     />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render checked', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Checkbox
       label="Option 1"
       name="checkbox-option-1"
@@ -41,11 +45,12 @@ test('should render checked', () => {
       onChange={() => {}}
     />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });
 
 test('should render without a label', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <Checkbox
       label={false}
       name="checkbox-option-1"
@@ -54,5 +59,6 @@ test('should render without a label', () => {
       onChange={() => {}}
     />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });

--- a/packages/cf-component-checkbox/test/CheckboxGroup.js
+++ b/packages/cf-component-checkbox/test/CheckboxGroup.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { felaSnapshot } from 'cf-style-provider';
+
 import { CheckboxGroup } from '../../cf-component-checkbox/src/index';
 
 test('should render', () => {
-  const component = renderer.create(
+  const snapshot = felaSnapshot(
     <CheckboxGroup
       values={['option1']}
       onChange={() => {}}
@@ -13,5 +14,6 @@ test('should render', () => {
       ]}
     />
   );
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });

--- a/packages/cf-component-checkbox/test/__snapshots__/Checkbox.js.snap
+++ b/packages/cf-component-checkbox/test/__snapshots__/Checkbox.js.snap
@@ -2,12 +2,12 @@
 
 exports[`should render 1`] = `
 <label
-  className="cf-checkbox"
+  className="a b c d"
   htmlFor="checkbox-option-1"
 >
   <input
     checked={false}
-    className="cf-checkbox__input"
+    className="e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj"
     id="checkbox-option-1"
     name="checkbox-option-1"
     onChange={[Function]}
@@ -15,21 +15,187 @@ exports[`should render 1`] = `
     value="option1"
   />
   <span
-    className="cf-checkbox__label"
+    className="ak j al am an"
   >
     Option 1
   </span>
 </label>
+`;
+
+exports[`should render 2`] = `
+"
+.a {
+  cursor: pointer
+}
+
+.b {
+  display: block
+}
+
+.c {
+  min-height: 1em
+}
+
+.d {
+  padding-left: 2em
+}
+
+.e {
+  z-index: 0
+}
+
+.f {
+  border: 1px solid #bdbdbd
+}
+
+.g {
+  border-radius: 2px
+}
+
+.h {
+  vertical-align: middle
+}
+
+.i {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.j {
+  font-size: 0.86667rem
+}
+
+.k {
+  background: #fff
+}
+
+.l {
+  color: #333333
+}
+
+.m {
+  outline: none
+}
+
+.n {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.o {
+  position: relative
+}
+
+.p {
+  height: 15px
+}
+
+.q {
+  width: 15px
+}
+
+.r {
+  margin: 1px 0 0
+}
+
+.s {
+  padding: 0px
+}
+
+.t {
+  line-height: normal
+}
+
+.u {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none
+}
+
+.v {
+  top: -1px
+}
+
+.w:hover {
+  border-color: #256298
+}
+
+.x:focus {
+  outline: 5px auto -webkit-focus-ring-color
+}
+
+.y:focus {
+  outline-offset: -1px
+}
+
+.z::before {
+  color: transparent
+}
+
+.ab::before {
+  position: absolute
+}
+
+.ac::before {
+  background-color: transparent
+}
+
+.ad::before {
+  -webkit-text-stroke: 0px
+}
+
+.ae::before {
+  transition: all 150ms ease-out;
+  -webkit-transition: all 150ms ease-out;
+  -moz-transition: all 150ms ease-out
+}
+
+.af::before {
+  content: '\\\\f009'
+}
+
+.ag::before {
+  font-family: cloudflare-font
+}
+
+.ah::before {
+  font-size: 15px
+}
+
+.ai::before {
+  left: -1px
+}
+
+.aj::before {
+  top: -1px
+}
+
+.ak {
+  display: inline
+}
+
+.al {
+  margin-bottom: 0.38333em
+}
+
+.am {
+  margin-left: 1em
+}
+
+.an {
+  min-height: 1.22em
+}
+"
 `;
 
 exports[`should render checked 1`] = `
 <label
-  className="cf-checkbox cf-checkbox--checked"
+  className="a b c d"
   htmlFor="checkbox-option-1"
 >
   <input
     checked={true}
-    className="cf-checkbox__input"
+    className="e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj"
     id="checkbox-option-1"
     name="checkbox-option-1"
     onChange={[Function]}
@@ -37,21 +203,187 @@ exports[`should render checked 1`] = `
     value="option1"
   />
   <span
-    className="cf-checkbox__label"
+    className="ak j al am an"
   >
     Option 1
   </span>
 </label>
 `;
 
+exports[`should render checked 2`] = `
+"
+.a {
+  cursor: pointer
+}
+
+.b {
+  display: block
+}
+
+.c {
+  min-height: 1em
+}
+
+.d {
+  padding-left: 2em
+}
+
+.e {
+  z-index: 0
+}
+
+.f {
+  border: 1px solid #bdbdbd
+}
+
+.g {
+  border-radius: 2px
+}
+
+.h {
+  vertical-align: middle
+}
+
+.i {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.j {
+  font-size: 0.86667rem
+}
+
+.k {
+  background: #fff
+}
+
+.l {
+  color: #333333
+}
+
+.m {
+  outline: none
+}
+
+.n {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.o {
+  position: relative
+}
+
+.p {
+  height: 15px
+}
+
+.q {
+  width: 15px
+}
+
+.r {
+  margin: 1px 0 0
+}
+
+.s {
+  padding: 0px
+}
+
+.t {
+  line-height: normal
+}
+
+.u {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none
+}
+
+.v {
+  top: -1px
+}
+
+.w:hover {
+  border-color: #256298
+}
+
+.x:focus {
+  outline: 5px auto -webkit-focus-ring-color
+}
+
+.y:focus {
+  outline-offset: -1px
+}
+
+.z::before {
+  color: #333333
+}
+
+.ab::before {
+  position: absolute
+}
+
+.ac::before {
+  background-color: transparent
+}
+
+.ad::before {
+  -webkit-text-stroke: 0px
+}
+
+.ae::before {
+  transition: all 150ms ease-out;
+  -webkit-transition: all 150ms ease-out;
+  -moz-transition: all 150ms ease-out
+}
+
+.af::before {
+  content: '\\\\f009'
+}
+
+.ag::before {
+  font-family: cloudflare-font
+}
+
+.ah::before {
+  font-size: 15px
+}
+
+.ai::before {
+  left: -1px
+}
+
+.aj::before {
+  top: -1px
+}
+
+.ak {
+  display: inline
+}
+
+.al {
+  margin-bottom: 0.38333em
+}
+
+.am {
+  margin-left: 1em
+}
+
+.an {
+  min-height: 1.22em
+}
+"
+`;
+
 exports[`should render without a label 1`] = `
 <label
-  className="cf-checkbox"
+  className="a b c d"
   htmlFor="checkbox-option-1"
 >
   <input
     checked={false}
-    className="cf-checkbox__input"
+    className="e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj"
     id="checkbox-option-1"
     name="checkbox-option-1"
     onChange={[Function]}
@@ -59,4 +391,154 @@ exports[`should render without a label 1`] = `
     value="option1"
   />
 </label>
+`;
+
+exports[`should render without a label 2`] = `
+"
+.a {
+  cursor: pointer
+}
+
+.b {
+  display: block
+}
+
+.c {
+  min-height: 1em
+}
+
+.d {
+  padding-left: 2em
+}
+
+.e {
+  z-index: 0
+}
+
+.f {
+  border: 1px solid #bdbdbd
+}
+
+.g {
+  border-radius: 2px
+}
+
+.h {
+  vertical-align: middle
+}
+
+.i {
+  font-family: \\"Open Sans\\", Helvetica, Arial, sans-serif
+}
+
+.j {
+  font-size: 0.86667rem
+}
+
+.k {
+  background: #fff
+}
+
+.l {
+  color: #333333
+}
+
+.m {
+  outline: none
+}
+
+.n {
+  transition: border-color 0.2s ease;
+  -webkit-transition: border-color 0.2s ease;
+  -moz-transition: border-color 0.2s ease
+}
+
+.o {
+  position: relative
+}
+
+.p {
+  height: 15px
+}
+
+.q {
+  width: 15px
+}
+
+.r {
+  margin: 1px 0 0
+}
+
+.s {
+  padding: 0px
+}
+
+.t {
+  line-height: normal
+}
+
+.u {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none
+}
+
+.v {
+  top: -1px
+}
+
+.w:hover {
+  border-color: #256298
+}
+
+.x:focus {
+  outline: 5px auto -webkit-focus-ring-color
+}
+
+.y:focus {
+  outline-offset: -1px
+}
+
+.z::before {
+  color: transparent
+}
+
+.ab::before {
+  position: absolute
+}
+
+.ac::before {
+  background-color: transparent
+}
+
+.ad::before {
+  -webkit-text-stroke: 0px
+}
+
+.ae::before {
+  transition: all 150ms ease-out;
+  -webkit-transition: all 150ms ease-out;
+  -moz-transition: all 150ms ease-out
+}
+
+.af::before {
+  content: '\\\\f009'
+}
+
+.ag::before {
+  font-family: cloudflare-font
+}
+
+.ah::before {
+  font-size: 15px
+}
+
+.ai::before {
+  left: -1px
+}
+
+.aj::before {
+  top: -1px
+}
+"
 `;

--- a/packages/cf-component-checkbox/test/__snapshots__/CheckboxGroup.js.snap
+++ b/packages/cf-component-checkbox/test/__snapshots__/CheckboxGroup.js.snap
@@ -1,46 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render 1`] = `
-<div
-  className="cf-checkbox__group"
->
-  <label
-    className="cf-checkbox cf-checkbox--checked"
-    htmlFor="group-option-1"
-  >
-    <input
-      checked={true}
-      className="cf-checkbox__input"
-      id="group-option-1"
-      name="group-option-1"
-      onChange={[Function]}
-      type="checkbox"
-      value="option1"
-    />
-    <span
-      className="cf-checkbox__label"
-    >
-      Option 1
-    </span>
-  </label>
-  <label
-    className="cf-checkbox"
-    htmlFor="group-option-2"
-  >
-    <input
-      checked={false}
-      className="cf-checkbox__input"
-      id="group-option-2"
-      name="group-option-2"
-      onChange={[Function]}
-      type="checkbox"
-      value="option2"
-    />
-    <span
-      className="cf-checkbox__label"
-    >
-      Option 2
-    </span>
-  </label>
-</div>
+exports[`should render 1`] = `<div />`;
+
+exports[`should render 2`] = `
+"
+
+"
 `;


### PR DESCRIPTION
BREAKING CHANGE: Styles are now managed in the component using the CSS-in-JS framework `fela`. This internal re-write warrants a re-write.

Additionally the `onChange` callback on the input has changed. The callback now gives you the change event rather than just the `Event.EventTarget.checked` property.

Related-to: #212