### PR TITLE
feat(cf-component-input): allow disabled on input

### DIFF
--- a/packages/cf-component-input/example/basic/component.js
+++ b/packages/cf-component-input/example/basic/component.js
@@ -32,6 +32,13 @@ class InputComponent extends React.Component {
           value={this.state.inputValue}
           onChange={this.handleChange}
         />
+
+        <Input
+          disabled
+          name="example"
+          value={this.state.inputValue}
+          onChange={this.handleChange}
+        />
       </div>
     );
   }

--- a/packages/cf-component-input/src/Input.js
+++ b/packages/cf-component-input/src/Input.js
@@ -47,7 +47,8 @@ Input.propTypes = {
   placeholder: PropTypes.string,
   autoComplete: PropTypes.string,
   invalid: PropTypes.bool,
-  className: PropTypes.string
+  className: PropTypes.string,
+  disabled: PropTypes.boolean
 };
 
 Input.defaultProps = {

--- a/packages/cf-component-input/test/__snapshots__/Input.js.snap
+++ b/packages/cf-component-input/test/__snapshots__/Input.js.snap
@@ -4,6 +4,7 @@ exports[`should pass all props down to the inner input and merge classnames 1`] 
 <input
   autoComplete={undefined}
   className="a b c d e f g h i j k l m n o"
+  disabled={true}
   invalid={true}
   name="example"
   onBlur={undefined}
@@ -86,6 +87,7 @@ exports[`should render 1`] = `
 <input
   autoComplete={undefined}
   className="a b c d e f g h i j k l m n o"
+  disabled={undefined}
   invalid={undefined}
   name="example"
   onBlur={undefined}
@@ -168,6 +170,7 @@ exports[`should render with autocomplete 1`] = `
 <input
   autoComplete="off"
   className="a b c d e f g h i j k l m n o"
+  disabled={undefined}
   invalid={undefined}
   name="example"
   onBlur={undefined}
@@ -250,6 +253,7 @@ exports[`should render with error 1`] = `
 <input
   autoComplete={undefined}
   className="a b c d e f g h i j k l m n o"
+  disabled={undefined}
   invalid={true}
   name="example"
   onBlur={undefined}
@@ -332,6 +336,7 @@ exports[`should render with placeholder 1`] = `
 <input
   autoComplete={undefined}
   className="a b c d e f g h i j k l m n o"
+  disabled={undefined}
   invalid={undefined}
   name="example"
   onBlur={undefined}
@@ -414,6 +419,7 @@ exports[`should render with type 1`] = `
 <input
   autoComplete={undefined}
   className="a b c d e f g h i j k l m n o"
+  disabled={undefined}
   invalid={undefined}
   name="example"
   onBlur={undefined}


### PR DESCRIPTION
In fela we need to whitelist all the props we want to be passed down to the wrapped component.

This PR adds the `disabled` property to the prop types of the `Input` component.