### PR TITLE
feat(cf-component-input): allow text-indent on input

### DIFF
--- a/packages/cf-component-input/src/Input.js
+++ b/packages/cf-component-input/src/Input.js
@@ -20,6 +20,7 @@ const styles = ({ theme }) => ({
   outline: theme.outline,
 
   transition: theme.transition,
+  textIndent: theme.textIndent,
 
   '&:hover': {
     borderColor: theme['&:hover'].borderColor

--- a/packages/cf-component-input/src/InputTheme.js
+++ b/packages/cf-component-input/src/InputTheme.js
@@ -16,6 +16,7 @@ export default baseTheme => ({
   outline: 'none',
 
   transition: 'border-color 0.2s ease',
+  textIndent: 'initial',
 
   '&:hover': {
     borderColor: '#256298'

--- a/packages/cf-component-input/test/__snapshots__/Input.js.snap
+++ b/packages/cf-component-input/test/__snapshots__/Input.js.snap
@@ -3,7 +3,7 @@
 exports[`should pass all props down to the inner input and merge classnames 1`] = `
 <input
   autoComplete={undefined}
-  className="a b c d e f g h i j k l m n o"
+  className="a b c d e f g h i j k l m n o p"
   disabled={true}
   invalid={true}
   name="example"
@@ -77,7 +77,11 @@ exports[`should pass all props down to the inner input and merge classnames 2`] 
   -moz-transition: border-color 0.2s ease
 }
 
-.o:hover {
+.o {
+  text-indent: initial
+}
+
+.p:hover {
   border-color: #256298
 }
 "
@@ -86,7 +90,7 @@ exports[`should pass all props down to the inner input and merge classnames 2`] 
 exports[`should render 1`] = `
 <input
   autoComplete={undefined}
-  className="a b c d e f g h i j k l m n o"
+  className="a b c d e f g h i j k l m n o p"
   disabled={undefined}
   invalid={undefined}
   name="example"
@@ -160,7 +164,11 @@ exports[`should render 2`] = `
   -moz-transition: border-color 0.2s ease
 }
 
-.o:hover {
+.o {
+  text-indent: initial
+}
+
+.p:hover {
   border-color: #256298
 }
 "
@@ -169,7 +177,7 @@ exports[`should render 2`] = `
 exports[`should render with autocomplete 1`] = `
 <input
   autoComplete="off"
-  className="a b c d e f g h i j k l m n o"
+  className="a b c d e f g h i j k l m n o p"
   disabled={undefined}
   invalid={undefined}
   name="example"
@@ -243,7 +251,11 @@ exports[`should render with autocomplete 2`] = `
   -moz-transition: border-color 0.2s ease
 }
 
-.o:hover {
+.o {
+  text-indent: initial
+}
+
+.p:hover {
   border-color: #256298
 }
 "
@@ -252,7 +264,7 @@ exports[`should render with autocomplete 2`] = `
 exports[`should render with error 1`] = `
 <input
   autoComplete={undefined}
-  className="a b c d e f g h i j k l m n o"
+  className="a b c d e f g h i j k l m n o p"
   disabled={undefined}
   invalid={true}
   name="example"
@@ -326,7 +338,11 @@ exports[`should render with error 2`] = `
   -moz-transition: border-color 0.2s ease
 }
 
-.o:hover {
+.o {
+  text-indent: initial
+}
+
+.p:hover {
   border-color: #256298
 }
 "
@@ -335,7 +351,7 @@ exports[`should render with error 2`] = `
 exports[`should render with placeholder 1`] = `
 <input
   autoComplete={undefined}
-  className="a b c d e f g h i j k l m n o"
+  className="a b c d e f g h i j k l m n o p"
   disabled={undefined}
   invalid={undefined}
   name="example"
@@ -409,7 +425,11 @@ exports[`should render with placeholder 2`] = `
   -moz-transition: border-color 0.2s ease
 }
 
-.o:hover {
+.o {
+  text-indent: initial
+}
+
+.p:hover {
   border-color: #256298
 }
 "
@@ -418,7 +438,7 @@ exports[`should render with placeholder 2`] = `
 exports[`should render with type 1`] = `
 <input
   autoComplete={undefined}
-  className="a b c d e f g h i j k l m n o"
+  className="a b c d e f g h i j k l m n o p"
   disabled={undefined}
   invalid={undefined}
   name="example"
@@ -492,7 +512,11 @@ exports[`should render with type 2`] = `
   -moz-transition: border-color 0.2s ease
 }
 
-.o:hover {
+.o {
+  text-indent: initial
+}
+
+.p:hover {
   border-color: #256298
 }
 "


### PR DESCRIPTION
In fela we need to add all properties we'd like to override with other values into the component.

This PR adds the `text-indent` key to the style object of the Input component.