### PR TITLE
fix(cf-component-tabs): set the correct colors

### DIFF
--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -34,50 +34,50 @@ const TabsGroup = createComponent(
 
 const TabItem = createComponent(
   ({ theme, selected }) => ({
-    flex: theme.flex,
-    background: theme.background,
-    color: theme.color,
-    cursor: theme.cursor,
-    display: theme.display,
-    margin: theme.margin,
-    padding: theme.padding,
-    position: theme.position,
-    textAlign: theme.textAlign,
-    verticalAlign: theme.verticalAlign,
-    outline: theme.outline,
-    userSelect: theme.userSelect,
+    flex: theme.item.flex,
+    background: theme.item.background,
+    color: theme.item.color,
+    cursor: theme.item.cursor,
+    display: theme.item.display,
+    margin: theme.item.margin,
+    padding: theme.item.padding,
+    position: theme.item.position,
+    textAlign: theme.item.textAlign,
+    verticalAlign: theme.item.verticalAlign,
+    outline: theme.item.outline,
+    userSelect: theme.item.userSelect,
 
-    borderStyle: theme.borderStyle,
+    borderStyle: theme.item.borderStyle,
     borderTopWidth: selected
-      ? theme.borderTopWidthSelected
-      : theme.borderTopWidth,
-    borderLeftWidth: theme.borderLeftWidth,
+      ? theme.item.borderTopWidthSelected
+      : theme.item.borderTopWidth,
+    borderLeftWidth: theme.item.borderLeftWidth,
     borderBottomWidth: selected
-      ? theme.borderBottomWidthSelected
-      : theme.borderBottomWidth,
-    borderRightWidth: theme.borderRightWidth,
+      ? theme.item.borderBottomWidthSelected
+      : theme.item.borderBottomWidth,
+    borderRightWidth: theme.item.borderRightWidth,
     borderTopColor: selected
-      ? theme.borderTopColorSelected
-      : theme.borderTopColor,
-    borderLeftColor: theme.borderLeftColor,
-    borderBottomColor: theme.borderBottomColor,
-    borderRightColor: theme.borderRightColor,
+      ? theme.item.borderTopColorSelected
+      : theme.item.borderTopColor,
+    borderLeftColor: theme.item.borderLeftColor,
+    borderBottomColor: theme.item.borderBottomColor,
+    borderRightColor: theme.item.borderRightColor,
 
     '&:last-child': {
-      borderRightWidth: theme['&:last-child'].borderRightWidth
+      borderRightWidth: theme.item['&:last-child'].borderRightWidth
     },
 
     '&:focus': {
       '&::after': {
-        outline: theme['&:focus']['&::after'].outline
+        outline: theme.item['&:focus']['&::after'].outline
       }
     },
 
     '&:hover': {
       background: selected
-        ? theme['&:hover'].backgroundSelected
-        : theme['&:hover'].background,
-      color: theme['&:hover'].color
+        ? theme.item['&:hover'].backgroundSelected
+        : theme.item['&:hover'].background,
+      color: theme.item['&:hover'].color
     }
   }),
   'li',

--- a/packages/cf-component-tabs/src/TabsTheme.js
+++ b/packages/cf-component-tabs/src/TabsTheme.js
@@ -1,44 +1,46 @@
 export default baseTheme => ({
-  flex: 1,
-  background: baseTheme.color.white,
-  color: baseTheme.colorBlue,
-  cursor: 'pointer',
-  display: 'table-cell',
-  margin: 0,
-  padding: '1.5rem 1rem',
-  position: 'relative',
-  textAlign: 'center',
-  verticalAlign: 'middle',
-  outline: 'none',
-  userSelect: 'none',
+  item: {
+    flex: 1,
+    background: baseTheme.colorWhite,
+    color: baseTheme.colorBlue,
+    cursor: 'pointer',
+    display: 'table-cell',
+    margin: 0,
+    padding: '1.5rem 1rem',
+    position: 'relative',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    outline: 'none',
+    userSelect: 'none',
 
-  borderTopWidth: 0,
-  borderTopWidthSelected: 2,
-  borderLeftWidth: 0,
-  borderBottomWidth: 1,
-  borderBottomWidthSelected: 0,
-  borderRightWidth: 1,
+    borderTopWidth: 0,
+    borderTopWidthSelected: 2,
+    borderLeftWidth: 0,
+    borderBottomWidth: 1,
+    borderBottomWidthSelected: 0,
+    borderRightWidth: 1,
 
-  borderStyle: 'solid',
-  borderTopColor: baseTheme.color.smoke,
-  borderTopColorSelected: baseTheme.colorBlue,
-  borderLeftColor: baseTheme.color.smoke,
-  borderBottomColor: baseTheme.color.smoke,
-  borderRightColor: baseTheme.color.smoke,
+    borderStyle: 'solid',
+    borderTopColor: baseTheme.color.smoke,
+    borderTopColorSelected: baseTheme.colorBlue,
+    borderLeftColor: baseTheme.color.smoke,
+    borderBottomColor: baseTheme.color.smoke,
+    borderRightColor: baseTheme.color.smoke,
 
-  '&:last-child': {
-    borderRightWidth: 0
-  },
+    '&:last-child': {
+      borderRightWidth: 0
+    },
 
-  '&:focus': {
-    '&::after': {
-      outline: 'none'
+    '&:focus': {
+      '&::after': {
+        outline: 'none'
+      }
+    },
+
+    '&:hover': {
+      background: baseTheme.color.moonshine,
+      backgroundSelected: baseTheme.colorWhite,
+      color: baseTheme.colorBlue
     }
-  },
-
-  '&:hover': {
-    background: baseTheme.color.moonshine,
-    backgroundSelected: baseTheme.colorWhite,
-    color: baseTheme.colorBlue
   }
 });

--- a/packages/cf-component-tabs/test/__snapshots__/Tabs.js.snap
+++ b/packages/cf-component-tabs/test/__snapshots__/Tabs.js.snap
@@ -2,12 +2,12 @@
 
 exports[`should render 1`] = `
 <section
-  className="a b"
+  className="a b c"
 >
   <div
     aria-hidden={false}
     aria-labelledby="2"
-    className="c"
+    className="d"
     role="tabpanel"
   >
     Two
@@ -26,6 +26,10 @@ exports[`should render 2`] = `
 }
 
 .c {
+  border: 1px solid #e0e0e0
+}
+
+.d {
   background-color: #fff
 }
 "


### PR DESCRIPTION
In #314 we errounisly made assumptions where colors are kept in the
theme. Trying to access the white color at `theme.color.white` and the
smoke color at `theme.color.smoke` resulted in `undefined` values that
`fela` swallows up and not emitting a rule.

This patch references the colors in the correct location as well as
minor housekeeping to keep the tabs theme a bit tidier.