### PR TITLE
chore: add default code reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# See https://github.com/blog/2392-introducing-code-owners for more info
+
+# These owners will be the default owners for everything in the repo.
+*        @tajo @sejoker @hturan @jculvey @marksteyn @jwineman @koddsson @manatarms


### PR DESCRIPTION
Adding the code reviewers is a tedious part of opening up a PR in cf-ui.

This patch adds users as "Code Owners" of all the files in the repo so
that they get added as default reviewers for every PR that's opened.

See https://github.com/blog/2392-introducing-code-owners for more info.