### PR TITLE
feat(cf-component-tabs): `TabsItem` own component

### DIFF
--- a/packages/cf-component-tabs/example/basic/component.js
+++ b/packages/cf-component-tabs/example/basic/component.js
@@ -1,5 +1,15 @@
 import React from 'react';
-import { Tabs, TabsPanel } from 'cf-component-tabs';
+import {
+  Tabs,
+  TabsItemUnstyled,
+  TabsItemTheme,
+  TabsPanel
+} from 'cf-component-tabs';
+import { applyTheme } from 'cf-style-container';
+
+const Tab = applyTheme(TabsItemUnstyled, TabsItemTheme, () => ({
+  background: '#FFFFF0'
+}));
 
 class TabsComponent extends React.Component {
   constructor(props) {
@@ -19,7 +29,7 @@ class TabsComponent extends React.Component {
         active={this.state.active}
         tabs={[
           { id: 'one', label: 'Tab One' },
-          { id: 'two', label: 'Tab Two' },
+          { id: 'two', label: 'Tab Two', component: Tab },
           { id: 'three', label: 'Tab Three' }
         ]}
         onChange={this.handleTabChange.bind(this)}

--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Viewport from 'cf-component-viewport';
 import Select from 'cf-component-select';
 import { createComponent } from 'cf-style-container';
+import { TabsItem } from './index';
 
 const find = (list, condition) => {
   let foundElement = undefined;
@@ -15,8 +16,8 @@ const find = (list, condition) => {
 };
 
 const styles = ({ theme }) => ({
-  marginTop: '1.5rem',
-  marginBottom: '1.5rem',
+  marginTop: theme.marginTop,
+  marginBottom: theme.marginBottom,
   border: `1px solid ${theme.color.smoke}`
 });
 
@@ -30,67 +31,6 @@ const TabsGroup = createComponent(
   }),
   'ul',
   ['role']
-);
-
-const TabItem = createComponent(
-  ({ theme, selected }) => ({
-    flex: theme.item.flex,
-    background: theme.item.background,
-    color: theme.item.color,
-    cursor: theme.item.cursor,
-    display: theme.item.display,
-    margin: theme.item.margin,
-    padding: theme.item.padding,
-    position: theme.item.position,
-    textAlign: theme.item.textAlign,
-    verticalAlign: theme.item.verticalAlign,
-    outline: theme.item.outline,
-    userSelect: theme.item.userSelect,
-
-    borderStyle: theme.item.borderStyle,
-    borderTopWidth: selected
-      ? theme.item.borderTopWidthSelected
-      : theme.item.borderTopWidth,
-    borderLeftWidth: theme.item.borderLeftWidth,
-    borderBottomWidth: selected
-      ? theme.item.borderBottomWidthSelected
-      : theme.item.borderBottomWidth,
-    borderRightWidth: theme.item.borderRightWidth,
-    borderTopColor: selected
-      ? theme.item.borderTopColorSelected
-      : theme.item.borderTopColor,
-    borderLeftColor: theme.item.borderLeftColor,
-    borderBottomColor: theme.item.borderBottomColor,
-    borderRightColor: theme.item.borderRightColor,
-
-    '&:last-child': {
-      borderRightWidth: theme.item['&:last-child'].borderRightWidth
-    },
-
-    '&:focus': {
-      '&::after': {
-        outline: theme.item['&:focus']['&::after'].outline
-      }
-    },
-
-    '&:hover': {
-      background: selected
-        ? theme.item['&:hover'].backgroundSelected
-        : theme.item['&:hover'].background,
-      color: theme.item['&:hover'].color
-    }
-  }),
-  'li',
-  [
-    'selected',
-    'key',
-    'role',
-    'tabIndex',
-    'aria-controls',
-    'aria-selected',
-    'onKeyDown',
-    'onClick'
-  ]
 );
 
 class Tabs extends React.Component {
@@ -129,21 +69,22 @@ class Tabs extends React.Component {
         </Viewport>
         <Viewport not size="mobile">
           <TabsGroup role="tablist">
-            {this.props.tabs.map(tab => {
+            {this.props.tabs.map((tab, index) => {
+              const Component = tab.component || TabsItem;
               const selected = tab.id === this.props.active;
               return (
-                <TabItem
+                <Component
                   selected={selected}
                   key={tab.id}
                   role="tab"
-                  tabIndex={0}
+                  tabIndex={index}
                   aria-controls={tab.id}
                   aria-selected={selected}
                   onKeyDown={this.handleKeyDown.bind(this, tab.id)}
                   onClick={this.handleChange.bind(this, tab.id)}
                 >
                   {tab.label}
-                </TabItem>
+                </Component>
               );
             })}
           </TabsGroup>

--- a/packages/cf-component-tabs/src/TabsItem.js
+++ b/packages/cf-component-tabs/src/TabsItem.js
@@ -1,0 +1,64 @@
+import { createComponent } from 'cf-style-container';
+
+const TabsItem = createComponent(
+  ({ theme, selected }) => ({
+    flex: theme.flex,
+    background: theme.background,
+    color: theme.color,
+    cursor: theme.cursor,
+    display: theme.display,
+    margin: theme.margin,
+    padding: theme.padding,
+    position: theme.position,
+    textAlign: theme.textAlign,
+    verticalAlign: theme.verticalAlign,
+    outline: theme.outline,
+    userSelect: theme.userSelect,
+
+    borderStyle: theme.borderStyle,
+    borderTopWidth: selected
+      ? theme.borderTopWidthSelected
+      : theme.borderTopWidth,
+    borderLeftWidth: theme.borderLeftWidth,
+    borderBottomWidth: selected
+      ? theme.borderBottomWidthSelected
+      : theme.borderBottomWidth,
+    borderRightWidth: theme.borderRightWidth,
+    borderTopColor: selected
+      ? theme.borderTopColorSelected
+      : theme.borderTopColor,
+    borderLeftColor: theme.borderLeftColor,
+    borderBottomColor: theme.borderBottomColor,
+    borderRightColor: theme.borderRightColor,
+
+    '&:last-child': {
+      borderRightWidth: theme['&:last-child'].borderRightWidth
+    },
+
+    '&:focus': {
+      '&::after': {
+        outline: theme['&:focus']['&::after'].outline
+      }
+    },
+
+    '&:hover': {
+      background: selected
+        ? theme['&:hover'].backgroundSelected
+        : theme['&:hover'].background,
+      color: theme['&:hover'].color
+    }
+  }),
+  'li',
+  [
+    'selected',
+    'key',
+    'role',
+    'tabIndex',
+    'aria-controls',
+    'aria-selected',
+    'onKeyDown',
+    'onClick'
+  ]
+);
+
+export default TabsItem;

--- a/packages/cf-component-tabs/src/TabsItemTheme.js
+++ b/packages/cf-component-tabs/src/TabsItemTheme.js
@@ -1,0 +1,44 @@
+export default baseTheme => ({
+  flex: 1,
+  background: baseTheme.colorWhite,
+  color: baseTheme.colorBlue,
+  cursor: 'pointer',
+  display: 'table-cell',
+  margin: 0,
+  padding: '1.5rem 1rem',
+  position: 'relative',
+  textAlign: 'center',
+  verticalAlign: 'middle',
+  outline: 'none',
+  userSelect: 'none',
+
+  borderTopWidth: 0,
+  borderTopWidthSelected: 2,
+  borderLeftWidth: 0,
+  borderBottomWidth: 1,
+  borderBottomWidthSelected: 0,
+  borderRightWidth: 1,
+
+  borderStyle: 'solid',
+  borderTopColor: baseTheme.color.smoke,
+  borderTopColorSelected: baseTheme.colorBlue,
+  borderLeftColor: baseTheme.color.smoke,
+  borderBottomColor: baseTheme.color.smoke,
+  borderRightColor: baseTheme.color.smoke,
+
+  '&:last-child': {
+    borderRightWidth: 0
+  },
+
+  '&:focus': {
+    '&::after': {
+      outline: 'none'
+    }
+  },
+
+  '&:hover': {
+    background: baseTheme.color.moonshine,
+    backgroundSelected: baseTheme.colorWhite,
+    color: baseTheme.colorBlue
+  }
+});

--- a/packages/cf-component-tabs/src/TabsTheme.js
+++ b/packages/cf-component-tabs/src/TabsTheme.js
@@ -1,46 +1,4 @@
 export default baseTheme => ({
-  item: {
-    flex: 1,
-    background: baseTheme.colorWhite,
-    color: baseTheme.colorBlue,
-    cursor: 'pointer',
-    display: 'table-cell',
-    margin: 0,
-    padding: '1.5rem 1rem',
-    position: 'relative',
-    textAlign: 'center',
-    verticalAlign: 'middle',
-    outline: 'none',
-    userSelect: 'none',
-
-    borderTopWidth: 0,
-    borderTopWidthSelected: 2,
-    borderLeftWidth: 0,
-    borderBottomWidth: 1,
-    borderBottomWidthSelected: 0,
-    borderRightWidth: 1,
-
-    borderStyle: 'solid',
-    borderTopColor: baseTheme.color.smoke,
-    borderTopColorSelected: baseTheme.colorBlue,
-    borderLeftColor: baseTheme.color.smoke,
-    borderBottomColor: baseTheme.color.smoke,
-    borderRightColor: baseTheme.color.smoke,
-
-    '&:last-child': {
-      borderRightWidth: 0
-    },
-
-    '&:focus': {
-      '&::after': {
-        outline: 'none'
-      }
-    },
-
-    '&:hover': {
-      background: baseTheme.color.moonshine,
-      backgroundSelected: baseTheme.colorWhite,
-      color: baseTheme.colorBlue
-    }
-  }
+  marginTop: '1.5rem',
+  marginBottom: '1.5rem'
 });

--- a/packages/cf-component-tabs/src/index.js
+++ b/packages/cf-component-tabs/src/index.js
@@ -2,16 +2,22 @@ import { applyTheme } from 'cf-style-container';
 
 import TabsUnstyled from './Tabs';
 import TabsTheme from './TabsTheme';
+import TabsItemUnstyled from './TabsItem';
+import TabsItemTheme from './TabsItemTheme';
 import TabsPanelUnstyled from './TabsPanel';
 import TabsPanelTheme from './TabsPanelTheme';
 
 const Tabs = applyTheme(TabsUnstyled, TabsTheme);
+const TabsItem = applyTheme(TabsItemUnstyled, TabsItemTheme);
 const TabsPanel = applyTheme(TabsPanelUnstyled, TabsPanelTheme);
 
 export {
   Tabs,
   TabsUnstyled,
   TabsTheme,
+  TabsItem,
+  TabsItemUnstyled,
+  TabsItemTheme,
   TabsPanel,
   TabsPanelUnstyled,
   TabsPanelTheme


### PR DESCRIPTION
In order to be able to apply styles to a "tab item" we need to abstract
it out into it's own component. That can be optionally be passed down to
the `Tabs` component defaulting to the styles previously applied.

This change is backwards compatible. See
`packages/cf-component-tabs/example/basic/component.js` for the optional
component property.