### PR TITLE
feat(cf-component-tabs): selected color override

### DIFF
--- a/packages/cf-component-tabs/src/TabsItem.js
+++ b/packages/cf-component-tabs/src/TabsItem.js
@@ -4,7 +4,7 @@ const TabsItem = createComponent(
   ({ theme, selected }) => ({
     flex: theme.flex,
     background: theme.background,
-    color: theme.color,
+    color: selected ? theme.colorSelected : theme.color,
     cursor: theme.cursor,
     display: theme.display,
     margin: theme.margin,

--- a/packages/cf-component-tabs/src/TabsItemTheme.js
+++ b/packages/cf-component-tabs/src/TabsItemTheme.js
@@ -2,6 +2,7 @@ export default baseTheme => ({
   flex: 1,
   background: baseTheme.colorWhite,
   color: baseTheme.colorBlue,
+  colorSelected: baseTheme.colorBlue,
   cursor: 'pointer',
   display: 'table-cell',
   margin: 0,


### PR DESCRIPTION
Even tho the current theme doesn't make any distinction on colors when a
item is selected or not there are instances in the dashboard where we'd
like to do exactly that. Unfortunately due to the styling model we have
now we need to specifically list out any possible rules we might use
when the component is implemented, warranting this change.