### PR TITLE
feat(cf-component-tabs): allow overriding border

### DIFF
--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -18,7 +18,9 @@ const find = (list, condition) => {
 const styles = ({ theme }) => ({
   marginTop: theme.marginTop,
   marginBottom: theme.marginBottom,
-  border: theme.border
+  borderStyle: theme.borderStyle,
+  borderColor: theme.borderColor,
+  borderWidth: theme.borderWidth
 });
 
 const TabsGroup = createComponent(

--- a/packages/cf-component-tabs/src/TabsTheme.js
+++ b/packages/cf-component-tabs/src/TabsTheme.js
@@ -1,5 +1,7 @@
 export default baseTheme => ({
   marginTop: '1.5rem',
   marginBottom: '1.5rem',
-  border: `1px solid ${baseTheme.color.smoke}`
+  borderStyle: 'solid',
+  borderColor: baseTheme.color.smoke,
+  borderWidth: 1
 });

--- a/packages/cf-component-tabs/test/__snapshots__/Tabs.js.snap
+++ b/packages/cf-component-tabs/test/__snapshots__/Tabs.js.snap
@@ -2,12 +2,12 @@
 
 exports[`should render 1`] = `
 <section
-  className="a b c"
+  className="a b c d e"
 >
   <div
     aria-hidden={false}
     aria-labelledby="2"
-    className="d"
+    className="f"
     role="tabpanel"
   >
     Two
@@ -26,10 +26,18 @@ exports[`should render 2`] = `
 }
 
 .c {
-  border: 1px solid #e0e0e0
+  border-style: solid
 }
 
 .d {
+  border-color: #e0e0e0
+}
+
+.e {
+  border-width: 1px
+}
+
+.f {
   background-color: #fff
 }
 "


### PR DESCRIPTION
Split up the `border` shorthand into `borderWidth`, `borderStyle` and
`borderColor` so that it can be overwritten more easily. The
`borderWidth` shorthand takes in either a number or a string conforming
to the normal rules of CSS.

For example if we wanted all the borders
except for the one on the bottom we could do something like:

    1px 1px 0 1px