### PR TITLE
feat(cf-component-select): migrate select to fela

### DIFF
--- a/packages/cf-component-form/example/basic/component.js
+++ b/packages/cf-component-form/example/basic/component.js
@@ -9,7 +9,7 @@ import {
 } from 'cf-component-form';
 import { Flex, FlexItem } from 'cf-component-flex';
 import { Input } from 'cf-component-input';
-import Select from 'cf-component-select';
+import { Select } from 'cf-component-select';
 import { Textarea } from 'cf-component-textarea';
 import { Button } from 'cf-component-button';
 

--- a/packages/cf-component-select/example/async/component.js
+++ b/packages/cf-component-select/example/async/component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Select from 'cf-component-select';
+import { Select } from 'cf-component-select';
 
 class SelectComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-select/example/basic/component.js
+++ b/packages/cf-component-select/example/basic/component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Select from 'cf-component-select';
+import { Select } from 'cf-component-select';
 
 class SelectComponent extends React.Component {
   constructor(props) {

--- a/packages/cf-component-select/src/Select.js
+++ b/packages/cf-component-select/src/Select.js
@@ -1,10 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
+import { createComponent } from 'cf-style-container';
+
+const styles = ({ theme }) => ({
+  flex: theme.flex,
+  margin: theme.margin,
+  width: theme.width,
+  display: theme.display,
+  verticalAlign: theme.verticalAlign
+});
+
+const Label = createComponent(
+  ({ theme }) => ({
+    display: 'block',
+    fontSize: '0.7em',
+    color: theme.color.storm,
+    fontWeight: 'bold',
+    textTransform: 'uppercase',
+    letterSpacing: '0.1em',
+    marginBottom: '0.5em'
+  }),
+  'label'
+);
 
 class Select extends React.Component {
   render() {
-    const { async, creatable, searchable, label, ...props } = this.props;
+    const {
+      async,
+      creatable,
+      searchable,
+      label,
+      className,
+      ...props
+    } = this.props;
 
     let SelectClass;
     if (async) {
@@ -14,8 +43,11 @@ class Select extends React.Component {
     }
 
     return (
-      <div className="cf-select">
-        {label && <label>{label}</label>}
+      <div className={className}>
+        {label &&
+          <Label>
+            {label}
+          </Label>}
         <SelectClass
           {...props}
           searchable={searchable}
@@ -34,4 +66,14 @@ Select.defaultProps = {
   creatable: false
 };
 
-export default Select;
+Select.propTypes = {
+  disabled: PropTypes.bool,
+  label: PropTypes.string,
+  value: PropTypes.number,
+  options: PropTypes.array,
+  searchable: PropTypes.bool,
+  multi: PropTypes.bool,
+  onChange: PropTypes.func
+};
+
+export default createComponent(styles, Select);

--- a/packages/cf-component-select/src/SelectTheme.js
+++ b/packages/cf-component-select/src/SelectTheme.js
@@ -1,0 +1,7 @@
+export default baseTheme => ({
+  flex: 'initial',
+  margin: 'initial',
+  width: 'initial',
+  display: 'initial',
+  verticalAlign: 'initial'
+});

--- a/packages/cf-component-select/src/index.js
+++ b/packages/cf-component-select/src/index.js
@@ -1,3 +1,8 @@
-import Select from './Select';
+import { applyTheme } from 'cf-style-container';
 
-export default Select;
+import SelectUnstyled from './Select';
+import SelectTheme from './SelectTheme';
+
+const Select = applyTheme(SelectUnstyled, SelectTheme);
+
+export { Select, SelectUnstyled, SelectTheme };

--- a/packages/cf-component-select/test/Select.js
+++ b/packages/cf-component-select/test/Select.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
-import Select from '../../cf-component-select/src/index';
+import { felaSnapshot } from 'cf-style-provider';
+import { Select } from '../../cf-component-select/src/index';
 
 test('should render', () => {
-  const tree = shallow(<Select />);
-  expect(toJson(tree)).toMatchSnapshot();
+  const snapshot = felaSnapshot(<Select />);
+  expect(snapshot.component).toMatchSnapshot();
+  expect(snapshot.styles).toMatchSnapshot();
 });

--- a/packages/cf-component-select/test/__snapshots__/Select.js.snap
+++ b/packages/cf-component-select/test/__snapshots__/Select.js.snap
@@ -2,47 +2,84 @@
 
 exports[`should render 1`] = `
 <div
-  className="cf-select"
+  className="a b c d e"
 >
-  <Select
-    addLabelText="Add \\"{label}\\"?"
-    arrowRenderer={[Function]}
-    autosize={true}
-    backspaceRemoves={false}
-    backspaceToRemoveMessage="Press backspace to remove {label}"
-    clearAllText="Clear all"
-    clearRenderer={[Function]}
-    clearValueText="Clear value"
-    clearable={false}
-    deleteRemoves={true}
-    delimiter=","
-    disabled={false}
-    escapeClearsValue={true}
-    filterOptions={[Function]}
-    ignoreAccents={true}
-    ignoreCase={true}
-    inputProps={Object {}}
-    isLoading={false}
-    joinValues={false}
-    labelKey="label"
-    matchPos="any"
-    matchProp="any"
-    menuBuffer={0}
-    menuRenderer={[Function]}
-    multi={false}
-    noResultsText="No results found"
-    onBlurResetsInput={true}
-    onCloseResetsInput={true}
-    optionComponent={[Function]}
-    pageSize={5}
-    placeholder="Select..."
-    required={false}
-    scrollMenuIntoView={true}
-    searchable={false}
-    simpleValue={false}
-    tabSelectsValue={true}
-    valueComponent={[Function]}
-    valueKey="value"
-  />
+  <div
+    className="Select Select--single"
+    style={undefined}
+  >
+    <div
+      className="Select-control"
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      style={undefined}
+    >
+      <span
+        className="Select-multi-value-wrapper"
+        id="react-select-2--value"
+      >
+        <div
+          className="Select-placeholder"
+        >
+          Select...
+        </div>
+        <div
+          aria-activedescendant="react-select-2--value"
+          aria-expanded={false}
+          aria-owns="react-select-2--value"
+          aria-readonly="false"
+          className="Select-input"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          role="combobox"
+          style={
+            Object {
+              "border": 0,
+              "display": "inline-block",
+              "width": 1,
+            }
+          }
+          tabIndex={0}
+        />
+      </span>
+      <span
+        className="Select-arrow-zone"
+        onMouseDown={[Function]}
+      >
+        <span
+          className="Select-arrow"
+          onMouseDown={[Function]}
+        />
+      </span>
+    </div>
+  </div>
 </div>
+`;
+
+exports[`should render 2`] = `
+"
+.a {
+  flex: initial;
+  -webkit-flex: initial
+}
+
+.b {
+  margin: initial
+}
+
+.c {
+  width: initial
+}
+
+.d {
+  display: initial
+}
+
+.e {
+  vertical-align: initial
+}
+"
 `;

--- a/packages/cf-component-tabs/src/Tabs.js
+++ b/packages/cf-component-tabs/src/Tabs.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Viewport from 'cf-component-viewport';
-import Select from 'cf-component-select';
+import { Select } from 'cf-component-select';
 import { createComponent } from 'cf-style-container';
 import { TabsItem } from './index';
 


### PR DESCRIPTION
Migrate the `cf-component-select` component to use the CSS-in-JS
framework fela.

Closes: #213