### PR TITLE
fix(cf-component-radio): allow padding/margin override

### DIFF
--- a/packages/cf-component-radio/src/Radio.js
+++ b/packages/cf-component-radio/src/Radio.js
@@ -6,8 +6,9 @@ const styles = ({ theme }) => ({
   cursor: theme.cursor,
   display: theme.display,
   minHeight: theme.minHeight,
-  paddingLeft: theme.paddingLeft,
-  marginTop: theme.marginTop,
+
+  margin: theme.margin,
+  padding: theme.padding,
 
   '&:first-child': {
     marginTop: theme['&:first-child'].marginTop

--- a/packages/cf-component-radio/src/RadioTheme.js
+++ b/packages/cf-component-radio/src/RadioTheme.js
@@ -2,8 +2,8 @@ export default baseTheme => ({
   cursor: 'pointer',
   display: 'block',
   minHeight: '1em',
-  paddingLeft: '2em',
-  marginTop: 'initial',
+  padding: '0 0 0 2em',
+  margin: 'initial',
 
   '&:first-child': {
     marginTop: 'initial'

--- a/packages/cf-component-radio/test/__snapshots__/Radio.js.snap
+++ b/packages/cf-component-radio/test/__snapshots__/Radio.js.snap
@@ -37,11 +37,11 @@ exports[`should render 2`] = `
 }
 
 .d {
-  padding-left: 2em
+  margin: initial
 }
 
 .e {
-  margin-top: initial
+  padding: 0 0 0 2em
 }
 
 .f:first-child {
@@ -245,11 +245,11 @@ exports[`should render checked 2`] = `
 }
 
 .d {
-  padding-left: 2em
+  margin: initial
 }
 
 .e {
-  margin-top: initial
+  padding: 0 0 0 2em
 }
 
 .f:first-child {
@@ -448,11 +448,11 @@ exports[`should render without a label 2`] = `
 }
 
 .d {
-  padding-left: 2em
+  margin: initial
 }
 
 .e {
-  margin-top: initial
+  padding: 0 0 0 2em
 }
 
 .f:first-child {


### PR DESCRIPTION
Previously we only allowed `marginTop` and `paddingLeft` to be
overridden but we want to override the whole shorthand in some places
where this component is implemented.