### PR TITLE
Fetch polyfill fix for Edge: correct order of requires in transpiled code

### DIFF
--- a/packages/cf-util-http/src/http.js
+++ b/packages/cf-util-http/src/http.js
@@ -1,3 +1,4 @@
+import './polyfillFetchInEdge';
 import 'isomorphic-fetch';
 
 import createLogger from 'cf-util-logger';

--- a/packages/cf-util-http/src/index.js
+++ b/packages/cf-util-http/src/index.js
@@ -1,2 +1,1 @@
-import './polyfillFetchInEdge';
 export * from './http';


### PR DESCRIPTION
before in transpiled index.js:
```
var _http = require('./http');

Object.keys(_http).forEach(function (key) {
  if (key === "default" || key === "__esModule") return;
  Object.defineProperty(exports, key, {
    enumerable: true,
    get: function get() {
      return _http[key];
    }
  });
});

require('./polyfillFetchInEdge');
```
after in transpiled http.js:

```

require('./polyfillFetchInEdge');

require('isomorphic-fetch');
```

I needed to run `require('./polyfillFetchInEdge'` before `require('isomorphic-fetch')` in order to polyfill `fetch` in Edge browser. 