### PR TITLE
chore(deployment): publish from the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ deploy:
   provider: script
   script: yarn run publish -- --yes
   on:
-    branch: production
+    branch: master


### PR DESCRIPTION
In 264539a we set up some pretty sweet continues deployment system but erroneously set the deployment branch to `production` when our "production" branch is in fact called "master".

This patch changes the Travis "deploy" branch to `master.