### PR TITLE
chore(deployment): install deps before deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - yarn test -- --runInBand
 deploy:
   provider: script
+  before_deploy: yarn
   script: yarn run publish -- --yes
   on:
     branch: master


### PR DESCRIPTION
Apparently, we need to install all dependencies before deploying since the deployment steps run in a different context than the previous build and tests contexts.