### PR TITLE
Added 'vertical' prop to ButtonGroup

### DIFF
--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -53,14 +53,24 @@ const before = (fadeZoomIn, loading) => {
   };
 };
 
-const marginLeft = (marginLeft, group, spaced) => {
-  if (!group) {
+const marginLeft = (marginLeft, group, spaced, vertical) => {
+  if (!group || vertical) {
     return { marginLeft };
   }
   if (spaced && group !== 'first') {
     return { marginLeft: '0.4rem' };
   }
   return { marginLeft: 0 };
+};
+
+const marginTop = (marginTop, group, spaced, vertical) => {
+  if (!group || !vertical) {
+    return { marginTop };
+  }
+  if (spaced && vertical && group !== 'first') {
+    return { marginTop: '0.4rem' };
+  }
+  return { marginTop: 0 };
 };
 
 const styles = props => {
@@ -126,7 +136,8 @@ const styles = props => {
     marginBottom: props.group ? 0 : theme.marginBottom,
     marginRight: props.group ? 0 : theme.marginRight,
     marginTop: props.group ? 0 : theme.marginTop,
-    ...marginLeft(theme.marginLeft, props.group, props.spaced),
+    ...marginTop(theme.marginTop, props.group, props.spaced, props.vertical),
+    ...marginLeft(theme.marginLeft, props.group, props.spaced, props.vertical),
     ...opacity(props.loading, props.disabled),
     paddingBottom: theme.paddingBottom,
     paddingLeft: theme.paddingLeft,
@@ -140,7 +151,8 @@ const styles = props => {
     userSelect: theme.userSelect,
     float: theme.float,
     maxWidth: theme.maxWidth,
-    float: theme.float
+    float: theme.float,
+    width: props.vertical ? '100%' : 'auto'
   };
 };
 
@@ -171,6 +183,7 @@ Button.propTypes = {
   onClick: PropTypes.func,
   submit: PropTypes.bool,
   spaced: PropTypes.bool,
+  vertical: PropTypes.bool,
   className: PropTypes.string.isRequired,
   group: PropTypes.oneOf(['first', 'inbetween', 'last']),
   type: PropTypes.oneOf(['default', 'primary', 'success', 'warning', 'danger'])

--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -98,9 +98,7 @@ const styles = props => {
       backgroundColor: props.loading
         ? theme.backgroundColor
         : theme[`${props.type}Background`],
-      boxShadow: `inset 0px 0px 0px ${theme.borderSize} ${theme[
-        `${props.type}focusOutlineColor`
-      ]}`,
+      boxShadow: `inset 0px 0px 0px ${theme.borderSize} ${theme[`${props.type}focusOutlineColor`]}`,
       color: props.loading
         ? theme.disabledBackground
         : theme[`${props.type}FocusColor`],

--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -53,8 +53,8 @@ const before = (fadeZoomIn, loading) => {
   };
 };
 
-const marginLeft = (marginLeft, group, spaced, vertical) => {
-  if (!group || vertical) {
+const marginLeft = (marginLeft, group, spaced, direction) => {
+  if (!group || direction === 'column') {
     return { marginLeft };
   }
   if (spaced && group !== 'first') {
@@ -63,11 +63,11 @@ const marginLeft = (marginLeft, group, spaced, vertical) => {
   return { marginLeft: 0 };
 };
 
-const marginTop = (marginTop, group, spaced, vertical) => {
-  if (!group || !vertical) {
+const marginTop = (marginTop, group, spaced, direction) => {
+  if (!group || direction === 'row') {
     return { marginTop };
   }
-  if (spaced && vertical && group !== 'first') {
+  if (spaced && direction === 'column' && group !== 'first') {
     return { marginTop: '0.4rem' };
   }
   return { marginTop: 0 };
@@ -98,7 +98,9 @@ const styles = props => {
       backgroundColor: props.loading
         ? theme.backgroundColor
         : theme[`${props.type}Background`],
-      boxShadow: `inset 0px 0px 0px ${theme.borderSize} ${theme[`${props.type}focusOutlineColor`]}`,
+      boxShadow: `inset 0px 0px 0px ${theme.borderSize} ${theme[
+        `${props.type}focusOutlineColor`
+      ]}`,
       color: props.loading
         ? theme.disabledBackground
         : theme[`${props.type}FocusColor`],
@@ -136,8 +138,8 @@ const styles = props => {
     marginBottom: props.group ? 0 : theme.marginBottom,
     marginRight: props.group ? 0 : theme.marginRight,
     marginTop: props.group ? 0 : theme.marginTop,
-    ...marginTop(theme.marginTop, props.group, props.spaced, props.vertical),
-    ...marginLeft(theme.marginLeft, props.group, props.spaced, props.vertical),
+    ...marginTop(theme.marginTop, props.group, props.spaced, props.direction),
+    ...marginLeft(theme.marginLeft, props.group, props.spaced, props.direction),
     ...opacity(props.loading, props.disabled),
     paddingBottom: theme.paddingBottom,
     paddingLeft: theme.paddingLeft,
@@ -152,7 +154,7 @@ const styles = props => {
     float: theme.float,
     maxWidth: theme.maxWidth,
     float: theme.float,
-    width: props.vertical ? '100%' : 'auto'
+    width: props.direction === 'column' ? '100%' : 'auto'
   };
 };
 
@@ -183,7 +185,7 @@ Button.propTypes = {
   onClick: PropTypes.func,
   submit: PropTypes.bool,
   spaced: PropTypes.bool,
-  vertical: PropTypes.bool,
+  direction: PropTypes.oneOf(['column', 'row']),
   className: PropTypes.string.isRequired,
   group: PropTypes.oneOf(['first', 'inbetween', 'last']),
   type: PropTypes.oneOf(['default', 'primary', 'success', 'warning', 'danger'])

--- a/packages/cf-component-button/src/ButtonGroup.js
+++ b/packages/cf-component-button/src/ButtonGroup.js
@@ -8,7 +8,7 @@ const styles = props => {
     display: theme.display,
     position: theme.position,
     verticalAlign: theme.verticalAlign,
-    whiteSpace: theme.whiteSpace
+    whiteSpace: props.vertical ? 'initial' : theme.whiteSpace
   };
 };
 
@@ -22,12 +22,13 @@ const getGroupByIndex = (index, length) => {
   return 'inbetween';
 };
 
-const addGroupProps = (children, spaced) =>
+const addGroupProps = (children, spaced, vertical) =>
   React.Children.map(children, (child, index) => {
     if (React.isValidElement(child)) {
       return React.cloneElement(child, {
         group: getGroupByIndex(index, React.Children.count(children)),
-        spaced
+        spaced,
+        vertical
       });
     }
     return child;
@@ -35,15 +36,20 @@ const addGroupProps = (children, spaced) =>
 
 class ButtonGroup extends React.Component {
   render() {
-    const { className, children, spaced } = this.props;
-    return <div className={className}>{addGroupProps(children, spaced)}</div>;
+    const { className, children, spaced, vertical } = this.props;
+    return (
+      <div className={className}>
+        {addGroupProps(children, spaced, vertical)}
+      </div>
+    );
   }
 }
 
 ButtonGroup.propTypes = {
   children: PropTypes.node,
   spaced: PropTypes.bool,
-  className: PropTypes.string.isRequired
+  className: PropTypes.string.isRequired,
+  vertical: PropTypes.bool
 };
 
 export default createComponent(styles, ButtonGroup);

--- a/packages/cf-component-button/src/ButtonGroup.js
+++ b/packages/cf-component-button/src/ButtonGroup.js
@@ -8,7 +8,7 @@ const styles = props => {
     display: theme.display,
     position: theme.position,
     verticalAlign: theme.verticalAlign,
-    whiteSpace: props.vertical ? 'initial' : theme.whiteSpace
+    whiteSpace: props.direction === 'column' ? 'initial' : theme.whiteSpace
   };
 };
 
@@ -22,13 +22,13 @@ const getGroupByIndex = (index, length) => {
   return 'inbetween';
 };
 
-const addGroupProps = (children, spaced, vertical) =>
+const addGroupProps = (children, spaced, direction) =>
   React.Children.map(children, (child, index) => {
     if (React.isValidElement(child)) {
       return React.cloneElement(child, {
         group: getGroupByIndex(index, React.Children.count(children)),
         spaced,
-        vertical
+        direction
       });
     }
     return child;
@@ -36,10 +36,10 @@ const addGroupProps = (children, spaced, vertical) =>
 
 class ButtonGroup extends React.Component {
   render() {
-    const { className, children, spaced, vertical } = this.props;
+    const { className, children, spaced, direction } = this.props;
     return (
       <div className={className}>
-        {addGroupProps(children, spaced, vertical)}
+        {addGroupProps(children, spaced, direction)}
       </div>
     );
   }
@@ -49,7 +49,11 @@ ButtonGroup.propTypes = {
   children: PropTypes.node,
   spaced: PropTypes.bool,
   className: PropTypes.string.isRequired,
-  vertical: PropTypes.bool
+  direction: PropTypes.oneOf(['column', 'row'])
+};
+
+ButtonGroup.defaultProps = {
+  direction: 'row'
 };
 
 export default createComponent(styles, ButtonGroup);

--- a/packages/cf-component-button/test/__snapshots__/Button.js.snap
+++ b/packages/cf-component-button/test/__snapshots__/Button.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should render as submit 1`] = `
 <button
-  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao"
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao ap"
   disabled={undefined}
   onClick={[Function]}
   type="submit"
@@ -177,12 +177,16 @@ exports[`should render as submit 2`] = `
 .ao {
   max-width: initial
 }
+
+.ap {
+  width: auto
+}
 "
 `;
 
 exports[`should render with loading 1`] = `
 <button
-  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao ap aq ar as at au av aw ax ay az ba bb"
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao ap aq ar as at au av aw ax ay az ba bb bc"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -430,12 +434,16 @@ exports[`should render with loading 2`] = `
 .bb {
   max-width: initial
 }
+
+.bc {
+  width: auto
+}
 "
 `;
 
 exports[`should render with loading and disabled overridden 1`] = `
 <button
-  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao ap aq ar as at au av aw ax ay az ba bb"
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao ap aq ar as at au av aw ax ay az ba bb bc"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -683,12 +691,16 @@ exports[`should render with loading and disabled overridden 2`] = `
 .bb {
   max-width: initial
 }
+
+.bc {
+  width: auto
+}
 "
 `;
 
 exports[`should render with type 1`] = `
 <button
-  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao"
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao ap"
   disabled={undefined}
   onClick={[Function]}
   type="button"
@@ -863,12 +875,16 @@ exports[`should render with type 2`] = `
 .ao {
   max-width: initial
 }
+
+.ap {
+  width: auto
+}
 "
 `;
 
 exports[`should render with type/disabled 1`] = `
 <button
-  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao"
+  className="a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ad ae af ag ah ai aj ak al am an ao ap"
   disabled={true}
   onClick={[Function]}
   type="button"
@@ -1042,6 +1058,10 @@ exports[`should render with type/disabled 2`] = `
 
 .ao {
   max-width: initial
+}
+
+.ap {
+  width: auto
 }
 "
 `;

--- a/packages/cf-component-button/test/__snapshots__/ButtonGroup.js.snap
+++ b/packages/cf-component-button/test/__snapshots__/ButtonGroup.js.snap
@@ -13,7 +13,7 @@ exports[`should render 1 button 1`] = `
   className="a b c d"
 >
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al am an ao ap aq ar as at"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al am an ao ap aq ar as at au"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -209,6 +209,10 @@ exports[`should render 1 button 2`] = `
 .at {
   max-width: initial
 }
+
+.au {
+  width: auto
+}
 "
 `;
 
@@ -237,7 +241,7 @@ exports[`should render 2 buttons 1`] = `
   className="a b c d"
 >
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al am an ao ap aq ar as at"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al am an ao ap aq ar as at au"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -245,7 +249,7 @@ exports[`should render 2 buttons 1`] = `
     Button
   </button>
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b au av aw ax ap aq ar as at"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b av aw ax ay ap aq ar as at au"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -443,18 +447,22 @@ exports[`should render 2 buttons 2`] = `
 }
 
 .au {
-  border-top-right-radius: 2px
+  width: auto
 }
 
 .av {
-  border-top-left-radius: 0px
+  border-top-right-radius: 2px
 }
 
 .aw {
-  border-bottom-left-radius: 0px
+  border-top-left-radius: 0px
 }
 
 .ax {
+  border-bottom-left-radius: 0px
+}
+
+.ay {
   border-bottom-right-radius: 2px
 }
 "
@@ -465,7 +473,7 @@ exports[`should render 3 buttons 1`] = `
   className="a b c d"
 >
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al am an ao ap aq ar as at"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al am an ao ap aq ar as at au"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -473,7 +481,7 @@ exports[`should render 3 buttons 1`] = `
     Button
   </button>
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al au av ao ap aq ar as at"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al av aw ao ap aq ar as at au"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -481,7 +489,7 @@ exports[`should render 3 buttons 1`] = `
     Button
   </button>
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b aw au av ax ap aq ar as at"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b ax av aw ay ap aq ar as at au"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -679,18 +687,22 @@ exports[`should render 3 buttons 2`] = `
 }
 
 .au {
-  border-top-left-radius: 0px
+  width: auto
 }
 
 .av {
-  border-bottom-left-radius: 0px
+  border-top-left-radius: 0px
 }
 
 .aw {
-  border-top-right-radius: 2px
+  border-bottom-left-radius: 0px
 }
 
 .ax {
+  border-top-right-radius: 2px
+}
+
+.ay {
   border-bottom-right-radius: 2px
 }
 "
@@ -701,7 +713,7 @@ exports[`should render 3 buttons with spacing 1`] = `
   className="a b c d"
 >
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al am an ao ap aq"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ae af ag ah ai aj ak b al am an ao ap aq ar"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -709,7 +721,7 @@ exports[`should render 3 buttons with spacing 1`] = `
     Button
   </button>
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ar af ag ah ai aj ak b al am an ao ap aq"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad as af ag ah ai aj ak b al am an ao ap aq ar"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -717,7 +729,7 @@ exports[`should render 3 buttons with spacing 1`] = `
     Button
   </button>
   <button
-    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad ar af ag ah ai aj ak b al am an ao ap aq"
+    className="e f g h i j k l m n o p q r s t u v a w x y z ab ac ad as af ag ah ai aj ak b al am an ao ap aq ar"
     disabled={undefined}
     onClick={[Function]}
     type="button"
@@ -903,6 +915,10 @@ exports[`should render 3 buttons with spacing 2`] = `
 }
 
 .ar {
+  width: auto
+}
+
+.as {
   margin-left: 0.4rem
 }
 "


### PR DESCRIPTION
This PR adds a `vertical` prop to `ButtonGroup`, allowing for vertical groups of buttons, as seen in the below screenshot:

<img width="319" alt="screen shot 2017-08-07 at 11 42 11" src="https://user-images.githubusercontent.com/65447/29023429-7d171a3c-7b65-11e7-9a25-1fc01d964e4f.png">