### PR TITLE
chore(tooling): enforce conventional commits in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 before_script:
   - yarn run bootstrap
 script:
+  - yarn run validate-commit-msg
   - yarn run build
   - yarn run lint
   - yarn test -- --runInBand

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_script:
   - yarn run bootstrap
 script:
-  - yarn run validate-commit-msg
+  - yarn run validate-commit-msg \"$(git log --walk-reflogs $TRAVIS_PULL_REQUEST_SLUG --pretty=%B)\"
   - yarn run build
   - yarn run lint
   - yarn test -- --runInBand


### PR DESCRIPTION
https://github.com/cloudflare/cf-ui/pull/348 is passing CI even though the commit message doesn't follow conventional commits.  We need to enforce this validation at the CI level to ensure no PRs are merged which will break the lerna deployment with `--conventional-commits`