### PR TITLE
feat(cf-component-button): add 'dangerOutline' button type

### DIFF
--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -75,18 +75,20 @@ const marginTop = (marginTop, group, spaced, direction) => {
 
 const border = (theme, group, type) => {
   const isOutlineButton = type === 'dangerOutline';
-  return isOutlineButton ? {
-     borderBottom: '1px solid',
-     borderLeft: '1px solid',
-     borderRight: '1px solid',
-     borderTop: '1px solid'
-  } : {
-    borderBottom: theme.borderBottom,
-    borderLeft: (group && group !== 'first') ? 0 : theme.borderLeft,
-    borderRight: theme.borderRight,
-    borderTop: theme.borderTop,
-  };
-}
+  return isOutlineButton
+    ? {
+        borderBottom: '1px solid',
+        borderLeft: '1px solid',
+        borderRight: '1px solid',
+        borderTop: '1px solid'
+      }
+    : {
+        borderBottom: theme.borderBottom,
+        borderLeft: group && group !== 'first' ? 0 : theme.borderLeft,
+        borderRight: theme.borderRight,
+        borderTop: theme.borderTop
+      };
+};
 
 const styles = props => {
   const theme = props.theme;
@@ -196,8 +198,14 @@ Button.propTypes = {
   direction: PropTypes.oneOf(['column', 'row']),
   className: PropTypes.string.isRequired,
   group: PropTypes.oneOf(['first', 'inbetween', 'last']),
-  type: PropTypes.oneOf(['default', 'primary', 'success', 'warning', 'danger', 'dangerOutline'])
-    .isRequired,
+  type: PropTypes.oneOf([
+    'default',
+    'primary',
+    'success',
+    'warning',
+    'danger',
+    'dangerOutline'
+  ]).isRequired,
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
   children: PropTypes.node

--- a/packages/cf-component-button/src/Button.js
+++ b/packages/cf-component-button/src/Button.js
@@ -73,6 +73,21 @@ const marginTop = (marginTop, group, spaced, direction) => {
   return { marginTop: 0 };
 };
 
+const border = (theme, group, type) => {
+  const isOutlineButton = type === 'dangerOutline';
+  return isOutlineButton ? {
+     borderBottom: '1px solid',
+     borderLeft: '1px solid',
+     borderRight: '1px solid',
+     borderTop: '1px solid'
+  } : {
+    borderBottom: theme.borderBottom,
+    borderLeft: (group && group !== 'first') ? 0 : theme.borderLeft,
+    borderRight: theme.borderRight,
+    borderTop: theme.borderTop,
+  };
+}
+
 const styles = props => {
   const theme = props.theme;
   return {
@@ -97,7 +112,7 @@ const styles = props => {
     '&:focus': {
       backgroundColor: props.loading
         ? theme.backgroundColor
-        : theme[`${props.type}Background`],
+        : theme[`${props.type}FocusBackground`],
       boxShadow: `inset 0px 0px 0px ${theme.borderSize} ${theme[`${props.type}focusOutlineColor`]}`,
       color: props.loading
         ? theme.disabledBackground
@@ -114,16 +129,11 @@ const styles = props => {
     backgroundColor: props.loading
       ? theme.disabledBackground
       : theme[`${props.type}Background`],
-    borderBottom: theme.borderBottom,
-    borderBottomWidth: theme.borderBottomWidth,
     borderColor: props.loading
       ? theme.disabledBorder
       : theme[`${props.type}Border`],
-    borderLeft: props.group && props.group !== 'first' ? 0 : theme.borderLeft,
-    borderRight: theme.borderRight,
+    ...border(theme, props.group, props.type),
     borderStyle: theme.borderStyle,
-    borderTop: theme.borderTop,
-    borderWidth: theme.borderWidth,
     color: props.loading
       ? theme.disabledBackground
       : theme[`${props.type}Color`],
@@ -186,7 +196,7 @@ Button.propTypes = {
   direction: PropTypes.oneOf(['column', 'row']),
   className: PropTypes.string.isRequired,
   group: PropTypes.oneOf(['first', 'inbetween', 'last']),
-  type: PropTypes.oneOf(['default', 'primary', 'success', 'warning', 'danger'])
+  type: PropTypes.oneOf(['default', 'primary', 'success', 'warning', 'danger', 'dangerOutline'])
     .isRequired,
   disabled: PropTypes.bool,
   loading: PropTypes.bool,

--- a/packages/cf-component-button/src/ButtonTheme.js
+++ b/packages/cf-component-button/src/ButtonTheme.js
@@ -12,6 +12,7 @@ export default baseTheme => {
     baseTheme.colorOrange
   );
   const dangerBorder = darken(baseTheme.colorOffsetDark, baseTheme.colorRed);
+
   const defaultHoverBackground = darken(
     baseTheme.colorOffsetDark,
     baseTheme.colorGrayLight
@@ -81,18 +82,21 @@ export default baseTheme => {
     successBackground: baseTheme.colorGreen,
     warningBackground: baseTheme.colorOrange,
     dangerBackground: baseTheme.colorRed,
+    dangerOutlineBackground: 'transparent',
 
     defaultBorder,
     primaryBorder,
     successBorder,
     warningBorder,
     dangerBorder,
+    dangerOutlineBorder: baseTheme.color.apple,
 
     defaultColor: baseTheme.colorGrayDark,
     primaryColor: baseTheme.colorWhite,
     successColor: baseTheme.colorWhite,
     warningColor: baseTheme.colorWhite,
     dangerColor: baseTheme.colorWhite,
+    dangerOutlineColor: baseTheme.color.apple,
 
     // Hover
     defaultHoverBackground,
@@ -100,6 +104,7 @@ export default baseTheme => {
     successHoverBackground: baseTheme.colorGreenDark,
     warningHoverBackground: baseTheme.colorOrangeDark,
     dangerHoverBackground: baseTheme.colorRedDark,
+    dangerOutlineHoverBackground: baseTheme.color.apple,
 
     defaultHoverBorder: darken(baseTheme.colorOffsetDark, defaultBorder),
     primaryHoverBorder: darken(baseTheme.colorOffsetDark, primaryBorder),
@@ -115,12 +120,14 @@ export default baseTheme => {
       baseTheme.colorOffsetDark,
       baseTheme.colorRedDark
     ),
+    dangerOutlineHoverBorder: baseTheme.color.cherry,
 
     defaultHoverColor: baseTheme.colorGrayDark,
     primaryHoverColor: baseTheme.colorWhite,
     successHoverColor: baseTheme.colorWhite,
     warningHoverColor: baseTheme.colorWhite,
     dangerHoverColor: baseTheme.colorWhite,
+    dangerOutlineHoverColor: baseTheme.colorWhite,
 
     // Active
     defaultActiveBackground,
@@ -128,6 +135,7 @@ export default baseTheme => {
     successActiveBackground,
     warningActiveBackground,
     dangerActiveBackground,
+    dangerOutlineActiveBackground: baseTheme.color.cherry,
 
     defaultActiveBorder: darken(
       baseTheme.colorOffsetDark,
@@ -149,19 +157,29 @@ export default baseTheme => {
       baseTheme.colorOffsetDark,
       dangerActiveBackground
     ),
+    dangerOutlineActiveBorder: baseTheme.color.cherry,
 
     defaultActiveColor: baseTheme.colorGrayDark,
     primaryActiveColor: baseTheme.colorWhite,
     successActiveColor: baseTheme.colorWhite,
     warningActiveColor: baseTheme.colorWhite,
     dangerActiveColor: baseTheme.colorWhite,
+    dangerOutlineActiveColor: baseTheme.colorWhite,
 
     // Focus
+    defaultFocusBackground: baseTheme.colorGrayLight,
+    primaryFocusBackground: baseTheme.colorBlue,
+    successFocusBackground: baseTheme.colorGreen,
+    warningFocusBackground: baseTheme.colorOrange,
+    dangerFocusBackground: baseTheme.colorRed,
+    dangerOutlineFocusBackground: baseTheme.color.cherry,
+
     defaultFocusColor: baseTheme.colorGrayDark,
     primaryFocusColor: baseTheme.colorWhite,
     successFocusColor: baseTheme.colorWhite,
     warningFocusColor: baseTheme.colorWhite,
     dangerFocusColor: baseTheme.colorWhite,
+    dangerOutlineFocusColor: baseTheme.colorWhite,
 
     defaultFocusOutlineColor: darken(
       baseTheme.colorOffsetDark,
@@ -182,6 +200,7 @@ export default baseTheme => {
     dangerFocusOutlineColor: darken(
       baseTheme.colorOffsetDark,
       dangerActiveBackground
-    )
+    ),
+    dangerOutlineFocusOutlineColor: 'transparent'
   };
 };

--- a/packages/cf-component-button/test/__snapshots__/Button.js.snap
+++ b/packages/cf-component-button/test/__snapshots__/Button.js.snap
@@ -58,11 +58,11 @@ exports[`should render as submit 2`] = `
 }
 
 .l {
-  border-bottom: 1px solid
+  border-color: #2869a2
 }
 
 .m {
-  border-color: #2869a2
+  border-bottom: 1px solid
 }
 
 .n {
@@ -315,11 +315,11 @@ exports[`should render with loading 2`] = `
 }
 
 .y {
-  border-bottom: 1px solid
+  border-color: #dbdbdb
 }
 
 .z {
-  border-color: #dbdbdb
+  border-bottom: 1px solid
 }
 
 .ab {
@@ -572,11 +572,11 @@ exports[`should render with loading and disabled overridden 2`] = `
 }
 
 .y {
-  border-bottom: 1px solid
+  border-color: #dbdbdb
 }
 
 .z {
-  border-color: #dbdbdb
+  border-bottom: 1px solid
 }
 
 .ab {
@@ -756,11 +756,11 @@ exports[`should render with type 2`] = `
 }
 
 .l {
-  border-bottom: 1px solid
+  border-color: #2869a2
 }
 
 .m {
-  border-color: #2869a2
+  border-bottom: 1px solid
 }
 
 .n {
@@ -940,11 +940,11 @@ exports[`should render with type/disabled 2`] = `
 }
 
 .l {
-  border-bottom: 1px solid
+  border-color: #2869a2
 }
 
 .m {
-  border-color: #2869a2
+  border-bottom: 1px solid
 }
 
 .n {

--- a/packages/cf-component-button/test/__snapshots__/ButtonGroup.js.snap
+++ b/packages/cf-component-button/test/__snapshots__/ButtonGroup.js.snap
@@ -86,11 +86,11 @@ exports[`should render 1 button 2`] = `
 }
 
 .p {
-  border-bottom: 1px solid
+  border-color: #2869a2
 }
 
 .q {
-  border-color: #2869a2
+  border-bottom: 1px solid
 }
 
 .r {
@@ -322,11 +322,11 @@ exports[`should render 2 buttons 2`] = `
 }
 
 .p {
-  border-bottom: 1px solid
+  border-color: #2869a2
 }
 
 .q {
-  border-color: #2869a2
+  border-bottom: 1px solid
 }
 
 .r {
@@ -562,11 +562,11 @@ exports[`should render 3 buttons 2`] = `
 }
 
 .p {
-  border-bottom: 1px solid
+  border-color: #2869a2
 }
 
 .q {
-  border-color: #2869a2
+  border-bottom: 1px solid
 }
 
 .r {
@@ -802,11 +802,11 @@ exports[`should render 3 buttons with spacing 2`] = `
 }
 
 .p {
-  border-bottom: 1px solid
+  border-color: #2869a2
 }
 
 .q {
-  border-color: #2869a2
+  border-bottom: 1px solid
 }
 
 .r {

--- a/packages/cf-style-container/test/__snapshots__/index.js.snap
+++ b/packages/cf-style-container/test/__snapshots__/index.js.snap
@@ -150,6 +150,7 @@ Object {
       "carrot": "#f56500",
       "cement": "#7D7D7D",
       "charcoal": "#333333",
+      "cherry": "#9F1F21",
       "dawn": "#F16975",
       "deepsea": "#1E4E79",
       "dew": "#85CBA8",


### PR DESCRIPTION
This PR adds a new `dangerOutline` button type, useful for low-contrast warning actions.

![outline](https://user-images.githubusercontent.com/65447/29692349-59e1394e-88e4-11e7-8233-8b422613c929.gif)
