### PR TITLE
fix(cf-component-card): specify react prop Title as node 

### DIFF
--- a/packages/cf-component-card/src/CardTitle.js
+++ b/packages/cf-component-card/src/CardTitle.js
@@ -12,7 +12,7 @@ const Title = ({ children, className }) => (
 );
 
 Title.propTypes = {
-  className: PropTypes.string,
+  className: PropTypes.node,
   children: PropTypes.string
 };
 


### PR DESCRIPTION
I have a use case when Card Title is an expander:

<img width="311" alt="screen shot 2017-09-04 at 12 23 45 pm" src="https://user-images.githubusercontent.com/125466/30024861-9d9b4468-916d-11e7-8d2b-91ddad51adce.png">

Using prop type node fixes a warning: "Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `Title`, expected `string`."