### PR TITLE
feat(cf-style-container): add applyStaticStyles method

### DIFF
--- a/packages/cf-style-container/README.md
+++ b/packages/cf-style-container/README.md
@@ -145,6 +145,20 @@ const MyComponent = ({ theme }) => {
 export default withRenderer(MyComponent);
 ```
 
+### applyStaticStyles(staticStyles, Component)
+
+A HOC that applies a string of static styles to a component using fela's [renderStatic](https://github.com/rofrischmann/fela/blob/master/docs/api/fela/Renderer.md#renderstaticstyle-selector).
+Useful for integration with older libraries that require side loading of a static CSS block.
+
+```jsx
+import { applyStaticStyles } from 'cf-style-container';
+
+const staticStyles = '.purple-component { background-color: purple }';
+const MyComponent = () => <div className='purple-component' />;
+
+export default applyStaticStyles(staticStyles, MyComponent);
+```
+
 ## mergeTheme(baseTheme, ...themes)
 
 `applyTheme()` calls this method internally to merge all themes. The returned

--- a/packages/cf-style-container/src/index.js
+++ b/packages/cf-style-container/src/index.js
@@ -75,6 +75,25 @@ const withRenderer = ComponentToWrap => {
 const createComponentStyles = (styleFunctions, component) =>
   connect(styleFunctions)(component);
 
+const applyStaticStyles = (staticStyles, ComponentToWrap) => {
+  class CompWithStaticStyles extends React.PureComponent {
+    componentWillMount() {
+      this.props.renderer.renderStatic(staticStyles);
+    }
+
+    render() {
+      const { renderer, ...props } = this.props;
+      return <ComponentToWrap {...props} />;
+    }
+  }
+
+  CompWithStaticStyles.propTypes = {
+    renderer: PropTypes.object.isRequired
+  };
+
+  return withRenderer(CompWithStaticStyles);
+};
+
 export {
   createComponent,
   mergeThemes,
@@ -85,7 +104,8 @@ export {
   createComponentStyles,
   capitalize,
   withTheme,
-  withRenderer
+  withRenderer,
+  applyStaticStyles
 };
 
 // Loops the key-value pairs of a props object, and apply a filter function to

--- a/packages/cf-style-container/test/index.js
+++ b/packages/cf-style-container/test/index.js
@@ -14,7 +14,8 @@ import {
   mapChildren,
   applyTheme,
   withTheme,
-  withRenderer
+  withRenderer,
+  applyStaticStyles
 } from '../src/index';
 
 test('mergeThemes should return an immutable and deeply cloned object', () => {
@@ -112,6 +113,22 @@ test('createComponentStyles creates a component', () => {
   const snapshot = felaSnapshot(<FelaComponent />);
   expect(snapshot.component).toMatchSnapshot();
   expect(snapshot.styles).toMatchSnapshot();
+});
+
+test('applyStaticStyles should add static styles to head', () => {
+  const staticStyles = '.test-static-style { background-color: purple }';
+  const Component = () => <div className="test-static-style" />;
+  const StyledComponent = applyStaticStyles(staticStyles, Component);
+
+  const renderer = createRenderer();
+  mount(
+    <Provider renderer={renderer}>
+      <StyledComponent />
+    </Provider>
+  );
+
+  const headStyle = document.head.querySelector('style').innerHTML;
+  expect(headStyle).toEqual(staticStyles);
 });
 
 test('filterNone will filter out all keys with undefined or null values', () => {


### PR DESCRIPTION
A HOC that applies a string of static styles to a component using fela's renderStatic. Useful for integration with older libraries that require side loading of a static CSS block.